### PR TITLE
Send PIN code email via GOV.UK Notify service

### DIFF
--- a/GetIntoTeachingApi/Adapters/INotificationClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/INotificationClientAdapter.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public interface INotificationClientAdapter
+    {
+        public Task SendEmailAsync(string apiKey, string email, string templateId, Dictionary<string, dynamic> personalisation);
+    }
+}

--- a/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
@@ -1,0 +1,15 @@
+﻿using Notify.Client;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public class NotificationClientAdapter : INotificationClientAdapter
+    {
+        public Task SendEmailAsync(string apiKey, string email, string templateId, Dictionary<string, dynamic> personalisation)
+        {
+            var client = new NotificationClient(apiKey);
+            return client.SendEmailAsync(email, templateId, personalisation);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,9 +1,11 @@
 ﻿using GetIntoTeachingApi.Models;
 using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApi.Controllers
 {
@@ -13,10 +15,18 @@ namespace GetIntoTeachingApi.Controllers
     public class CandidatesController : ControllerBase
     {
         private readonly ILogger<CandidatesController> _logger;
+        private readonly ICandidateAccessTokenService _tokenService;
+        private readonly INotifyService _notifyService;
 
-        public CandidatesController(ILogger<CandidatesController> logger)
+        public CandidatesController(
+            ILogger<CandidatesController> logger, 
+            ICandidateAccessTokenService tokenService, 
+            INotifyService notifyService
+        )
         {
             _logger = logger;
+            _tokenService = tokenService;
+            _notifyService = notifyService;
         }
 
         [HttpPost]
@@ -36,6 +46,13 @@ that can then be used for verification.",
             if (!ModelState.IsValid)
             {
                 return BadRequest(this.ModelState);
+            }
+
+            if (true) // TODO:
+            {
+                string token = _tokenService.GenerateToken(candidate.Email);
+                var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
+                _notifyService.SendEmail(candidate.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
             }
 
             // TODO:

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="Notify" Version="2.7.0" />
     <PackageReference Include="Otp.NET" Version="1.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />

--- a/GetIntoTeachingApi/Services/INotifyService.cs
+++ b/GetIntoTeachingApi/Services/INotifyService.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface INotifyService
+    {
+        public void SendEmail(string email, string templateId, Dictionary<string, dynamic> personalisation);
+    }
+}

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -1,0 +1,36 @@
+﻿using GetIntoTeachingApi.Adapters;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class NotifyService : INotifyService
+    {
+        public static readonly string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
+        private readonly ILogger<NotifyService> _logger;
+        private readonly INotificationClientAdapter _client;
+
+        public NotifyService(ILogger<NotifyService> logger, INotificationClientAdapter client)
+        {
+            _logger = logger;
+            _client = client;
+        }
+
+        public void SendEmail(string email, string templateId, Dictionary<string, dynamic> personalisation)
+        {
+            _client.SendEmailAsync(
+                ApiKey(),
+                email,
+                templateId,
+                personalisation
+            ).ContinueWith(task => _logger.LogWarning(task.Exception.Message), TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        private string ApiKey()
+        {
+            return Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -12,6 +12,8 @@ using GetIntoTeachingApi.Auth;
 using GetIntoTeachingApi.Requirements;
 using System.Collections.Generic;
 using GetIntoTeachingApi.OperationFilters;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi
 {
@@ -28,6 +30,10 @@ namespace GetIntoTeachingApi
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IAuthorizationHandler, SharedSecretHandler>();
+            services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
+            services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
+            services.AddSingleton<INotifyService, NotifyService>();
+
             services.AddAuthorization(options =>
             {
                 options.AddPolicy("SharedSecret", policy => 
@@ -36,10 +42,12 @@ namespace GetIntoTeachingApi
                     )
                 );
             });
+
             services.AddControllers().AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();
             });
+
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1",
@@ -65,12 +73,14 @@ The GIT API aims to provide:
                         }
                     }
                 );
+
                 c.AddSecurityDefinition("apiKey", new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.ApiKey,
                     Name = "Authorization",
                     In = ParameterLocation.Header
                 });
+                
                 c.AddSecurityRequirement(new OpenApiSecurityRequirement
                 {
                     {
@@ -81,6 +91,7 @@ The GIT API aims to provide:
                         new List<string>()
                     }
                 });
+
                 c.OperationFilter<AuthResponsesOperationFilter>();
                 c.EnableAnnotations();
                 c.AddFluentValidationRules();

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -6,11 +6,26 @@ using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
 using GetIntoTeachingApiTests.Utils;
+using GetIntoTeachingApi.Services;
+using System.Collections.Generic;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class CandidatesControllerTests
     {
+        private readonly Mock<ILogger<CandidatesController>> _mockLogger;
+        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly CandidatesController _controller;
+
+        public CandidatesControllerTests()
+        {
+            _mockLogger = new Mock<ILogger<CandidatesController>>();
+            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockNotifyService = new Mock<INotifyService>();
+            _controller = new CandidatesController(_mockLogger.Object, _mockTokenService.Object, _mockNotifyService.Object);
+        }
+
         [Fact]
         public void Authorize_HasSharedSecretPolicy()
         {
@@ -21,15 +36,31 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new CandidateAccessTokenRequest { Email = "invalid-email@" };
-            var mockLogger = new Mock<ILogger<CandidatesController>>();
-            var controller = new CandidatesController(mockLogger.Object);
-            controller.ModelState.AddModelError("Email", "Email is invalid.");
+            _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
-            var response = controller.CreateAccessToken(request);
+            var response = _controller.CreateAccessToken(request);
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
             errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
+
+        [Fact]
+        public void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
+        {
+            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockTokenService.Setup(mock => mock.GenerateToken("email@address.com")).Returns("123456");
+
+            var response = _controller.CreateAccessToken(request);
+
+            response.Should().BeOfType<NoContentResult>();
+            _mockNotifyService.Verify(
+                mock => mock.SendEmail(
+                    "email@address.com", 
+                    NotifyService.NewPinCodeEmailTemplateId, 
+                    It.Is<Dictionary<string, dynamic>>(personalisation => personalisation["pin_code"] as string == "123456")
+                )
+            );
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
@@ -1,0 +1,68 @@
+﻿using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Utils;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class NotifyServiceTests : IDisposable
+    {
+        private readonly string _previousNotifyApiKey;
+        private readonly Mock<INotificationClientAdapter> _mockNotificationClient;
+        private readonly Mock<ILogger<NotifyService>> _mockLogger;
+        private readonly NotifyService _service;
+        private readonly Dictionary<string, dynamic> _personalisation;
+
+        public NotifyServiceTests()
+        {
+            _previousNotifyApiKey = Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
+            Environment.SetEnvironmentVariable("NOTIFY_API_KEY", "api_key");
+
+            _mockNotificationClient = new Mock<INotificationClientAdapter>();
+            _mockLogger = new Mock<ILogger<NotifyService>>();
+            _service = new NotifyService(_mockLogger.Object, _mockNotificationClient.Object);
+            _personalisation = new Dictionary<string, dynamic> { { "pin_code", "123456" } };
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("NOTIFY_API_KEY", _previousNotifyApiKey);
+        }
+
+        [Fact]
+        public void SendEmail_SendsAnEmail()
+        {
+            _service.SendEmail("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation);
+
+            _mockNotificationClient.Verify(
+                mock => mock.SendEmailAsync(
+                    "api_key",
+                    "email@address.com", 
+                    NotifyService.NewPinCodeEmailTemplateId, 
+                    _personalisation
+                )
+            );
+        }
+
+        [Fact]
+        public void SendEmail_WhenSendingFails_LogsException()
+        {
+            _mockNotificationClient.Setup(
+                mock => mock.SendEmailAsync(
+                    "api_key", 
+                    "email@address.com", 
+                    NotifyService.NewPinCodeEmailTemplateId, 
+                    _personalisation
+                )
+            ).ThrowsAsync(new Exception("Unable to send email!"));
+
+            _service.SendEmail("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation);
+
+            LoggerTestHelpers.VerifyWarningWasCalled(_mockLogger, "Unable to send email!");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/LoggerTestHelpers.cs
+++ b/GetIntoTeachingApiTests/Utils/LoggerTestHelpers.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public static class LoggerTestHelpers
+    {
+        public static Mock<ILogger<T>> VerifyWarningWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
+        {
+            Func<object, Type, bool> state = (v, t) =>  v.ToString().Contains(expectedMessage);
+
+            logger.Verify(
+                mock => mock.Log(
+                    It.Is<LogLevel>(logLevel => logLevel == LogLevel.Warning),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => state(v, t)),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+                )
+            );
+
+            return logger;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ public void UnitOfWork_StateUnderTest_ExpectedBehavior()
     // assert
 }
 ```
+
+### Emails
+
+We send emails using the [GOV.UK Notify](https://www.notifications.service.gov.uk/) service; leveraging the [.Net Client](https://github.com/alphagov/notifications-net-client).


### PR DESCRIPTION
Includes the GOV.UK Notify C# client and wraps it in an adapter so that its mockable in unit tests. This is utilised by a basic `NotifyService` in order to send emails using a given `templateId` and `personalisation` (template attributes).

The `CandidatesController` has been updated to generate and email out a PIN code to a candidate for a valid `CandidateAccessTokenRequest`. There is a `// TODO:` in the action which will later be the call out to the CRM to find a matching candidate (so we only send a PIN code if there is a matching candidate in the CRM).

<img width="746" alt="Screenshot 2020-05-05 at 19 48 41" src="https://user-images.githubusercontent.com/29867726/81104115-f2404f80-8f09-11ea-8190-a93170fea686.png">
