### PR TITLE
Match CandidateAccessTokenRequest with existing candidate

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -17,16 +17,19 @@ namespace GetIntoTeachingApi.Controllers
         private readonly ILogger<CandidatesController> _logger;
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly INotifyService _notifyService;
+        private readonly ICrmService _crm;
 
         public CandidatesController(
-            ILogger<CandidatesController> logger, 
-            ICandidateAccessTokenService tokenService, 
-            INotifyService notifyService
+            ILogger<CandidatesController> logger,
+            ICandidateAccessTokenService tokenService,
+            INotifyService notifyService,
+            ICrmService crm
         )
         {
             _logger = logger;
             _tokenService = tokenService;
             _notifyService = notifyService;
+            _crm = crm;
         }
 
         [HttpPost]
@@ -34,28 +37,32 @@ namespace GetIntoTeachingApi.Controllers
         [SwaggerOperation(
             Summary = "Creates a candidate access token.",
             Description = @"
-Finds a candidate matching at least 3 of the provided CandidateAccessTokenRequest attributes. 
+Finds a candidate matching at least 3 of the provided CandidateAccessTokenRequest attributes (including email). 
 If a candidate is found, an access token (PIN code) will be sent to the candidate email address 
 that can then be used for verification.",
             OperationId = "CreateCandidateAccessToken",
             Tags = new[] { "Candidates" }
         )]
+        [ProducesResponseType(204)]
+        [ProducesResponseType(404)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
-        public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] CandidateAccessTokenRequest candidate)
+        public async Task<IActionResult> CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] CandidateAccessTokenRequest request)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(this.ModelState);
             }
 
-            if (true) // TODO:
+            Candidate candidate = await _crm.GetCandidate(request.Email);
+            if (!request.Match(candidate))
             {
-                string token = _tokenService.GenerateToken(candidate.Email);
-                var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
-                _notifyService.SendEmail(candidate.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
+                return NotFound();
             }
 
-            // TODO:
+            string token = _tokenService.GenerateToken(request.Email);
+            var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
+            _notifyService.SendEmail(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
+
             return NoContent();
         }
     }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class Candidate
