### PR TITLE
Add CrmService to encapsulate interactions with Dynamics365

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceContextAdapter.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public interface IOrganizationServiceContextAdapter
     {
-        public IQueryable<Entity> CreateQuery(string connectionString, string entityName);
+        public Task<IQueryable<Entity>> CreateQuery(string connectionString, string entityName);
     }
 }

--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceContextAdapter.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Xrm.Sdk;
+using System.Linq;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public interface IOrganizationServiceContextAdapter
+    {
+        public IQueryable<Entity> CreateQuery(string connectionString, string entityName);
+    }
+}

--- a/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
@@ -6,10 +6,26 @@ namespace GetIntoTeachingApi.Adapters
 {
     public class NotificationClientAdapter : INotificationClientAdapter
     {
+        private readonly IDictionary<string, NotificationClient> _clients;
+
+        public NotificationClientAdapter()
+        {
+            _clients = new Dictionary<string, NotificationClient>();
+        }
+
         public Task SendEmailAsync(string apiKey, string email, string templateId, Dictionary<string, dynamic> personalisation)
         {
-            var client = new NotificationClient(apiKey);
-            return client.SendEmailAsync(email, templateId, personalisation);
+            return Client(apiKey).SendEmailAsync(email, templateId, personalisation);
+        }
+
+        private NotificationClient Client(string apiKey)
+        {
+            if (!_clients.ContainsKey(apiKey))
+            {
+                _clients[apiKey] = new NotificationClient(apiKey);
+            }
+
+            return _clients[apiKey];
         }
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
+using System.Linq;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public class OrganizationServiceContextAdapter : IOrganizationServiceContextAdapter
+    {
+        public IQueryable<Entity> CreateQuery(string connectionString, string entityName)
+        {
+            var client = new CdsServiceClient(connectionString);
+            var context = new OrganizationServiceContext(client);
+            return context.CreateQuery(entityName);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
@@ -4,6 +4,7 @@ using Microsoft.Xrm.Sdk.Client;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApi.Adapters
 {
@@ -16,9 +17,11 @@ namespace GetIntoTeachingApi.Adapters
             _contexts = new Dictionary<string, OrganizationServiceContext>();
         }
 
-        public IQueryable<Entity> CreateQuery(string connectionString, string entityName)
+        public async Task<IQueryable<Entity>> CreateQuery(string connectionString, string entityName)
         {
-            return Context(connectionString).CreateQuery(entityName);
+            var context = Context(connectionString);
+            var task = Task.Run(() => context.CreateQuery(entityName));
+            return await task;
         }
 
         private OrganizationServiceContext Context(string connectionString)

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceContextAdapter.cs
@@ -1,17 +1,35 @@
 ﻿using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public class OrganizationServiceContextAdapter : IOrganizationServiceContextAdapter
     {
+        private readonly IDictionary<string, OrganizationServiceContext> _contexts;
+
+        public OrganizationServiceContextAdapter()
+        {
+            _contexts = new Dictionary<string, OrganizationServiceContext>();
+        }
+
         public IQueryable<Entity> CreateQuery(string connectionString, string entityName)
         {
-            var client = new CdsServiceClient(connectionString);
-            var context = new OrganizationServiceContext(client);
-            return context.CreateQuery(entityName);
+            return Context(connectionString).CreateQuery(entityName);
+        }
+
+        private OrganizationServiceContext Context(string connectionString)
+        {
+            if (!_contexts.ContainsKey(connectionString))
+            {
+                var client = new CdsServiceClient(connectionString);
+                _contexts[connectionString] = new OrganizationServiceContext(client);
+            }
+
+            return _contexts[connectionString];
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -12,10 +14,12 @@ namespace GetIntoTeachingApi.Controllers
     public class TypesController : ControllerBase
     {
         private readonly ILogger<TypesController> _logger;
+        private readonly ICrmService _crm;
 
-        public TypesController(ILogger<TypesController> logger)
+        public TypesController(ILogger<TypesController> logger, ICrmService crm)
         {
             _logger = logger;
+            _crm = crm;
         }
 
         [HttpGet]
@@ -25,10 +29,11 @@ namespace GetIntoTeachingApi.Controllers
             OperationId = "GetCountryTypes",
             Tags = new[] { "Types" }
         )]
+        [ProducesResponseType(typeof(TypeEntity), 200)]
         public IActionResult GetCountries()
         {
-            // TODO:
-            return Ok(new[] { new Object() });
+            IEnumerable<TypeEntity> countryTypes = _crm.GetCountries();
+            return Ok(countryTypes);
         }
 
         [HttpGet]
@@ -38,10 +43,11 @@ namespace GetIntoTeachingApi.Controllers
             OperationId = "GetTeachingSubjects",
             Tags = new[] { "Types" }
         )]
+        [ProducesResponseType(typeof(TypeEntity), 200)]
         public IActionResult GetTeachingSubjects()
         {
-            // TODO:
-            return Ok(new[] { new Object() });
+            IEnumerable<TypeEntity> teachingSubjectTypes = _crm.GetTeachingSubjects();
+            return Ok(teachingSubjectTypes);
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -5,6 +5,7 @@ using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApi.Controllers
 {
@@ -30,9 +31,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(TypeEntity), 200)]
-        public IActionResult GetCountries()
+        public async Task<IActionResult> GetCountries()
         {
-            IEnumerable<TypeEntity> countryTypes = _crm.GetCountries();
+            IEnumerable<TypeEntity> countryTypes = await _crm.GetCountries();
             return Ok(countryTypes);
         }
 
@@ -44,9 +45,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(TypeEntity), 200)]
-        public IActionResult GetTeachingSubjects()
+        public async Task<IActionResult> GetTeachingSubjects()
         {
-            IEnumerable<TypeEntity> teachingSubjectTypes = _crm.GetTeachingSubjects();
+            IEnumerable<TypeEntity> teachingSubjectTypes = await _crm.GetTeachingSubjects();
             return Ok(teachingSubjectTypes);
         }
     }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -5,8 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.2.1-Alpha" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="Notify" Version="2.7.0" />
     <PackageReference Include="Otp.NET" Version="1.2.2" />

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class TypeEntity
+    {
+        public Guid Id { get; set; }
+        public dynamic Value { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using AutoMapper;
+using AutoMapper.Configuration.Annotations;
+using Microsoft.Xrm.Sdk;
+using System;
 
 namespace GetIntoTeachingApi.Models
 {

--- a/GetIntoTeachingApi/Profiles/TypeEntityProfile.cs
+++ b/GetIntoTeachingApi/Profiles/TypeEntityProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Profiles
+{
+    public class TypeEntityProfile : Profile
+    {
+        public TypeEntityProfile()
+        {
+            CreateMap<Entity, TypeEntity>().ForMember(dest => 
+                dest.Value,
+                opt => opt.MapFrom(src => src.Attributes["dfe_name"])
+            );
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoMapper;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CrmService : ICrmService
+    {
+        private readonly IOrganizationServiceContextAdapter _context;
+        private readonly IMapper _mapper;
+
+        public CrmService(IOrganizationServiceContextAdapter context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        public IEnumerable<TypeEntity> GetTeachingSubjects()
+        {
+            return from subject in _context.CreateQuery(ConnectionString(), "dfe_teachingsubjectlist")
+                   select _mapper.Map<TypeEntity>(subject);
+        }
+
+        public IEnumerable<TypeEntity> GetCountries()
+        {
+            return from subject in _context.CreateQuery(ConnectionString(), "dfe_country")
+                   select _mapper.Map<TypeEntity>(subject);
+        }
+
+        private string ConnectionString()
+        {
+            return $"AuthType=ClientSecret; url={InstanceUrl()}; ClientId={ClientId()}; ClientSecret={ClientSecret()}";
+        }
+
+        private string InstanceUrl()
+        {
+            return Environment.GetEnvironmentVariable("CRM_SERVICE_URL");
+        }
+
+        private string ClientId()
+        {
+            return Environment.GetEnvironmentVariable("CRM_CLIENT_ID");
+        }
+
+        private string ClientSecret()
+        {
+            return Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
@@ -18,15 +19,15 @@ namespace GetIntoTeachingApi.Services
             _mapper = mapper;
         }
 
-        public IEnumerable<TypeEntity> GetTeachingSubjects()
+        public async Task<IEnumerable<TypeEntity>> GetTeachingSubjects()
         {
-            return from subject in _context.CreateQuery(ConnectionString(), "dfe_teachingsubjectlist")
+            return from subject in await _context.CreateQuery(ConnectionString(), "dfe_teachingsubjectlist")
                    select _mapper.Map<TypeEntity>(subject);
         }
 
-        public IEnumerable<TypeEntity> GetCountries()
+        public async Task<IEnumerable<TypeEntity>> GetCountries()
         {
-            return from subject in _context.CreateQuery(ConnectionString(), "dfe_country")
+            return from subject in await _context.CreateQuery(ConnectionString(), "dfe_country")
                    select _mapper.Map<TypeEntity>(subject);
         }
 

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -1,0 +1,11 @@
+﻿using GetIntoTeachingApi.Models;
+using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICrmService
+    {
+        public IEnumerable<TypeEntity> GetTeachingSubjects();
+        public IEnumerable<TypeEntity> GetCountries();
+    }
+}

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -1,11 +1,12 @@
 ﻿using GetIntoTeachingApi.Models;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApi.Services
 {
     public interface ICrmService
     {
-        public IEnumerable<TypeEntity> GetTeachingSubjects();
-        public IEnumerable<TypeEntity> GetCountries();
+        public Task<IEnumerable<TypeEntity>> GetTeachingSubjects();
+        public Task<IEnumerable<TypeEntity>> GetCountries();
     }
 }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using GetIntoTeachingApi.OperationFilters;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Services;
+using AutoMapper;
 
 namespace GetIntoTeachingApi
 {
@@ -29,9 +30,13 @@ namespace GetIntoTeachingApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddAutoMapper(typeof(Startup));
+
             services.AddSingleton<IAuthorizationHandler, SharedSecretHandler>();
             services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
+            services.AddSingleton<IOrganizationServiceContextAdapter, OrganizationServiceContextAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
+            services.AddSingleton<ICrmService, CrmService>();
             services.AddSingleton<INotifyService, NotifyService>();
 
             services.AddAuthorization(options =>

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -32,24 +33,24 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetCountries_ReturnsAllCountries()
+        public async void GetCountries_ReturnsAllCountries()
         {
             IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
-            _mockCrm.Setup(mock => mock.GetCountries()).Returns(mockEntities);
+            _mockCrm.Setup(mock => mock.GetCountries()).Returns(Task.FromResult(mockEntities));
 
-            var response = _controller.GetCountries();
+            var response = await _controller.GetCountries();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetTeachingSubjects_ReturnsAllSubjects()
+        public async void GetTeachingSubjects_ReturnsAllSubjects()
         {
             IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
-            _mockCrm.Setup(mock => mock.GetTeachingSubjects()).Returns(mockEntities);
+            _mockCrm.Setup(mock => mock.GetTeachingSubjects()).Returns(Task.FromResult(mockEntities));
 
-            var response = _controller.GetTeachingSubjects();
+            var response = await _controller.GetTeachingSubjects();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().BeEquivalentTo(mockEntities);

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -1,15 +1,67 @@
 ﻿using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApiTests.Utils;
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class TypesControllerTests
     {
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<ILogger<TypesController>> _mockLogger;
+        private readonly TypesController _controller;
+
+        public TypesControllerTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _mockLogger = new Mock<ILogger<TypesController>>();
+            _controller = new TypesController(_mockLogger.Object, _mockCrm.Object);
+        }
+
         [Fact]
         public void Authorize_HasSharedSecretPolicy()
         {
             PolicyTestHelpers.VerifyTypeIsAuthorizeWithSharedSecret(typeof(TypesController));
+        }
+
+        [Fact]
+        public void GetCountries_ReturnsAllCountries()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetCountries()).Returns(mockEntities);
+
+            var response = _controller.GetCountries();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
+        [Fact]
+        public void GetTeachingSubjects_ReturnsAllSubjects()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetTeachingSubjects()).Returns(mockEntities);
+
+            var response = _controller.GetTeachingSubjects();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
+        private IEnumerable<TypeEntity> MockTypeEntities()
+        {
+            return new []
+            {
+                new TypeEntity { Id = Guid.NewGuid(), Value = "Type 1" },
+                new TypeEntity { Id = Guid.NewGuid(), Value = "Type 2" },
+            };
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
+++ b/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class TypeEntityTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Profiles/ProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/ProfileTests.cs
@@ -1,0 +1,18 @@
+﻿using AutoMapper;
+using GetIntoTeachingApi.Profiles;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Profiles
+{
+    public class ProfileTests
+    {
+        [Fact]
+        public void TypeEntityProfile_HasValidConfiguration()
+        {
+            var config = new MapperConfiguration(config => {
+                config.AddProfile<TypeEntityProfile>();
+            });
+            config.AssertConfigurationIsValid();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -1,0 +1,105 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Profiles;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class CrmServiceTests : IDisposable
+    {
+        private static readonly string ConnectionString = "AuthType=ClientSecret; url=service_url; ClientId=client_id; ClientSecret=client_secret";
+        private string _previousCrmServiceUrl;
+        private string _previousCrmClientId;
+        private string _previousCrmClientSecret;
+        private Mock<IOrganizationServiceContextAdapter> _mockContext;
+        private ICrmService _crm;
+
+        public CrmServiceTests()
+        {
+            _previousCrmServiceUrl = Environment.GetEnvironmentVariable("CRM_SERVICE_URL");
+            _previousCrmClientId = Environment.GetEnvironmentVariable("CRM_CLIENT_ID");
+            _previousCrmClientSecret = Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
+
+            Environment.SetEnvironmentVariable("CRM_SERVICE_URL", "service_url");
+            Environment.SetEnvironmentVariable("CRM_CLIENT_ID", "client_id");
+            Environment.SetEnvironmentVariable("CRM_CLIENT_SECRET", "client_secret");
+
+            var config = new MapperConfiguration(config => {
+                config.AddProfile<TypeEntityProfile>();
+            });
+            var mapper = new Mapper(config);
+
+            _mockContext = new Mock<IOrganizationServiceContextAdapter>();
+            _crm = new CrmService(_mockContext.Object, mapper);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("CRM_SERVICE_URL", _previousCrmServiceUrl);
+            Environment.SetEnvironmentVariable("CRM_CLIENT_ID", _previousCrmClientId);
+            Environment.SetEnvironmentVariable("CRM_CLIENT_SECRET", _previousCrmClientSecret);
+        }
+
+        [Fact]
+        public void GetCountries_ReturnsAllOrderedByName()
+        {
+            IQueryable<Entity> queryableCountries = MockCountries().AsQueryable();
+            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_country")).Returns(queryableCountries);
+
+            var result = _crm.GetCountries();
+
+            result.Select(country => country.Value).Should().BeEquivalentTo(
+                new[] { "Country 1", "Country 2", "Country 3" }
+            );
+        }
+
+        [Fact]
+        public void GetTeachingSubjects_ReturnsAllOrderedByName()
+        {
+            IQueryable<Entity> queryableCountries = MockTeachingSubjects().AsQueryable();
+            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_teachingsubjectlist")).Returns(queryableCountries);
+
+            var result = _crm.GetTeachingSubjects();
+
+            result.Select(subject => subject.Value).Should().BeEquivalentTo(
+                new[] { "Subject 1", "Subject 2", "Subject 3" }
+            );
+        }
+
+        private IEnumerable<Entity> MockCountries()
+        {
+            var country1 = new Entity("dfe_country");
+            country1.Attributes["dfe_name"] = "Country 1";
+
+            var country2 = new Entity("dfe_country");
+            country2.Attributes["dfe_name"] = "Country 2";
+
+            var country3 = new Entity("dfe_country");
+            country3.Attributes["dfe_name"] = "Country 3";
+
+            return new[] { country3, country1, country2 };
+        }
+
+        private IEnumerable<Entity> MockTeachingSubjects()
+        {
+            var subject1 = new Entity("dfe_teachingsubjectlist");
+            subject1.Attributes["dfe_name"] = "Subject 1";
+
+            var subject2 = new Entity("dfe_teachingsubjectlist");
+            subject2.Attributes["dfe_name"] = "Subject 2";
+
+            var subject3 = new Entity("dfe_teachingsubjectlist");
+            subject3.Attributes["dfe_name"] = "Subject 3";
+
+            return new[] { subject3, subject1, subject2 };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Services
@@ -49,12 +50,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetCountries_ReturnsAllOrderedByName()
+        public async void GetCountries_ReturnsAllOrderedByName()
         {
             IQueryable<Entity> queryableCountries = MockCountries().AsQueryable();
-            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_country")).Returns(queryableCountries);
+            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_country")).Returns(Task.FromResult(queryableCountries));
 
-            var result = _crm.GetCountries();
+            var result = await _crm.GetCountries();
 
             result.Select(country => country.Value).Should().BeEquivalentTo(
                 new[] { "Country 1", "Country 2", "Country 3" }
@@ -62,12 +63,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetTeachingSubjects_ReturnsAllOrderedByName()
+        public async void GetTeachingSubjects_ReturnsAllOrderedByName()
         {
             IQueryable<Entity> queryableCountries = MockTeachingSubjects().AsQueryable();
-            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_teachingsubjectlist")).Returns(queryableCountries);
+            _mockContext.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_teachingsubjectlist")).Returns(Task.FromResult(queryableCountries));
 
-            var result = _crm.GetTeachingSubjects();
+            var result = await _crm.GetTeachingSubjects();
 
             result.Select(subject => subject.Value).Should().BeEquivalentTo(
                 new[] { "Subject 1", "Subject 2", "Subject 3" }

--- a/README.md
+++ b/README.md
@@ -16,11 +16,33 @@ The API is an ASP.NET Core web application; to get up and running clone the repo
 
 When the application runs in development it will open the Swagger documentation by default.
 
+### Environment
+
+If you want to run the API locally end-to-end you will need to set some environment variables:
+
+```
+# Secret shared between the API and client.
+SHARED_SECRET=****
+
+# Secret used when generating Timed One Time Passwords
+TOTP_SECRET_KEY=****
+
+# CRM credentials
+CRM_SERVICE_URL=****
+CRM_CLIENT_ID=****
+CRM_CLIENT_SECRET=****
+
+# GOV.UK Notify Service credentials
+NOTIFY_API_KEY=****
+```
+
 ### Documentation
 
 [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) is used for generating Swagger documentation. We use the swagger-ui middleware to expose interactive documentation when the application runs.
 
 We also use the [MicroElements.Swashbuckle.FluentValidation](https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation) package to make Swashbuckle aware of the FluentValidation classes, so that additional validation meta data gets displayed alongside model attributes.
+
+You can hit the API endpoints directly from the Swagger UI - hit the `Authorize` button at the top and enter the development `Authorization` header value `Bearer <shared_secret>`. You can then open up an endpoint and 'Try it out' to execute a request.
 
 ### Validation
 


### PR DESCRIPTION
Add an `TypeEntity` model so that we can model generic 'types' (e.g. Country, Teaching Subject) (`Type` is a keyword, hence `TypeEntity`).

Add a service that encapsulates the interactions with the Dynamics365 instance. Currently it supports getting countries and teaching subjects, however it will be extended to write back to Dynamics as well.

Use the `CdsServiceClient` SDK which is currently in ALPHA. We may swap over to .NET Framework in the future so that we can use the stable `CrmServiceClient` instead.

Wrap the `IOrganizationServiceContext` in an adapter so that we can mock it in unit tests and execute the LINQ queries against an in-memory `IQueryable`.

AutoMapper is used to translate between `Entity` objects returned from the SDK and our models (in this case the `TypeEntity` model.