### PR TITLE
Protect endpoints with auth policy

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -1,0 +1,29 @@
+﻿using GetIntoTeachingApi.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Threading.Tasks;
+
+namespace GetIntoTeachingApi.Auth
+{
+    public class SharedSecretHandler : AuthorizationHandler<SharedSecretRequirement>
+    {
+        IHttpContextAccessor _httpContextAccessor;
+
+        public SharedSecretHandler(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, SharedSecretRequirement requirement)
+        {
+            string authorizationHeader = _httpContextAccessor.HttpContext.Request.Headers["Authorization"];
+            if (authorizationHeader != null && authorizationHeader.Contains($"Bearer {requirement.SharedSecret}"))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Auth/SharedSecretRequirement.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretRequirement.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace GetIntoTeachingApi.Requirements
+{
+    public class SharedSecretRequirement : IAuthorizationRequirement
+    {
+        public string SharedSecret { get; set; }
+
+        public SharedSecretRequirement(string sharedSecret)
+        {
+            SharedSecret = sharedSecret;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,4 +1,5 @@
 ﻿using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -8,6 +9,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/candidates")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class CandidatesController : ControllerBase
     {
         private readonly ILogger<CandidatesController> _logger;

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,4 +1,5 @@
 ﻿using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -9,6 +10,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/mailing_list")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class MailingListController : ControllerBase
     {
         private readonly ILogger<MailingListController> _logger;

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System;
@@ -7,6 +8,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/privacy_policies")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class PrivacyPoliciesController : ControllerBase
     {
         private readonly ILogger<PrivacyPoliciesController> _logger;

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -46,7 +46,6 @@ Retrieves an existing candidate for the Teacher Training Adviser service. The `a
             OperationId = "GetExistingTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" }
         )]
-        [ProducesResponseType(401)]
         public IActionResult Get(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromHeader(Name = "Candidate-Email"), SwaggerParameter("Candidate email address.", Required = true)] string email

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -5,11 +5,13 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Authorization;
 
 namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
 {
     [Route("api/teacher_training_adviser/candidates")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class CandidatesController : ControllerBase
     {
         private readonly ILogger<CandidatesController> _logger;

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GetIntoTeachingApi.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -9,6 +10,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/teaching_events")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class TeachingEventsController : ControllerBase
     {
         private readonly ILogger<TeachingEventsController> _logger;

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -7,6 +8,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/types")]
     [ApiController]
+    [Authorize(Policy = "SharedSecret")]
     public class TypesController : ControllerBase
     {
         private readonly ILogger<TypesController> _logger;

--- a/GetIntoTeachingApi/OperationFilters/AuthResponsesOperationFilter.cs
+++ b/GetIntoTeachingApi/OperationFilters/AuthResponsesOperationFilter.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace GetIntoTeachingApi.OperationFilters
+{
+    public class AuthResponsesOperationFilter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var authAttributes = context.MethodInfo.DeclaringType.GetCustomAttributes(true)
+                .Union(context.MethodInfo.GetCustomAttributes(true))
+                .OfType<AuthorizeAttribute>();
+
+            if (authAttributes.Any())
+            {
+                operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -7,6 +7,9 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Auth;
+using GetIntoTeachingApi.Requirements;
 
 namespace GetIntoTeachingApi
 {
@@ -22,6 +25,15 @@ namespace GetIntoTeachingApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<IAuthorizationHandler, SharedSecretHandler>();
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("SharedSecret", policy => 
+                    policy.Requirements.Add(
+                        new SharedSecretRequirement(Environment.GetEnvironmentVariable("SHARED_SECRET"))
+                    )
+                );
+            });
             services.AddControllers().AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -10,6 +10,8 @@ using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using GetIntoTeachingApi.Auth;
 using GetIntoTeachingApi.Requirements;
+using System.Collections.Generic;
+using GetIntoTeachingApi.OperationFilters;
 
 namespace GetIntoTeachingApi
 {
@@ -63,6 +65,23 @@ The GIT API aims to provide:
                         }
                     }
                 );
+                c.AddSecurityDefinition("apiKey", new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.ApiKey,
+                    Name = "Authorization",
+                    In = ParameterLocation.Header
+                });
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "apiKey" }
+                        },
+                        new List<string>()
+                    }
+                });
+                c.OperationFilter<AuthResponsesOperationFilter>();
                 c.EnableAnnotations();
                 c.AddFluentValidationRules();
             });

--- a/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Auth;
+using GetIntoTeachingApi.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Auth
+{
+    public class SharedSecretHandlerTests
+    {
+        private readonly SharedSecretHandler _handler;
+        private readonly Mock<IHttpContextAccessor> _mockHttpHandler;
+
+        public SharedSecretHandlerTests()
+        {
+            _mockHttpHandler = new Mock<IHttpContextAccessor>();
+            _mockHttpHandler.Setup(mock => mock.HttpContext.Request.Headers["Authorization"]).Returns("Bearer shared_secret");
+            _handler = new SharedSecretHandler(_mockHttpHandler.Object);
+        }
+
+        [Fact]
+        public async void HandleRequirement_WithCorrectSecret_CallsSucceed()
+        {
+            var requirements = new[] { new SharedSecretRequirement("shared_secret") };
+            var context = new AuthorizationHandlerContext(requirements, null, null);
+
+            await _handler.HandleAsync(context);
+
+            context.HasSucceeded.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void HandleRequirement_WithIncorrectSecret_DoesNotCallSucceed()
+        {
+            var requirements = new[] { new SharedSecretRequirement("incorrect_shared_secret") };
+            var context = new AuthorizationHandlerContext(requirements, null, null);
+
+            await _handler.HandleAsync(context);
+
+            context.HasSucceeded.Should().BeFalse();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -5,12 +5,18 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
-using System.Collections.Generic;
+using GetIntoTeachingApiTests.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class CandidatesControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(CandidatesController));
+        }
+
         [Fact]
         public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -5,11 +5,18 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
+using GetIntoTeachingApiTests.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class MailingListControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(MailingListController));
+        }
+
         [Fact]
         public void CreateCandidateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -1,6 +1,15 @@
-﻿namespace GetIntoTeachingApiTests.Controllers
+﻿using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApiTests.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Controllers
 {
     public class PrivacyPoliciesControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(PrivacyPoliciesController));
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -6,11 +6,18 @@ using GetIntoTeachingApi.Controllers.TeacherTrainingAdviser;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using GetIntoTeachingApi.Models;
+using GetIntoTeachingApiTests.Utils;
 
 namespace GetIntoTeachingApiTests.TeacherTrainingAdvisor.Controllers
 {
     public class CandidatesControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(CandidatesController));
+        }
+
         [Fact]
         public void Get_InvalidAccessToken_RespondsWithUnauthorized()
         {

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -5,11 +5,18 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
+using GetIntoTeachingApiTests.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class TeachingEventsControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(TeachingEventsController));
+        }
+
         [Fact]
         public void AddAttendee_InvalidRequest_RespondsWithValidationErrors()
         {

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -1,6 +1,15 @@
-﻿namespace GetIntoTeachingApiTests.Controllers
+﻿using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApiTests.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Controllers
 {
     public class TypesControllerTests
     {
+        [Fact]
+        public void Authorize_HasSharedSecretPolicy()
+        {
+            PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(TypesController));
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/PolicyTestHelpers.cs
+++ b/GetIntoTeachingApiTests/Utils/PolicyTestHelpers.cs
@@ -1,0 +1,14 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using System;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    class PolicyTestHelpers
+    {
+        public static void VerifyTypeIsAuthorizeWithSharedSecret(Type type) 
+        {
+            type.Should().BeDecoratedWith<AuthorizeAttribute>(attribute => (attribute.Policy.Contains("SharedSecret")));
+        }
+    }
+}


### PR DESCRIPTION
We want to ensure that requests to the API originate from our server(s) - to enforce this we are going to have clients send an `Authorization: Bearer <shared_secret>` header. This PR adds a policy handler and requirement for the presence of the header, matching it to the APIs shared secret value. The policy is applied to all controllers and the Swagger docs have been updated to detail the authorization mechanism.