+    {
+        public Guid Id { get; set; }
+        public string Email { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DateTime? DateOfBirth { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateAccessTokenRequest.cs
+++ b/GetIntoTeachingApi/Models/CandidateAccessTokenRequest.cs
@@ -1,10 +1,14 @@
 ﻿using Swashbuckle.AspNetCore.Annotations;
 using System;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace GetIntoTeachingApi.Models
 {
     public class CandidateAccessTokenRequest
     {
+        private static readonly int MinimumAdditionalAttributeMatches = 2;
+
         [SwaggerSchema("First name")]
         public string FirstName { get; set; }
         [SwaggerSchema("Last name")]
@@ -13,5 +17,21 @@ namespace GetIntoTeachingApi.Models
         public string Email { get; set; }
         [SwaggerSchema("Date of birth", Format = "date")]
         public DateTime? DateOfBirth { get; set; }
+
+        public bool Match(Candidate candidate)
+        {
+            if (candidate == null || !candidate.Email.Equals(Email, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var additionalAttributeMatches = new[] {
+                (FirstName != null && FirstName.Equals(candidate.FirstName, StringComparison.OrdinalIgnoreCase)),
+                (LastName != null && LastName.Equals(candidate.LastName, StringComparison.OrdinalIgnoreCase)),
+                (DateOfBirth != null && DateOfBirth?.Date == candidate.DateOfBirth?.Date) 
+            };
+
+            return additionalAttributeMatches.Where(m => m).Count() >= MinimumAdditionalAttributeMatches;
+        }
     }
 }

--- a/GetIntoTeachingApi/Profiles/CandidateProfile.cs
+++ b/GetIntoTeachingApi/Profiles/CandidateProfile.cs
@@ -1,0 +1,27 @@
+﻿using AutoMapper;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+using System;
+
+namespace GetIntoTeachingApi.Profiles
+{
+    public class CandidateProfile : Profile
+    {
+        public CandidateProfile()
+        {
+            CreateMap<Entity, Candidate>().ForMember(dest =>
+                dest.Email,
+                opt => opt.MapFrom(src => src.GetAttributeValue<string>("emailaddress1"))
+            ).ForMember(dest =>
+                dest.FirstName,
+                opt => opt.MapFrom(src => src.GetAttributeValue<string>("firstname"))
+            ).ForMember(dest =>
+                dest.LastName,
+                opt => opt.MapFrom(src => src.GetAttributeValue<string>("lastname"))
+            ).ForMember(dest =>
+                dest.DateOfBirth,
+                opt => opt.MapFrom(src => src.GetAttributeValue<DateTime>("birthdate"))
+            );
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -45,6 +45,19 @@ namespace GetIntoTeachingApi.Services
                 .First();
         }
 
+        public async Task<Candidate> GetCandidate(string email)
+        {
+            return (await _context.CreateQuery(ConnectionString(), "contact"))
+                .Where((contact) =>
+                    // Will perform a case-insensitive comparison
+                    contact.GetAttributeValue<string>("emailaddress1") == email
+                )
+                .OrderByDescending((contact) => contact.GetAttributeValue<DateTime>("createdon"))
+                .Select((candidate) => _mapper.Map<Candidate>(candidate))
+                .FirstOrDefault();
+        }
+
+
         private string ConnectionString()
         {
             return $"AuthType=ClientSecret; url={InstanceUrl()}; ClientId={ClientId()}; ClientSecret={ClientSecret()}";

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -9,5 +9,6 @@ namespace GetIntoTeachingApi.Services
         public Task<IEnumerable<TypeEntity>> GetTeachingSubjects();
         public Task<IEnumerable<TypeEntity>> GetCountries();
         public Task<PrivacyPolicy> GetLatestPrivacyPolicy();
+        public Task<Candidate> GetCandidate(string email);
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using GetIntoTeachingApiTests.Utils;
 using GetIntoTeachingApi.Services;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -16,6 +17,7 @@ namespace GetIntoTeachingApiTests.Controllers
         private readonly Mock<ILogger<CandidatesController>> _mockLogger;
         private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
         private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly Mock<ICrmService> _mockCrm;
         private readonly CandidatesController _controller;
 
         public CandidatesControllerTests()
@@ -23,7 +25,8 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockLogger = new Mock<ILogger<CandidatesController>>();
             _mockTokenService = new Mock<ICandidateAccessTokenService>();
             _mockNotifyService = new Mock<INotifyService>();
-            _controller = new CandidatesController(_mockLogger.Object, _mockTokenService.Object, _mockNotifyService.Object);
+            _mockCrm = new Mock<ICrmService>();
+            _controller = new CandidatesController(_mockLogger.Object, _mockTokenService.Object, _mockNotifyService.Object, _mockCrm.Object);
         }
 
         [Fact]
@@ -33,12 +36,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
+        public async void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new CandidateAccessTokenRequest { Email = "invalid-email@" };
             _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
-            var response = _controller.CreateAccessToken(request);
+            var response = await _controller.CreateAccessToken(request);
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
@@ -46,20 +49,38 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
+        public async void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
         {
             var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            var candidate = new Candidate { Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
             _mockTokenService.Setup(mock => mock.GenerateToken("email@address.com")).Returns("123456");
+            _mockCrm.Setup(mock => mock.GetCandidate(request.Email)).Returns(Task.FromResult(candidate));
 
-            var response = _controller.CreateAccessToken(request);
+            var response = await _controller.CreateAccessToken(request);
 
             response.Should().BeOfType<NoContentResult>();
             _mockNotifyService.Verify(
                 mock => mock.SendEmail(
-                    "email@address.com", 
-                    NotifyService.NewPinCodeEmailTemplateId, 
+                    "email@address.com",
+                    NotifyService.NewPinCodeEmailTemplateId,
                     It.Is<Dictionary<string, dynamic>>(personalisation => personalisation["pin_code"] as string == "123456")
                 )
+            );
+        }
+
+        [Fact]
+        public async void CreateAccessToken_MismatchedCandidate_ReturnsNotFound()
+        {
+            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            var candidate = new Candidate { Email = request.Email, FirstName = "Jane", LastName = "Doe" };
+            _mockCrm.Setup(mock => mock.GetCandidate(request.Email)).Returns(Task.FromResult(candidate));
+
+            var response = await _controller.CreateAccessToken(request);
+
+            response.Should().BeOfType<NotFoundResult>();
+            _mockNotifyService.Verify(mock => 
+                mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()), 
+                Times.Never()
             );
         }
     }

--- a/GetIntoTeachingApiTests/Models/CandidateAccessTokenRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateAccessTokenRequestTests.cs
@@ -1,7 +1,147 @@
-﻿namespace GetIntoTeachingApiTests.Models
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
 {
     public class CandidateAccessTokenRequestTests
     {
-        
+        private readonly CandidateAccessTokenRequest _request;
+
+        public CandidateAccessTokenRequestTests()
+        {
+            _request = new CandidateAccessTokenRequest
+            {
+                Email = "email@address.com",
+                FirstName = "first",
+                LastName = "last",
+                DateOfBirth = new DateTime(2000, 1, 1)
+            };
+        }
+
+        [Fact]
+        public void Match_WithNullCandidate_ReturnsFalse()
+        {
+            _request.Match(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithEmailAndNoAdditionalAttributes_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                Email = "email@address.com",
+            };
+
+            _request.Match(candidate).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithEmailAndOneAdditionalAttribute_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email,
+                FirstName = _request.FirstName
+            };
+
+            _request.Match(candidate).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithEmailAndTwoAdditionalAttributes_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email,
+                FirstName = _request.FirstName,
+                LastName = _request.LastName
+            };
+
+            _request.Match(candidate).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Match_WithoutEmailAndWithTwoAdditionalAttributes_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                Email = "wrong@email.com",
+                FirstName = _request.FirstName,
+                LastName = _request.LastName
+            };
+
+            _request.Match(candidate).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithWrongEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                Email = "wrong@email.com",
+                FirstName = _request.FirstName,
+                LastName = _request.LastName,
+                DateOfBirth = _request.DateOfBirth
+            };
+
+            _request.Match(candidate).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithNullEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email,
+                FirstName = _request.FirstName,
+                LastName = _request.LastName,
+                DateOfBirth = _request.DateOfBirth
+            };
+            _request.Email = null;
+
+            _request.Match(candidate).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Match_WithEmailAndThreeAdditionalAttributes_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email,
+                FirstName = _request.FirstName,
+                LastName = _request.LastName,
+                DateOfBirth = _request.DateOfBirth
+            };
+
+            _request.Match(candidate).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Match_WithCaseInsensitiveMatch_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email.ToUpper(),
+                FirstName = _request.FirstName.ToUpper(),
+                LastName = _request.LastName.ToUpper(),
+            };
+
+            _request.Match(candidate).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Match_WithMatchingDateButDifferentTimes_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                Email = _request.Email,
+                FirstName = _request.FirstName,
+                DateOfBirth = _request.DateOfBirth?.AddMinutes(30),
+            };
+
+            _request.Match(candidate).Should().BeTrue();
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    class CandidateTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Profiles/CandidateProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/CandidateProfileTests.cs
@@ -1,0 +1,39 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApiTests.Utils;
+using Microsoft.Xrm.Sdk;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Profiles
+{
+    public class CandidateProfileTests
+    {
+        private readonly Mapper _mapper;
+
+        public CandidateProfileTests()
+        {
+            _mapper = MapperHelpers.CreateMapper();
+        }
+
+        [Fact]
+        public void CandidateProfile_MapsCorrectly()
+        {
+            var entity = new Entity();
+            entity.Id = Guid.NewGuid();
+            entity.Attributes["emailaddress1"] = "email@address.com";
+            entity.Attributes["firstname"] = "first";
+            entity.Attributes["lastname"] = "last";
+            entity.Attributes["birthdate"] = new DateTime(1967, 3, 10);
+
+            var candidate = _mapper.Map<Candidate>(entity);
+
+            candidate.Id.Should().Be(entity.Id);
+            candidate.Email.Should().Be(entity.GetAttributeValue<string>("emailaddress1"));
+            candidate.FirstName.Should().Be(entity.GetAttributeValue<string>("firstname"));
+            candidate.LastName.Should().Be(entity.GetAttributeValue<string>("lastname"));
+            candidate.DateOfBirth.Should().Be(entity.GetAttributeValue<DateTime>("birthdate"));
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/MapperHelpers.cs
+++ b/GetIntoTeachingApiTests/Utils/MapperHelpers.cs
@@ -10,6 +10,7 @@ namespace GetIntoTeachingApiTests.Utils
             var config = new MapperConfiguration(config => {
                 config.AddProfile<TypeEntityProfile>();
                 config.AddProfile<PrivacyPolicyProfile>();
+                config.AddProfile<CandidateProfile>();
             });
 
             return new Mapper(config);


### PR DESCRIPTION
We need to be able to retrieve a candidate from the CRM by email address so that we can match it to an incoming `CandidateAccessTokenRequest`.

Add basic `Candidate` model with minimal attributes (to be fleshed out in a later PR where we return the `Candidate` from our API).

Add profile to map from Dynamics `Entity` to our `Candidate` model.

When a request for an existing candidate arrives we compare email address as well as first, last name and date of birth with what we have stored in the CRM. If the email matches in addition to 2/3 of the additional attributes then we go ahead and email a pin code to the candidate email address (they can then exchange this for the existing candidate details).