### PR TITLE
Add endpoints for pick list options

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -1,10 +1,14 @@
 ﻿using Microsoft.Xrm.Sdk;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public interface IOrganizationServiceAdapter
     {
         public IQueryable<Entity> CreateQuery(string connectionString, string entityName);
+        public IEnumerable<PickListItem> GetPickListItemsForAttribute(string connectionString, string entityName, string attributeName);
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -3,6 +3,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using System.Collections.Generic;
 using System.Linq;
+using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 
 namespace GetIntoTeachingApi.Adapters
 {
@@ -19,6 +20,17 @@ namespace GetIntoTeachingApi.Adapters
         {
             var context = Context(connectionString);
             return context.CreateQuery(entityName);
+        }
+
+        public IEnumerable<PickListItem> GetPickListItemsForAttribute(
+            string connectionString, 
+            string entityName, 
+            string attributeName
+        )
+        {
+            var client = Client(connectionString);
+            PickListMetaElement metaElement = client.GetPickListElementFromMetadataEntity(entityName, attributeName);
+            return metaElement.Items;
         }
 
         private OrganizationServiceContext Context(string connectionString)

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetCountries()
         {
-            IEnumerable<TypeEntity> countryTypes = _crm.GetCountries();
+            IEnumerable<TypeEntity> countryTypes = _crm.GetLookupItems("dfe_country");
             return Ok(countryTypes);
         }
 
@@ -46,8 +46,65 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetTeachingSubjects()
         {
-            IEnumerable<TypeEntity> teachingSubjectTypes = _crm.GetTeachingSubjects();
+            IEnumerable<TypeEntity> teachingSubjectTypes = _crm.GetLookupItems("dfe_teachingsubjectlist");
             return Ok(teachingSubjectTypes);
+        }
+
+
+        [HttpGet]
+        [Route("candidate/initial_teacher_training_years")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of candidate initial teacher training years.",
+            OperationId = "GetCandidateInitialTeacherTrainingYears",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetCandidateInitialTeacherTrainingYears()
+        {
+            IEnumerable<TypeEntity> initialTeacherTrainingYears = _crm.GetPickListItems("contact", "dfe_ittyear");
+            return Ok(initialTeacherTrainingYears);
+        }
+
+        [HttpGet]
+        [Route("candidate/preferred_education_phases")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of candidate preferred education phases.",
+            OperationId = "GetCandidatePreferredEducationPhases",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetCandidatePreferredEducationPhases()
+        {
+            IEnumerable<TypeEntity> preferredEducationPhases = _crm.GetPickListItems("contact", "dfe_preferrededucationphase01");
+            return Ok(preferredEducationPhases);
+        }
+
+        [HttpGet]
+        [Route("candidate/location")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of candidate locations.",
+            OperationId = "GetCandidateLocations",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetCandidateLocations()
+        {
+            IEnumerable<TypeEntity> locations = _crm.GetPickListItems("contact", "dfe_isinuk");
+            return Ok(locations);
+        }
+
+        [HttpGet]
+        [Route("qualification/degree_status")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of qualification degree status.",
+            OperationId = "GetCandidateQualifications",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetQualificationDegreeStatus()
+        {
+            IEnumerable<TypeEntity> status = _crm.GetPickListItems("dfe_qualification", "dfe_degreestatus");
+            return Ok(status);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -4,7 +4,7 @@ namespace GetIntoTeachingApi.Models
 {
     public class TypeEntity
     {
-        public Guid Id { get; set; }
+        public dynamic Id { get; set; }
         public dynamic Value { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Profiles/TypeEntityProfile.cs
+++ b/GetIntoTeachingApi/Profiles/TypeEntityProfile.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using GetIntoTeachingApi.Models;
 using Microsoft.Xrm.Sdk;
+using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 
 namespace GetIntoTeachingApi.Profiles
 {
@@ -8,10 +9,20 @@ namespace GetIntoTeachingApi.Profiles
     {
         public TypeEntityProfile()
         {
-            CreateMap<Entity, TypeEntity>().ForMember(dest => 
+            CreateMap<Entity, TypeEntity>().ForMember(dest =>
                 dest.Value,
                 opt => opt.MapFrom(src => src.GetAttributeValue<string>("dfe_name"))
             );
+
+            CreateMap<PickListItem, TypeEntity>()
+                .ForMember(dest =>
+                    dest.Id,
+                    opt => opt.MapFrom(src => src.PickListItemId)
+                )
+                .ForMember(dest =>
+                    dest.Value,
+                    opt => opt.MapFrom(src => src.DisplayLabel)
+                );
         }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -20,15 +20,15 @@ namespace GetIntoTeachingApi.Services
             _mapper = mapper;
         }
 
-        public IEnumerable<TypeEntity> GetTeachingSubjects()
+        public IEnumerable<TypeEntity> GetLookupItems(string entityName)
         {
-            return _organizationalService.CreateQuery(ConnectionString(), "dfe_teachingsubjectlist")
+            return _organizationalService.CreateQuery(ConnectionString(), entityName)
                 .Select((subject) => _mapper.Map<TypeEntity>(subject));
         }
 
-        public IEnumerable<TypeEntity> GetCountries()
+        public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName)
         {
-            return _organizationalService.CreateQuery(ConnectionString(), "dfe_country")
+            return _organizationalService.GetPickListItemsForAttribute(ConnectionString(), entityName, attributeName)
                 .Select((subject) => _mapper.Map<TypeEntity>(subject));
         }
 

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -5,8 +5,8 @@ namespace GetIntoTeachingApi.Services
 {
     public interface ICrmService
     {
-        public IEnumerable<TypeEntity> GetTeachingSubjects();
-        public IEnumerable<TypeEntity> GetCountries();
+        public IEnumerable<TypeEntity> GetLookupItems(string entityName);
+        public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         public PrivacyPolicy GetLatestPrivacyPolicy();
         public Candidate GetCandidate(string email);
     }

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void GetCountries_ReturnsAllCountries()
         {
             IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
-            _mockCrm.Setup(mock => mock.GetCountries()).Returns(mockEntities);
+            _mockCrm.Setup(mock => mock.GetLookupItems("dfe_country")).Returns(mockEntities);
 
             var response = _controller.GetCountries();
 
@@ -47,9 +47,57 @@ namespace GetIntoTeachingApiTests.Controllers
         public void GetTeachingSubjects_ReturnsAllSubjects()
         {
             IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
-            _mockCrm.Setup(mock => mock.GetTeachingSubjects()).Returns(mockEntities);
+            _mockCrm.Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist")).Returns(mockEntities);
 
             var response = _controller.GetTeachingSubjects();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetCandidateInitialTeacherTrainingYears_ReturnsAllYears()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear")).Returns(mockEntities);
+
+            var response = _controller.GetCandidateInitialTeacherTrainingYears();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetCandidatePreferredEducationPhases_ReturnsAllPhases()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01")).Returns(mockEntities);
+
+            var response = _controller.GetCandidatePreferredEducationPhases();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetCandidateLocations_ReturnsAllLocations()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("contact", "dfe_isinuk")).Returns(mockEntities);
+
+            var response = _controller.GetCandidateLocations();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetQualificationDegreeStatus_ReturnsAllStatus()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus")).Returns(mockEntities);
+
+            var response = _controller.GetQualificationDegreeStatus();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().Be(mockEntities);

--- a/GetIntoTeachingApiTests/Profiles/TypeEntityProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/TypeEntityProfileTests.cs
@@ -5,6 +5,7 @@ using GetIntoTeachingApiTests.Utils;
 using Microsoft.Xrm.Sdk;
 using System;
 using Xunit;
+using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 
 namespace GetIntoTeachingApiTests.Profiles
 {
@@ -18,7 +19,7 @@ namespace GetIntoTeachingApiTests.Profiles
         }
 
         [Fact]
-        public void TypeEntityProfile_MapsCorrectly()
+        public void TypeEntityProfile_WithALookupItem_MapsCorrectly()
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
@@ -26,8 +27,21 @@ namespace GetIntoTeachingApiTests.Profiles
 
             var typeEntity = _mapper.Map<TypeEntity>(entity);
 
-            typeEntity.Id.Should().Be(entity.Id);
+            ((Guid) typeEntity.Id).Should().Be(entity.Id);
             (typeEntity.Value as string).Should().Be(entity.GetAttributeValue<string>("dfe_name"));
+        }
+
+        [Fact]
+        public void TypeEntityProfile_WithAPickListItem_MapsCorrectly()
+        {
+            var pickListItem = new PickListItem();
+            pickListItem.PickListItemId = 123;
+            pickListItem.DisplayLabel = "name";
+
+            var typeEntity = _mapper.Map<TypeEntity>(pickListItem);
+
+            ((int) typeEntity.Id).Should().Be(pickListItem.PickListItemId);
+            (typeEntity.Value as string).Should().Be(pickListItem.DisplayLabel);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -42,30 +43,29 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetCountries_ReturnsAllOrderedByName()
+        public void GetLookupItems_ReturnsAll()
         {
             IQueryable<Entity> queryableCountries = MockCountries().AsQueryable();
             _mockOrganizationalService.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_country"))
                 .Returns(queryableCountries);
 
-            var result = _crm.GetCountries();
+            var result = _crm.GetLookupItems("dfe_country");
 
             result.Select(country => country.Value).Should().BeEquivalentTo(
                 new[] { "Country 1", "Country 2", "Country 3" }
             );
         }
 
-        [Fact]
-        public void GetTeachingSubjects_ReturnsAllOrderedByName()
+        public void GetPickListItems_ReturnsAll()
         {
-            IQueryable<Entity> queryableCountries = MockTeachingSubjects().AsQueryable();
-            _mockOrganizationalService.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_teachingsubjectlist"))
-                .Returns(queryableCountries);
+            IEnumerable<PickListItem> initialTeacherTrainingYears = MockInitialTeacherTrainingYears();
+            _mockOrganizationalService.Setup(mock => mock.GetPickListItemsForAttribute(ConnectionString, "contact", "dfe_ittyear"))
+                .Returns(initialTeacherTrainingYears);
 
-            var result = _crm.GetTeachingSubjects();
+            var result = _crm.GetPickListItems("contact", "dfe_ittyear");
 
-            result.Select(subject => subject.Value).Should().BeEquivalentTo(
-                new[] { "Subject 1", "Subject 2", "Subject 3" }
+            result.Select(year => year.Value).Should().BeEquivalentTo(
+                new[] { "2010", "2011", "2012" }
             );
         }
 
@@ -160,21 +160,16 @@ namespace GetIntoTeachingApiTests.Services
             var country3 = new Entity("dfe_country");
             country3.Attributes["dfe_name"] = "Country 3";
 
-            return new[] { country3, country1, country2 };
+            return new[] { country1, country2, country3 };
         }
 
-        private IEnumerable<Entity> MockTeachingSubjects()
+        private IEnumerable<PickListItem> MockInitialTeacherTrainingYears()
         {
-            var subject1 = new Entity("dfe_teachingsubjectlist");
-            subject1.Attributes["dfe_name"] = "Subject 1";
+            var year1 = new PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
+            var year2 = new PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
+            var year3 = new PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
 
-            var subject2 = new Entity("dfe_teachingsubjectlist");
-            subject2.Attributes["dfe_name"] = "Subject 2";
-
-            var subject3 = new Entity("dfe_teachingsubjectlist");
-            subject3.Attributes["dfe_name"] = "Subject 3";
-
-            return new[] { subject3, subject1, subject2 };
+            return new[] { year1, year2, year3 };
         }
     }
 }


### PR DESCRIPTION
The `contact` entity in Dynamics has a number of attributes that have a preset list of possible values. These are stored in 'pick list item' objects in Dynamics. This PR exposes these items under the `/types` endpoint so that the client can query possible values.

The `CdsServiceClient` also caches all of the Dynamics metadata, which contains both these pick list items and the lookup objects (countries/teachings subjects). Whilst there's no control over how the cache works, they do provide a mechanism to clear the cache - so if we find it becomes out of date too often we will be able to manually clear it periodically.

Updates the `CrmService` to use a couple of generic methods for retrieving pick list items and lookups; the side effect of this is that the Dynamics domain now leaks out of the `CrmService` into the `TypesController`. I will look into encapsulating the entity names/attribute names somewhere more suitable in a future PR.