### PR TITLE
Perform candidate matching in CrmService

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -45,15 +45,15 @@ that can then be used for verification.",
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
-        public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] CandidateAccessTokenRequest request)
+        public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(this.ModelState);
             }
 
-            Candidate candidate = _crm.GetCandidate(request.Email);
-            if (!request.Match(candidate))
+            Candidate candidate = _crm.GetCandidate(request);
+            if (candidate == null)
             {
                 return NotFound();
             }

--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 namespace GetIntoTeachingApi.Models
 {
-    public class CandidateAccessTokenRequest
+    public class ExistingCandidateRequest
     {
         private static readonly int MinimumAdditionalAttributeMatches = 2;
 

--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -4,9 +4,9 @@ using System.Linq;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class CandidateAccessTokenRequestValidator : AbstractValidator<CandidateAccessTokenRequest>
+    public class ExistingCandidateRequestValidator : AbstractValidator<ExistingCandidateRequest>
     {
-        public CandidateAccessTokenRequestValidator()
+        public ExistingCandidateRequestValidator()
         {
             RuleFor(request => request.Email).NotEmpty().EmailAddress();
             RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.Now);
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
         }
 
-        private Boolean SpecifyTwoAdditionalRequiredAttributes(CandidateAccessTokenRequest request)
+        private Boolean SpecifyTwoAdditionalRequiredAttributes(ExistingCandidateRequest request)
         {
             var additionalRequiredAttributes = new Object[] { request.DateOfBirth, request.FirstName, request.LastName };
             return additionalRequiredAttributes.Where(attribute => attribute != null).Count() >= 2;

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -8,6 +8,6 @@ namespace GetIntoTeachingApi.Services
         public IEnumerable<TypeEntity> GetLookupItems(string entityName);
         public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         public PrivacyPolicy GetLatestPrivacyPolicy();
-        public Candidate GetCandidate(string email);
+        public Candidate GetCandidate(ExistingCandidateRequest request);
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {
-            var request = new CandidateAccessTokenRequest { Email = "invalid-email@" };
+            var request = new ExistingCandidateRequest { Email = "invalid-email@" };
             _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
             var response = _controller.CreateAccessToken(request);
@@ -48,12 +48,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public async void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
+        public void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
         {
-            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             var candidate = new Candidate { Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
             _mockTokenService.Setup(mock => mock.GenerateToken("email@address.com")).Returns("123456");
-            _mockCrm.Setup(mock => mock.GetCandidate(request.Email)).Returns(candidate);
+            _mockCrm.Setup(mock => mock.GetCandidate(request)).Returns(candidate);
 
             var response = _controller.CreateAccessToken(request);
 
@@ -70,9 +70,8 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void CreateAccessToken_MismatchedCandidate_ReturnsNotFound()
         {
-            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
-            var candidate = new Candidate { Email = request.Email, FirstName = "Jane", LastName = "Doe" };
-            _mockCrm.Setup(mock => mock.GetCandidate(request.Email)).Returns(candidate);
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockCrm.Setup(mock => mock.GetCandidate(request)).Returns<Candidate>(null);
 
             var response = _controller.CreateAccessToken(request);
 

--- a/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
 {
-    public class CandidateAccessTokenRequestTests
+    public class ExistingCandidateRequestTests
     {
-        private readonly CandidateAccessTokenRequest _request;
+        private readonly ExistingCandidateRequest _request;
 
-        public CandidateAccessTokenRequestTests()
+        public ExistingCandidateRequestTests()
         {
-            _request = new CandidateAccessTokenRequest
+            _request = new ExistingCandidateRequest
             {
                 Email = "email@address.com",
                 FirstName = "first",

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -7,19 +7,19 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.Validators
 {
-    public class CandidateAccessTokenRequestValidatorTests
+    public class ExistingCandidateRequestValidatorTests
     {
-        private readonly CandidateAccessTokenRequestValidator _validator;
+        private readonly ExistingCandidateRequestValidator _validator;
 
-        public CandidateAccessTokenRequestValidatorTests()
+        public ExistingCandidateRequestValidatorTests()
         {
-            _validator = new CandidateAccessTokenRequestValidator();
+            _validator = new ExistingCandidateRequestValidator();
         }
 
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new CandidateAccessTokenRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.Now.AddDays(-18) };
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.Now.AddDays(-18) };
 
             var result = _validator.TestValidate(request);
 
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SpecifyNoAdditionalRequiredAttributes_HasError()
         {
-            var request = new CandidateAccessTokenRequest();
+            var request = new ExistingCandidateRequest();
 
             var result = _validator.TestValidate(request);
 
@@ -75,7 +75,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SpecifyOneAdditionalRequiredAttributes_HasError()
         {
-            var request = new CandidateAccessTokenRequest { FirstName = "first" };
+            var request = new ExistingCandidateRequest { FirstName = "first" };
 
             var result = _validator.TestValidate(request);
 
@@ -85,7 +85,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SpecifyTwoAdditionalRequiredAttributes_HasNoError()
         {
-            var request = new CandidateAccessTokenRequest { FirstName = "first", LastName = "last" };
+            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last" };
 
             var result = _validator.TestValidate(request);
 
@@ -95,7 +95,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SpecifyThreeAdditionalRequiredAttributes_HasNoError()
         {
-            var request = new CandidateAccessTokenRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.Now.AddDays(-18) };
+            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.Now.AddDays(-18) };
 
             var result = _validator.TestValidate(request);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApiTests.Utils;
 using Microsoft.Xrm.Sdk;
@@ -56,6 +57,7 @@ namespace GetIntoTeachingApiTests.Services
             );
         }
 
+        [Fact]
         public void GetPickListItems_ReturnsAll()
         {
             IEnumerable<PickListItem> initialTeacherTrainingYears = MockInitialTeacherTrainingYears();
@@ -82,19 +84,25 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Theory]
-        [InlineData("john@doe.com", "New John")]
-        [InlineData("JOHN@doe.com", "New John")]
-        [InlineData("jane@doe.com", "Jane")]
-        [InlineData("bob@doe.com", null)]
-        public void GetCandidate_MatchesNewestCandidateByEmail(string email, string firstName)
+        [InlineData("john@doe.com", "New John", "Doe", "New John")]
+        [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
+        [InlineData("jane@doe.com", "Jane", "Doe", "Jane")]
+        [InlineData("bob@doe.com", "Bob", "Doe", null)]
+        public void GetCandidate_MatchesOnNewestCandidateWithEmail(
+            string email, 
+            string firstName, 
+            string lastName, 
+            string expectedFirstName
+        )
         {
+            var request = new ExistingCandidateRequest { Email = email, FirstName = firstName, LastName = lastName };
             IQueryable<Entity> queryableCandidates = MockCandidates().AsQueryable();
             _mockOrganizationalService.Setup(mock => mock.CreateQuery(ConnectionString, "contact"))
                 .Returns(queryableCandidates);
 
-            var result = _crm.GetCandidate(email);
+            var result = _crm.GetCandidate(request);
 
-            result?.FirstName.Should().Be(firstName);
+            result?.FirstName.Should().Be(expectedFirstName);
         }
 
         private IEnumerable<Entity> MockCandidates()


### PR DESCRIPTION
Candidate matching is currently performed in the controller, however we are going to be matching requests to existing candidates in other places so it makes sense to perform that operation within the `CrmService` so it can be reused.

This PR updates the logic so we try and match up to 20 candidates by email, returning the first/latest candidate that matches the additional attributes successfully.