### PR TITLE
Add Timed One Time Password (TOTP) for candidate access tokens

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Models;
 
 namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
 {
@@ -11,10 +13,12 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
     public class CandidatesController : ControllerBase
     {
         private readonly ILogger<CandidatesController> _logger;
+        private readonly ICandidateAccessTokenService _tokenService;
 
-        public CandidatesController(ILogger<CandidatesController> logger)
+        public CandidatesController(ILogger<CandidatesController> logger, ICandidateAccessTokenService tokenService)
         {
             _logger = logger;
+            _tokenService = tokenService;
         }
 
         [HttpPost]
@@ -40,11 +44,18 @@ Retrieves an existing candidate for the Teacher Training Adviser service. The `a
             OperationId = "GetExistingTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" }
         )]
+        [ProducesResponseType(401)]
         public IActionResult Get(
-            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken, 
-            [FromHeader(Name = "Authorization"), SwaggerParameter("Bearer <sharedSecret>.", Required = true)] string sharedSecret
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromHeader(Name = "Candidate-Email"), SwaggerParameter("Candidate email address.", Required = true)] string email
         )
         {
+            var challenge = new CandidateAccessTokenChallenge { Token = accessToken, Email = email };
+            if (!_tokenService.IsValid(challenge))
+            {
+                return Unauthorized();
+            }
+
             // TODO:
             return Ok(new Object());
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="Otp.NET" Version="1.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
   </ItemGroup>

--- a/GetIntoTeachingApi/Models/CandidateAccessTokenChallenge.cs
+++ b/GetIntoTeachingApi/Models/CandidateAccessTokenChallenge.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateAccessTokenChallenge
+    {
+        public string Token { get; set; }
+        public string Email { get; set; }
+
+        public bool HasToken()
+        {
+            return !string.IsNullOrWhiteSpace(Token);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -1,0 +1,60 @@
+﻿using GetIntoTeachingApi.Models;
+using OtpNet;
+using System;
+using System.Text;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CandidateAccessTokenService : ICandidateAccessTokenService
+    {
+        // The amount of time a user has to verify their access token is:
+        // (VerificationWindow * StepsInSeconds) + Remaining Seconds in Current Step
+        public static readonly int VerificationWindow = 2;
+        public static readonly int StepInSeconds = 30;
+        private static readonly int Length = 6;
+
+        public string GenerateToken(string email)
+        {
+           var  totp = CreateTotp(email);
+            return totp.ComputeTotp();
+        }
+
+        public bool IsValid(CandidateAccessTokenChallenge challenge)
+        {
+            return IsValid(challenge, DateTime.UtcNow);
+        }
+
+        public bool IsValid(CandidateAccessTokenChallenge challenge, DateTime timestamp)
+        {
+            if (!challenge.HasToken())
+            {
+                return false;
+            }
+
+            var totp = CreateTotp(challenge.Email);
+
+            long timeWindowUsed;
+            return totp.VerifyTotp(
+                timestamp,
+                challenge.Token,
+                out timeWindowUsed,
+                new VerificationWindow(previous: VerificationWindow, future: VerificationWindow)
+            );
+        }
+
+        private Totp CreateTotp(string email)
+        {
+            return new Totp(CompoundSharedSecretBytes(email), totpSize: Length, step: StepInSeconds);
+        }
+
+        private byte[] CompoundSharedSecretBytes(string email)
+        {
+            return Encoding.ASCII.GetBytes(email + TotpSecretKey());
+        }
+
+        private string TotpSecretKey()
+        {
+            return Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
@@ -1,0 +1,12 @@
+﻿using GetIntoTeachingApi.Models;
+using System;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICandidateAccessTokenService
+    {
+        public string GenerateToken(string email);
+        public bool IsValid(CandidateAccessTokenChallenge challenge, DateTime timestamp);
+        public bool IsValid(CandidateAccessTokenChallenge challenge);
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -1,6 +1,28 @@
-﻿namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
+﻿using Xunit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Controllers.TeacherTrainingAdviser;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApiTests.TeacherTrainingAdvisor.Controllers
 {
     public class CandidatesControllerTests
     {
+        [Fact]
+        public void Get_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var mockTokenService = new Mock<ICandidateAccessTokenService>();
+            var challenge = new CandidateAccessTokenChallenge { Token = "000000", Email = "email@address.com" };
+            mockTokenService.Setup(tokenService => tokenService.IsValid(challenge)).Returns(false);
+            var mockLogger = new Mock<ILogger<CandidatesController>>();
+            var controller = new CandidatesController(mockLogger.Object, mockTokenService.Object);
+
+            var response = controller.Get("000000", "email@address.com");
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateAccessTokenChallengeTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateAccessTokenChallengeTests.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateAccessTokenChallengeTests
+    {
+        [Theory]
+        [InlineData("  ", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        [InlineData("123456", true)]
+        public void HasToken_ReturnsAsExpected(string token, bool expectedOutcome)
+        {
+            var challenge = new CandidateAccessTokenChallenge { Token = token };
+            challenge.HasToken().Should().Be(expectedOutcome);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
@@ -1,0 +1,78 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidateAccessTokenServiceTests : IDisposable
+    {
+        private readonly ICandidateAccessTokenService _service;
+
+        private string _previousTotpSecretKey;
+
+        public CandidateAccessTokenServiceTests()
+        {
+            _previousTotpSecretKey = Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
+
+            Environment.SetEnvironmentVariable("TOTP_SECRET_KEY", "secret_key");
+
+            _service = new CandidateAccessTokenService();
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("TOTP_SECRET_KEY", _previousTotpSecretKey);
+        }
+
+        [Theory]
+        [InlineData("email@address.com")]
+        [InlineData("email!@address.com")]
+        [InlineData("e@a.com")]
+        public void GenerateToken_ReturnsAValidToken(string email)
+        {
+            string token = _service.GenerateToken(email);
+            var challenge = new CandidateAccessTokenChallenge { Token = token, Email = email };
+            _service.IsValid(challenge).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GenerateToken_DifferentEmailsInSameStep_ReturnDifferentTokens()
+        {
+            string token1 = _service.GenerateToken("email1@address.com");
+            string token2 = _service.GenerateToken("email2@address.com");
+            token1.Should().NotBeEquivalentTo(token2);
+        }
+
+        [Fact]
+        public void GenerateToken_SameEmailInSameStep_ReturnSameToken()
+        {
+            string token1 = _service.GenerateToken("email@address.com");
+            string token2 = _service.GenerateToken("email@address.com");
+            token1.Should().BeEquivalentTo(token2);
+        }
+
+        [Theory]
+        [InlineData("000000")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("abcdef")]
+        public void IsValid_WithInvalidToken_ReturnsFalse(string invalidToken)
+        {
+            var challenge = new CandidateAccessTokenChallenge { Token = invalidToken, Email = "email@address.com" };
+            _service.IsValid(challenge).Should().BeFalse();
+        }
+
+
+        [Fact]
+        public void IsValid_WithExpiredToken_ReturnsFalse()
+        {
+            int secondsToOutsideOfWindow = CandidateAccessTokenService.StepInSeconds * (2 * CandidateAccessTokenService.VerificationWindow);
+            var dateTimeOutsideOfWindow = DateTime.UtcNow.AddSeconds(-secondsToOutsideOfWindow);
+            string token = _service.GenerateToken("email@address.com");
+            var challenge = new CandidateAccessTokenChallenge { Token = token, Email = "email@address.com" };
+            _service.IsValid(challenge, dateTimeOutsideOfWindow).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
Adds a `CandidateAccessTokenService` class that is able to generate Timed One Time Password (TOTP) codes. These can then be emailed out and later verified (the verification also checks a shared secret that should be sent from the client consuming the API). 

Currently, the TOTPs are configured with a 30 second 'step', which means a new code will be generated every 30 seconds and they have a window size of 2, meaning the user will have 1 minute (plus the time left in the current 'step') in order to send the code back in a candidate request. We can change this later on if we want to allow longer (by adjusting the windows size - the step size should remain as per the RFC).

We configure the TOTP secret to be a compound value of candidate email address and shared secret; this results in different email addresses generating different tokens within the same step (time period), as the key is used in conjunction with the current time when deriving the token:

```
TOTP(K,T) = Truncate(HMAC-SHA-1(K,T))
```

If we didn't do this, then we would be vulnerable to a candidate generating a token for their own email address _and_ another candidate's email address -- the token would be valid/the same for both. As per the RFC the HMAC is truncated, which means that two different emails _could_ result in the same token, but chances of this should be very slim (and the tokens themselves are only 'live' for a handful of minutes which means it should be even slimmer).