### PR TITLE
Stub GiT controller actions, request models/validation

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,0 +1,43 @@
+﻿using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/candidates")]
+    [ApiController]
+    public class CandidatesController : ControllerBase
+    {
+        private readonly ILogger<CandidatesController> _logger;
+
+        public CandidatesController(ILogger<CandidatesController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpPost]
+        [Route("access_token")]
+        [SwaggerOperation(
+            Summary = "Creates a candidate access token.",
+            Description = @"
+Finds a candidate matching at least 3 of the provided CandidateAccessTokenRequest attributes. 
+If a candidate is found, an access token (PIN code) will be sent to the candidate email address 
+that can then be used for verification.",
+            OperationId = "CreateCandidateAccessToken",
+            Tags = new[] { "Candidates" }
+        )]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] CandidateAccessTokenRequest candidate)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(this.ModelState);
+            }
+
+            // TODO:
+            return NoContent();
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,0 +1,41 @@
+﻿using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/mailing_list")]
+    [ApiController]
+    public class MailingListController : ControllerBase
+    {
+        private readonly ILogger<MailingListController> _logger;
+
+        public MailingListController(ILogger<MailingListController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpPost]
+        [Route("members")]
+        [SwaggerOperation(
+            Summary = "Adds a new member to the mailing list.",
+            Description = "Adds a new member to the mailing list. A new candidate will also be created if a matching candidate can not be found.",
+            OperationId = "AddMailingListMember",
+            Tags = new[] { "Mailing List" }
+        )]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        public IActionResult AddMember([FromBody, SwaggerRequestBody("Member to add to the mailing list.", Required = true)] CandidateIdentification member)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(this.ModelState);
+            }
+
+            // TODO:
+            return Ok(new Object());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+using System;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/privacy_policies")]
+    [ApiController]
+    public class PrivacyPoliciesController : ControllerBase
+    {
+        private readonly ILogger<PrivacyPoliciesController> _logger;
+
+        public PrivacyPoliciesController(ILogger<PrivacyPoliciesController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Route("latest")]
+        [SwaggerOperation(
+            Summary = "Retrieves the latest privacy policy.",
+            OperationId = "GetLatestPrivacyPolicy",
+            Tags = new[] { "Privacy Policies" }
+        )]
+        public IActionResult GetLatest()
+        {
+            // TODO:
+            return Ok(new Object());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
+{
+    [Route("api/teacher_training_adviser/candidates")]
+    [ApiController]
+    public class CandidatesController : ControllerBase
+    {
+        private readonly ILogger<CandidatesController> _logger;
+
+        public CandidatesController(ILogger<CandidatesController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpPost]
+        [SwaggerOperation(
+            Summary = "Upserts a candidate for the Teacher Training Adviser service.",
+            OperationId = "UpsertTeacherTrainingAdviserCandidate",
+            Tags = new[] { "Teacher Training Adviser" }
+        )]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        public IActionResult Upsert([FromBody, SwaggerRequestBody("Candidate to upsert for the Teacher Training Adviser service.", Required = true)] Object candidate) // TODO:
+        {
+            // TODO:
+            return Ok(new Object());
+        }
+
+        [HttpGet]
+        [Route("{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves an existing candidate for the Teacher Training Adviser service.",
+            Description = @"
+Retrieves an existing candidate for the Teacher Training Adviser service. The `accessToken` is obtained from a 
+`POST /candidates/access_tokens` request and must be sent along with the shared secret in the `Authorization` header.",
+            OperationId = "GetExistingTeacherTrainingAdviserCandidate",
+            Tags = new[] { "Teacher Training Adviser" }
+        )]
+        public IActionResult Get(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken, 
+            [FromHeader(Name = "Authorization"), SwaggerParameter("Bearer <sharedSecret>.", Required = true)] string sharedSecret
+        )
+        {
+            // TODO:
+            return Ok(new Object());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/teaching_events")]
+    [ApiController]
+    public class TeachingEventsController : ControllerBase
+    {
+        private readonly ILogger<TeachingEventsController> _logger;
+
+        public TeachingEventsController(ILogger<TeachingEventsController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Route("upcoming")]
+        [SwaggerOperation(
+            Summary = "Retrieves the upcoming teaching events.",
+            Description = @"
+Retrieves the upcoming teaching events; limited to 10 by default, but this can be increased to a 
+maximum of 50 using the `limit` query parameter.",
+            OperationId = "GetUpcomingTeachingEvents",
+            Tags = new[] { "Teaching Events" }
+        )]
+        public IActionResult GetUpcoming([FromQuery, SwaggerParameter("Number of results to return (maximum of 50).")] int limit)
+        {
+            // TODO:
+            return Ok(new[] { new Object() });
+        }
+
+        [HttpGet]
+        [Route("search")]
+        [SwaggerOperation(
+            Summary = "Searches for teaching events.",
+            Description = @"Searches for teaching events by postcode. Optionally limit the results by distance (in miles) and the type of event.",
+            OperationId = "SearchTeachingEvents",
+            Tags = new[] { "Teaching Events" }
+        )]
+        public IActionResult Search(
+            [FromQuery, SwaggerParameter("Postcode to center search around.", Required = true)] string postcode,
+            [FromQuery, SwaggerParameter("Search radius in miles (omit to search nationally).")] string radius,
+            [FromQuery, SwaggerParameter("Type of teaching events to search for (omit to search for all types). Must match an `eventType` of the `TeachingEvent` schema.")] int type
+            )
+        {
+            // TODO:
+            return Ok(new[] { new Object() });
+        }
+
+        [HttpGet]
+        [Route("{readableEventId}")]
+        [SwaggerOperation(
+            Summary = "Retrieves an event.",
+            OperationId = "GetTeachingEvent",
+            Tags = new[] { "Teaching Events" }
+        )]
+        public IActionResult Get([FromRoute, SwaggerParameter("The `readableEventId` of the `TeachingEvent`.", Required = true)] string readableEventId)
+        {
+            // TODO:
+            return Ok(new Object());
+        }
+
+        [HttpPost]
+        [SwaggerOperation(
+            Summary = "Creates a new teaching event.",
+            OperationId = "CreateTeachingEvent",
+            Tags = new[] { "Teaching Events" }
+        )]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        public IActionResult Create([FromBody, SwaggerRequestBody("Teaching event to create.", Required = true)] Object teachingEvent) // TODO:
+        {
+            // TODO:
+            return Ok(new Object());
+        }
+
+        [HttpPost]
+        [Route("{readableEventId}/attendees")]
+        [SwaggerOperation(
+            Summary = "Adds an attendee to a teaching event.",
+            OperationId = "AddTeachingEventAttendee",
+            Tags = new[] { "Teaching Events" }
+        )]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        public IActionResult AddAttendee(
+            [FromRoute, SwaggerParameter("The `readableEventId` of the `TeachingEvent`.", Required = true)] string readableEventId,
+            [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] CandidateIdentification attendee
+        )
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(this.ModelState);
+            }
+
+            // TODO:
+            return Ok(new Object());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/types")]
+    [ApiController]
+    public class TypesController : ControllerBase
+    {
+        private readonly ILogger<TypesController> _logger;
+
+        public TypesController(ILogger<TypesController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Route("countries")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of countries.",
+            OperationId = "GetCountryTypes",
+            Tags = new[] { "Types" }
+        )]
+        public IActionResult GetCountries()
+        {
+            // TODO:
+            return Ok(new[] { new Object() });
+        }
+
+        [HttpGet]
+        [Route("teaching_subjects")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of teaching subjects.",
+            OperationId = "GetTeachingSubjects",
+            Tags = new[] { "Types" }
+        )]
+        public IActionResult GetTeachingSubjects()
+        {
+            // TODO:
+            return Ok(new[] { new Object() });
+        }
+    }
+}

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -4,5 +4,13 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
+    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
+  </ItemGroup>
+
 
 </Project>

--- a/GetIntoTeachingApi/Models/CandidateAccessTokenRequest.cs
+++ b/GetIntoTeachingApi/Models/CandidateAccessTokenRequest.cs
@@ -1,0 +1,17 @@
+﻿using Swashbuckle.AspNetCore.Annotations;
+using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateAccessTokenRequest
+    {
+        [SwaggerSchema("First name")]
+        public string FirstName { get; set; }
+        [SwaggerSchema("Last name")]
+        public string LastName { get; set; }
+        [SwaggerSchema("Email address", Format = "email")]
+        public string Email { get; set; }
+        [SwaggerSchema("Date of birth", Format = "date")]
+        public DateTime? DateOfBirth { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateIdentification.cs
+++ b/GetIntoTeachingApi/Models/CandidateIdentification.cs
@@ -1,0 +1,14 @@
+﻿using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateIdentification
+    {
+        [SwaggerSchema("First name")]
+        public string FirstName { get; set; }
+        [SwaggerSchema("Last name")]
+        public string LastName { get; set; }
+        [SwaggerSchema("Email address", Format = "email")]
+        public string Email { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidateAccessTokenRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateAccessTokenRequestValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+using System;
+using System.Linq;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidateAccessTokenRequestValidator : AbstractValidator<CandidateAccessTokenRequest>
+    {
+        public CandidateAccessTokenRequestValidator()
+        {
+            RuleFor(request => request.Email).NotEmpty().EmailAddress();
+            RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.Now);
+            RuleFor(request => request)
+                .Must(request => SpecifyTwoAdditionalRequiredAttributes(request))
+                .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
+        }
+
+        private Boolean SpecifyTwoAdditionalRequiredAttributes(CandidateAccessTokenRequest request)
+        {
+            var additionalRequiredAttributes = new Object[] { request.DateOfBirth, request.FirstName, request.LastName };
+            return additionalRequiredAttributes.Where(attribute => attribute != null).Count() >= 2;
+        }
+    }
+}
+

--- a/GetIntoTeachingApi/Models/Validators/CandidateIdentificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateIdentificationValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidateIdentificationValidator : AbstractValidator<CandidateIdentification>
+    {
+        public CandidateIdentificationValidator()
+        {
+            RuleFor(request => request.FirstName).NotEmpty();
+            RuleFor(request => request.LastName).NotEmpty();
+            RuleFor(request => request.Email).NotEmpty().EmailAddress();
+        }
+    }
+}
+

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -12,6 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,6 +20,7 @@
     "GetIntoTeachingApi": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -1,15 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
+using System;
+using FluentValidation.AspNetCore;
 
 namespace GetIntoTeachingApi
 {
@@ -25,7 +22,38 @@ namespace GetIntoTeachingApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers();
+            services.AddControllers().AddFluentValidation(c =>
+            {
+                c.RegisterValidatorsFromAssemblyContaining<Startup>();
+            });
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1",
+                    new OpenApiInfo
+                    {
+                        Title = "Get into Teaching API - V1",
+                        Version = "v1",
+                        Description = @"
+Provides a RESTful API for integrating with the Get into Teaching CRM.
+
+The Get into Teaching (GIT) API sits in front of the GIT CRM, which uses the [Microsoft Dynamics365](https://docs.microsoft.com/en-us/dynamics365/) platform (the [Customer Engagement](https://docs.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/overview) module is used for storing Candidate information and the [Marketing](https://docs.microsoft.com/en-us/dynamics365/marketing/developer/using-events-api) module for managing Events).
+
+The GIT API aims to provide:
+
+* Simple, task-based RESTful APIs.
+* Message queueing (while the GIT CRM is offline for updates).
+* Validation to ensure consistency across services writing to the GIT CRM.
+                        ",
+                        License = new OpenApiLicense
+                        {
+                            Name = "MIT License",
+                            Url = new Uri("https://opensource.org/licenses/MIT")
+                        }
+                    }
+                );
+                c.EnableAnnotations();
+                c.AddFluentValidationRules();
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -39,6 +67,13 @@ namespace GetIntoTeachingApi
             app.UseHttpsRedirection();
 
             app.UseRouting();
+
+            app.UseSwagger();
+
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Get into Teaching API V1");
+            });
 
             app.UseAuthorization();
 

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -1,0 +1,29 @@
+﻿using Xunit;
+using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using FluentAssertions;
+using System.Collections.Generic;
+
+namespace GetIntoTeachingApiTests.Controllers
+{
+    public class CandidatesControllerTests
+    {
+        [Fact]
+        public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var request = new CandidateAccessTokenRequest { Email = "invalid-email@" };
+            var mockLogger = new Mock<ILogger<CandidatesController>>();
+            var controller = new CandidatesController(mockLogger.Object);
+            controller.ModelState.AddModelError("Email", "Email is invalid.");
+
+            var response = controller.CreateAccessToken(request);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Controllers
+{
+    public class MailingListControllerTests
+    {
+        [Fact]
+        public void CreateCandidateAccessToken_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var member = new CandidateIdentification { FirstName = null };
+            var mockLogger = new Mock<ILogger<MailingListController>>();
+            var controller = new MailingListController(mockLogger.Object);
+            controller.ModelState.AddModelError("FirstName", "First name must be specified.");
+
+            var response = controller.AddMember(member);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("FirstName").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Controllers
+{
+    public class PrivacyPoliciesControllerTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
+{
+    public class CandidatesControllerTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Controllers
+{
+    public class TeachingEventsControllerTests
+    {
+        [Fact]
+        public void AddAttendee_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var attendee = new CandidateIdentification { FirstName = null };
+            var mockLogger = new Mock<ILogger<TeachingEventsController>>();
+            var controller = new TeachingEventsController(mockLogger.Object);
+            controller.ModelState.AddModelError("FirstName", "First name must be specified.");
+
+            var response = controller.AddAttendee("123", attendee);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("FirstName").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Controllers
+{
+    public class TypesControllerTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+	<PackageReference Include="FluentAssertions" Version="5.10.3" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/GetIntoTeachingApiTests/Models/CandidateAccessTokenRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateAccessTokenRequestTests.cs
@@ -1,0 +1,7 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateAccessTokenRequestTests
+    {
+        
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidateIdentification.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateIdentification.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateIdentification
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateAccessTokenRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateAccessTokenRequestValidatorTests.cs
@@ -1,0 +1,105 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidateAccessTokenRequestValidatorTests
+    {
+        private readonly CandidateAccessTokenRequestValidator _validator;
+
+        public CandidateAccessTokenRequestValidatorTests()
+        {
+            _validator = new CandidateAccessTokenRequestValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.Now.AddDays(-18) };
+
+            var result = _validator.TestValidate(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Email, "valid@email.com");
+        }
+
+        [Fact]
+        public void Validate_DateOfBirthInFuture_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, DateTime.Now.AddDays(1));
+        }
+
+        [Fact]
+        public void Validate_DateOfBirthInPast_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.DateOfBirth, DateTime.Now.AddDays(-1));
+        }
+
+        [Fact]
+        public void Validate_SpecifyNoAdditionalRequiredAttributes_HasError()
+        {
+            var request = new CandidateAccessTokenRequest();
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request).WithErrorMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
+        }
+
+        [Fact]
+        public void Validate_SpecifyOneAdditionalRequiredAttributes_HasError()
+        {
+            var request = new CandidateAccessTokenRequest { FirstName = "first" };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request).WithErrorMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
+        }
+
+        [Fact]
+        public void Validate_SpecifyTwoAdditionalRequiredAttributes_HasNoError()
+        {
+            var request = new CandidateAccessTokenRequest { FirstName = "first", LastName = "last" };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request);
+        }
+
+        [Fact]
+        public void Validate_SpecifyThreeAdditionalRequiredAttributes_HasNoError()
+        {
+            var request = new CandidateAccessTokenRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.Now.AddDays(-18) };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateIdentificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateIdentificationValidatorTests.cs
@@ -1,0 +1,63 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models.Validators;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidateIdentificationValidatorTests
+    {
+        private readonly CandidateIdentificationValidator _validator;
+
+        public CandidateIdentificationValidatorTests()
+        {
+            _validator = new CandidateIdentificationValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var member = new GetIntoTeachingApi.Models.CandidateIdentification { Email = "email@address.com", FirstName = "first", LastName = "last" };
+
+            var result = _validator.TestValidate(member);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(member => member.Email, null as string);
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(member => member.Email, "");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(member => member.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(member => member.Email, "valid@email.com");
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(member => member.FirstName, "");
+        }
+
+        [Fact]
+        public void Validate_LastNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(member => member.LastName, "");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,8 +12,33 @@ The GIT API aims to provide:
 
 ## Getting Started
 
-Clone the repository and run the application in Visual Studio or Visual Studio Code. You can then access the example endpoint at [https://localhost:5001/example](https://localhost:5001/example).
+The API is an ASP.NET Core web application; to get up and running clone the repository and open `GetIntoTeachingApi.sln` in Visual Studio.
 
-## Documentation
+When the application runs in development it will open the Swagger documentation by default.
 
-The Swagger documentation for the API can be found in [docs/swagger.yml](docs/swagger.yml).
+### Documentation
+
+[Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) is used for generating Swagger documentation. We use the swagger-ui middleware to expose interactive documentation when the application runs.
+
+We also use the [MicroElements.Swashbuckle.FluentValidation](https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation) package to make Swashbuckle aware of the FluentValidation classes, so that additional validation meta data gets displayed alongside model attributes.
+
+### Validation
+
+[FluentValidation](https://fluentvalidation.net/) is used for validating the various models. The validators are registered at startup, so validating incoming payloads that have a corresponding validator is as simple as calling `ModelState.IsValid`.
+
+### Testing
+
+[XUnit](https://xunit.net/) is used for testing; all tests can be found in the `GetIntoTeachingTests` project. We also use [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for mocking any dependencies and [FluentAssertions](https://fluentassertions.com) for assertions.
+
+The unit tests take the convention:
+
+```
+public void UnitOfWork_StateUnderTest_ExpectedBehavior()
+{
+    // arrange
+
+    // act
+
+    // assert
+}
+```


### PR DESCRIPTION
Stubs out the controller actions we will need for the Get into Teaching website (TTA registration, events and mailing list). The request models have been created where possible, but in places that will hook into the generated OData entities for Dynamics I've left the models as `Object`.

Model validation uses [FluentValidation](https://fluentvalidation.net/) and I've also added [FluentAssertions](https://fluentassertions.com/) and [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for testing.

Started migrating the Swagger documentation into the source code using [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) (which can [integrate nicely with FluentValidation](https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation)) - when this has been fully migrated over we can remove `docs/swagger.yml`:

<img width="1073" alt="Screenshot 2020-05-04 at 09 39 23" src="https://user-images.githubusercontent.com/29867726/80949065-30931d00-8deb-11ea-9fab-716e2ce798d0.png">
