### PR TITLE
Return full candidate information

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -61,6 +61,7 @@ exchanged for your token matches the request payload here).",
             Tags = new[] { "Teacher Training Adviser" }
         )]
         [ProducesResponseType(typeof(Candidate), 200)]
+        [ProducesResponseType(404)]
         public IActionResult Get(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken, 
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request
@@ -71,8 +72,14 @@ exchanged for your token matches the request payload here).",
                 return Unauthorized();
             }
 
-            // TODO:
-            return Ok(new Object());
+            Candidate candidate = _crm.GetCandidate(request);
+
+            if (candidate == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(candidate);
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -32,8 +32,8 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetCountries()
         {
-            IEnumerable<TypeEntity> countryTypes = _crm.GetLookupItems("dfe_country");
-            return Ok(countryTypes);
+            IEnumerable<TypeEntity> countries = _crm.GetLookupItems("dfe_country");
+            return Ok(countries);
         }
 
         [HttpGet]
@@ -46,10 +46,9 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetTeachingSubjects()
         {
-            IEnumerable<TypeEntity> teachingSubjectTypes = _crm.GetLookupItems("dfe_teachingsubjectlist");
-            return Ok(teachingSubjectTypes);
+            IEnumerable<TypeEntity> subjects = _crm.GetLookupItems("dfe_teachingsubjectlist");
+            return Ok(subjects);
         }
-
 
         [HttpGet]
         [Route("candidate/initial_teacher_training_years")]
@@ -61,8 +60,8 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetCandidateInitialTeacherTrainingYears()
         {
-            IEnumerable<TypeEntity> initialTeacherTrainingYears = _crm.GetPickListItems("contact", "dfe_ittyear");
-            return Ok(initialTeacherTrainingYears);
+            IEnumerable<TypeEntity> years = _crm.GetPickListItems("contact", "dfe_ittyear");
+            return Ok(years);
         }
 
         [HttpGet]
@@ -75,12 +74,12 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public IActionResult GetCandidatePreferredEducationPhases()
         {
-            IEnumerable<TypeEntity> preferredEducationPhases = _crm.GetPickListItems("contact", "dfe_preferrededucationphase01");
-            return Ok(preferredEducationPhases);
+            IEnumerable<TypeEntity> educationPhases = _crm.GetPickListItems("contact", "dfe_preferrededucationphase01");
+            return Ok(educationPhases);
         }
 
         [HttpGet]
-        [Route("candidate/location")]
+        [Route("candidate/locations")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate locations.",
             OperationId = "GetCandidateLocations",
@@ -97,7 +96,7 @@ namespace GetIntoTeachingApi.Controllers
         [Route("qualification/degree_status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of qualification degree status.",
-            OperationId = "GetCandidateQualifications",
+            OperationId = "GetQualificationDegreeStatus",
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
@@ -105,6 +104,48 @@ namespace GetIntoTeachingApi.Controllers
         {
             IEnumerable<TypeEntity> status = _crm.GetPickListItems("dfe_qualification", "dfe_degreestatus");
             return Ok(status);
+        }
+
+        [HttpGet]
+        [Route("qualification/categories")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of qualification categories.",
+            OperationId = "GetQualificationCategories",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetQualificationCategories()
+        {
+            IEnumerable<TypeEntity> categories = _crm.GetPickListItems("dfe_qualification", "dfe_category");
+            return Ok(categories);
+        }
+
+        [HttpGet]
+        [Route("qualification/types")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of qualification types.",
+            OperationId = "GetQualificationTypes",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetQualificationTypes()
+        {
+            IEnumerable<TypeEntity> types = _crm.GetPickListItems("dfe_qualification", "dfe_type");
+            return Ok(types);
+        }
+
+        [HttpGet]
+        [Route("past_teaching_position/education_phases")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of past teaching position education phases.",
+            OperationId = "GetPastTeachingPositionEducationPhases",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetPastTeachingPositionEducationPhases()
+        {
+            IEnumerable<TypeEntity> educationPhases = _crm.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase");
+            return Ok(educationPhases);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Address.cs
+++ b/GetIntoTeachingApi/Models/Address.cs
@@ -1,0 +1,12 @@
+﻿namespace GetIntoTeachingApi.Models
+{
+    public class Address
+    {
+        public string Line1 { get; set; }
+        public string Line2 { get; set; }
+        public string Line3 { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string Postcode { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -4,10 +4,17 @@ namespace GetIntoTeachingApi.Models
 {
     public class Candidate
     {
-        public Guid Id { get; set; }
+        public Guid? Id { get; set; }
+        public Guid? PreferredTeachingSubjectId { get; set; }
+        public int? PreferredEducationPhaseId { get; set; }
+        public int? LocationId { get; set; }
+        public int? InitialTeacherTrainingYearId { get; set; }
         public string Email { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public DateTime? DateOfBirth { get; set; }
+        public Address Address { get; set; }
+        public CandidateQualification[] Qualifications { get; set; }
+        public CandidatePastTeachingPosition[] PastTeachingPositions { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidatePastTeachingPosition
+    {
+        public Guid? Id { get; set; }
+        public Guid? SubjectTaughtId { get; set; }
+        public int? EducationPhaseId { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateQualification
+    {
+        public Guid? Id { get; set; }
+        public int? CategoryId { get; set; }
+        public int? TypeId { get; set; }
+        public int? DegreeStatusId { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Profiles/CandidatePastTeachingPositionProfile.cs
+++ b/GetIntoTeachingApi/Profiles/CandidatePastTeachingPositionProfile.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Profiles
+{
+    public class CandidatePastTeachingPositionProfile : Profile
+    {
+        public CandidatePastTeachingPositionProfile()
+        {
+            CreateMap<Entity, CandidatePastTeachingPosition>()
+                .ForMember(dest => dest.SubjectTaughtId,
+                    opt => opt.MapFrom(src =>
+                        src.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id))
+                .ForMember(dest => dest.EducationPhaseId,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value));
+        }
+    }
+}

--- a/GetIntoTeachingApi/Profiles/CandidateProfile.cs
+++ b/GetIntoTeachingApi/Profiles/CandidateProfile.cs
@@ -9,19 +9,36 @@ namespace GetIntoTeachingApi.Profiles
     {
         public CandidateProfile()
         {
-            CreateMap<Entity, Candidate>().ForMember(dest =>
-                dest.Email,
-                opt => opt.MapFrom(src => src.GetAttributeValue<string>("emailaddress1"))
-            ).ForMember(dest =>
-                dest.FirstName,
-                opt => opt.MapFrom(src => src.GetAttributeValue<string>("firstname"))
-            ).ForMember(dest =>
-                dest.LastName,
-                opt => opt.MapFrom(src => src.GetAttributeValue<string>("lastname"))
-            ).ForMember(dest =>
-                dest.DateOfBirth,
-                opt => opt.MapFrom(src => src.GetAttributeValue<DateTime>("birthdate"))
-            );
+            CreateMap<Entity, Candidate>()
+                .ForMember(dest => dest.PreferredTeachingSubjectId,
+                    opt => opt.MapFrom(src =>
+                        src.GetAttributeValue<EntityReference>("dfe_preferredteachingsubject01").Id))
+                .ForMember(dest => dest.PreferredEducationPhaseId,
+                    opt => opt.MapFrom(src =>
+                        src.GetAttributeValue<OptionSetValue>("dfe_preferrededucationphase01").Value))
+                .ForMember(dest => dest.LocationId,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<OptionSetValue>("dfe_isinuk").Value))
+                .ForMember(dest => dest.InitialTeacherTrainingYearId,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<OptionSetValue>("dfe_ittyear").Value))
+                .ForMember(dest => dest.Email,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("emailaddress1")))
+                .ForMember(dest => dest.FirstName,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("firstname")))
+                .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.GetAttributeValue<string>("lastname")))
+                .ForMember(dest => dest.DateOfBirth,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<DateTime>("birthdate")))
+                .ForPath(dest => dest.Address.Line1,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_line1")))
+                .ForPath(dest => dest.Address.Line2,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_line2")))
+                .ForPath(dest => dest.Address.Line3,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_line3")))
+                .ForPath(dest => dest.Address.City,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_city")))
+                .ForPath(dest => dest.Address.State,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_stateorprovince")))
+                .ForPath(dest => dest.Address.Postcode,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<string>("address1_postalcode")));
         }
     }
 }

--- a/GetIntoTeachingApi/Profiles/CandidateQualificationProfile.cs
+++ b/GetIntoTeachingApi/Profiles/CandidateQualificationProfile.cs
@@ -1,0 +1,21 @@
+﻿using AutoMapper;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Profiles
+{
+    public class CandidateQualificationProfile : Profile
+    {
+        public CandidateQualificationProfile()
+        {
+            CreateMap<Entity, CandidateQualification>()
+                .ForMember(dest => dest.CategoryId,
+                    opt => opt.MapFrom(src =>
+                        src.GetAttributeValue<OptionSetValue>("dfe_category").Value))
+                .ForMember(dest => dest.TypeId,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<OptionSetValue>("dfe_type").Value))
+                .ForMember(dest => dest.DegreeStatusId,
+                    opt => opt.MapFrom(src => src.GetAttributeValue<OptionSetValue>("dfe_degreestatus").Value));
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -103,6 +103,42 @@ namespace GetIntoTeachingApiTests.Controllers
             ok.Value.Should().Be(mockEntities);
         }
 
+        [Fact]
+        public void GetQualificationCategories_ReturnsAllCategories()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_category")).Returns(mockEntities);
+
+            var response = _controller.GetQualificationCategories();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetQualificatioTypes_ReturnsAllTypes()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_type")).Returns(mockEntities);
+
+            var response = _controller.GetQualificationTypes();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
+        public void GetPastTeachingPositionEducationPhases_ReturnsAllPhases()
+        {
+            IEnumerable<TypeEntity> mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase")).Returns(mockEntities);
+
+            var response = _controller.GetPastTeachingPositionEducationPhases();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
         private IEnumerable<TypeEntity> MockTypeEntities()
         {
             return new []

--- a/GetIntoTeachingApiTests/Models/AddressTests.cs
+++ b/GetIntoTeachingApiTests/Models/AddressTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class AddressTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidatePastTeachingPositionTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateQualificationTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Profiles/CandidatePastTeachingPositionProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/CandidatePastTeachingPositionProfileTests.cs
@@ -1,0 +1,35 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApiTests.Utils;
+using Microsoft.Xrm.Sdk;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Profiles
+{
+    public class CandidatePastTeachingPositionProfileTests
+    {
+        private readonly Mapper _mapper;
+
+        public CandidatePastTeachingPositionProfileTests()
+        {
+            _mapper = MapperHelpers.CreateMapper();
+        }
+
+        [Fact]
+        public void CandidatePastTeachingPositionProfile_MapsCorrectly()
+        {
+            var entity = new Entity();
+            entity.Id = Guid.NewGuid();
+            entity.Attributes["dfe_subjecttaught"] = new EntityReference { Id = Guid.NewGuid() };
+            entity.Attributes["dfe_educationphase"] = new OptionSetValue { Value = 1 };
+
+            var candidate = _mapper.Map<CandidatePastTeachingPosition>(entity);
+
+            candidate.Id.Should().Be(entity.Id);
+            candidate.SubjectTaughtId.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id);
+            candidate.EducationPhaseId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Profiles/CandidateProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/CandidateProfileTests.cs
@@ -22,18 +22,36 @@ namespace GetIntoTeachingApiTests.Profiles
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
+            entity.Attributes["dfe_preferredteachingsubject01"] = new EntityReference { Id = Guid.NewGuid() };
+            entity.Attributes["dfe_preferrededucationphase01"] = new OptionSetValue { Value = 1 };
+            entity.Attributes["dfe_isinuk"] = new OptionSetValue { Value = 2 };
+            entity.Attributes["dfe_ittyear"] = new OptionSetValue { Value = 3 };
             entity.Attributes["emailaddress1"] = "email@address.com";
             entity.Attributes["firstname"] = "first";
             entity.Attributes["lastname"] = "last";
             entity.Attributes["birthdate"] = new DateTime(1967, 3, 10);
+            entity.Attributes["address1_line1"] = "line1";
+            entity.Attributes["address1_line2"] = "line2";
+            entity.Attributes["address1_line3"] = "line3";
+            entity.Attributes["address1_stateorprovince"] = "state";
+            entity.Attributes["address1_postalcode"] = "postcode";
 
             var candidate = _mapper.Map<Candidate>(entity);
 
             candidate.Id.Should().Be(entity.Id);
+            candidate.PreferredTeachingSubjectId.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_preferredteachingsubject01").Id);
+            candidate.PreferredEducationPhaseId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_preferrededucationphase01").Value);
+            candidate.LocationId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_isinuk").Value);
+            candidate.InitialTeacherTrainingYearId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_ittyear").Value);
             candidate.Email.Should().Be(entity.GetAttributeValue<string>("emailaddress1"));
             candidate.FirstName.Should().Be(entity.GetAttributeValue<string>("firstname"));
             candidate.LastName.Should().Be(entity.GetAttributeValue<string>("lastname"));
             candidate.DateOfBirth.Should().Be(entity.GetAttributeValue<DateTime>("birthdate"));
+            candidate.Address.Line1.Should().Be(entity.GetAttributeValue<string>("address1_line1"));
+            candidate.Address.Line2.Should().Be(entity.GetAttributeValue<string>("address1_line2"));
+            candidate.Address.Line3.Should().Be(entity.GetAttributeValue<string>("address1_line3"));
+            candidate.Address.State.Should().Be(entity.GetAttributeValue<string>("address1_stateorprovince"));
+            candidate.Address.Postcode.Should().Be(entity.GetAttributeValue<string>("address1_postalcode"));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Profiles/CandidateQualificationProfileTests.cs
+++ b/GetIntoTeachingApiTests/Profiles/CandidateQualificationProfileTests.cs
@@ -1,0 +1,37 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApiTests.Utils;
+using Microsoft.Xrm.Sdk;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Profiles
+{
+    public class CandidateQualificationProfileTests
+    {
+        private readonly Mapper _mapper;
+
+        public CandidateQualificationProfileTests()
+        {
+            _mapper = MapperHelpers.CreateMapper();
+        }
+
+        [Fact]
+        public void CandidateQualificationProfile_MapsCorrectly()
+        {
+            var entity = new Entity();
+            entity.Id = Guid.NewGuid();
+            entity.Attributes["dfe_category"] = new OptionSetValue { Value = 1 };
+            entity.Attributes["dfe_type"] = new OptionSetValue { Value = 2 };
+            entity.Attributes["dfe_degreestatus"] = new OptionSetValue { Value = 3 };
+
+            var candidate = _mapper.Map<CandidateQualification>(entity);
+
+            candidate.Id.Should().Be(entity.Id);
+            candidate.CategoryId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_category").Value);
+            candidate.TypeId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_type").Value);
+            candidate.DegreeStatusId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_degreestatus").Value);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/MapperHelpers.cs
+++ b/GetIntoTeachingApiTests/Utils/MapperHelpers.cs
@@ -11,6 +11,8 @@ namespace GetIntoTeachingApiTests.Utils
                 config.AddProfile<TypeEntityProfile>();
                 config.AddProfile<PrivacyPolicyProfile>();
                 config.AddProfile<CandidateProfile>();
+                config.AddProfile<CandidateQualificationProfile>();
+                config.AddProfile<CandidatePastTeachingPositionProfile>();
             });
 
             return new Mapper(config);


### PR DESCRIPTION
As part of the Get into Teaching registration form we will be asking candidates about their past teaching positions and qualifications. The information is stored as separate entities in Dynamics - this PR updates the `CrmService` to query the entities when retrieving a candidate (running them through the AutoMapper profile to get back an equivalent API model).

Add type endpoints for retrieving the type information associated with candidate qualifications and past teaching positions.

Add the remaining models associated with a `Candidate` that we will need for the GiT registration form (`Address`, `CandidateQualification` and `CandidatePastTeachingPosition`).

Include associated AutoMapper profiles for mapping to the new models from Dynamics `Entity` objects.

Hook the GET `/teacher_training_adviser/candidates/{accessToken}` endpoint up the the CRM to retrieve and respond with the matching candidate.
