### PR TITLE
Add candidate validation

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/AddressValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/AddressValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class AddressValidator : AbstractValidator<Address>
+    {
+        public AddressValidator()
+        {
+            RuleFor(address => address.Line1).NotEmpty().MaximumLength(1024);
+            RuleFor(address => address.Line2).MaximumLength(1024);
+            RuleFor(address => address.Line3).MaximumLength(1024);
+            RuleFor(address => address.City).NotEmpty().MaximumLength(128);
+            RuleFor(address => address.State).NotEmpty().MaximumLength(128);
+            RuleFor(address => address.Postcode).NotEmpty().MaximumLength(40);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentValidation;
+using GetIntoTeachingApi.Services;
+using System.Linq;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidatePastTeachingPositionValidator : AbstractValidator<CandidatePastTeachingPosition>
+    {
+        private readonly ICrmService _crm;
+
+        public CandidatePastTeachingPositionValidator(ICrmService crm)
+        {
+            _crm = crm;
+
+            RuleFor(position => position.EducationPhaseId)
+                .Must(id => EducationPhaseIds().Contains(id))
+                .WithMessage("Must be a valid past teaching position education phase.");
+            RuleFor(candidate => candidate.SubjectTaughtId)
+                .Must(id => TeachingSubjectIds().Contains(id))
+                .WithMessage("Must be a valid teaching subject.");
+        }
+
+        public IEnumerable<Guid?> TeachingSubjectIds()
+        {
+            return _crm.GetLookupItems("dfe_teachingsubjectlist").Select(subject => (Guid?)subject.Id);
+        }
+
+        public IEnumerable<int?> EducationPhaseIds()
+        {
+            return _crm.
+                GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase")
+                .Select(type => (int?)type.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using FluentValidation;
+using GetIntoTeachingApi.Services;
+using System.Linq;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidateQualificationValidator : AbstractValidator<CandidateQualification>
+    {
+        private readonly ICrmService _crm;
+
+        public CandidateQualificationValidator(ICrmService crm)
+        {
+            _crm = crm;
+
+            RuleFor(qualification => qualification.TypeId)
+                .Must(id => TypeIds().Contains(id))
+                .WithMessage("Must be a valid qualification type.");
+            RuleFor(qualification => qualification.CategoryId)
+                .Must(id => CategoryIds().Contains(id))
+                .Unless(qualification => qualification.CategoryId == null)
+                .WithMessage("Must be a valid qualification category.");
+            RuleFor(qualification => qualification.DegreeStatusId)
+                .Must(id => StatusIds().Contains(id))
+                .Unless(qualification => qualification.DegreeStatusId == null)
+                .WithMessage("Must be a valid qualification degree status.");
+        }
+
+        public IEnumerable<int?> CategoryIds()
+        {
+            return _crm.GetPickListItems("dfe_qualification", "dfe_category").Select(category => (int?)category.Id);
+        }
+
+        public IEnumerable<int?> TypeIds()
+        {
+            return _crm.GetPickListItems("dfe_qualification", "dfe_type").Select(type => (int?)type.Id);
+        }
+
+        public IEnumerable<int?> StatusIds()
+        {
+            return _crm.GetPickListItems("dfe_qualification", "dfe_degreestatus").Select(status => (int?)status.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -1,0 +1,76 @@
+﻿using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidateValidator : AbstractValidator<Candidate>
+    {
+        private readonly ICrmService _crm;
+
+        public CandidateValidator(ICrmService crm)
+        {
+            _crm = crm;
+
+            RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
+            RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
+            RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress().MaximumLength(100);
+            RuleFor(candidate => candidate.DateOfBirth).NotNull().LessThan(candidate => DateTime.Now);
+            RuleFor(candidate => candidate.Telephone).NotEmpty().MaximumLength(50);
+            RuleFor(candidate => candidate.PhoneCallScheduledStartAt).NotNull().GreaterThan(candidate => DateTime.Now);
+
+            RuleFor(candidate => candidate.Address)
+                .SetValidator(new AddressValidator())
+                .Unless(candidate => candidate.Address == null);
+            RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(crm));
+            RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(crm));
+
+            RuleFor(candidate => candidate.AcceptedPrivacyPolicyId)
+                .Must(id => PrivacyPolicyIds().Contains(id))
+                .WithMessage("Must be a valid privacy policy.");
+            RuleFor(candidate => candidate.PreferredTeachingSubjectId)
+                .Must(id => PreferredTeachingSubjectIds().Contains(id))
+                .Unless(candidate => candidate.PreferredTeachingSubjectId == null)
+                .WithMessage("Must be a valid teaching subject.");
+            RuleFor(candidate => candidate.PreferredEducationPhaseId)
+                .Must(id => PreferredEducationPhaseIds().Contains(id))
+                .Unless(candidate => candidate.PreferredEducationPhaseId == null)
+                .WithMessage("Must be a valid candidate education phase.");
+            RuleFor(candidate => candidate.LocationId)
+                .Must(id => LocationIds().Contains(id))
+                .Unless(candidate => candidate.LocationId == null)
+                .WithMessage("Must be a valid candidate location.");
+            RuleFor(candidate => candidate.InitialTeacherTrainingYearId)
+                .Must(id => InitialTeacherTrainingYearIds().Contains(id))
+                .Unless(candidate => candidate.InitialTeacherTrainingYearId == null)
+                .WithMessage("Must be a valid candidate initial teacher training year.");
+        }
+
+        public IEnumerable<Guid?> PreferredTeachingSubjectIds()
+        {
+            return _crm.GetLookupItems("dfe_teachingsubjectlist").Select(subject => (Guid?)subject.Id);
+        }
+
+        public IEnumerable<Guid?> PrivacyPolicyIds()
+        {
+            return _crm.GetPrivacyPolicies().Select(policy => (Guid?)policy.Id);
+        }
+
+        public IEnumerable<int?> PreferredEducationPhaseIds()
+        {
+            return _crm.GetPickListItems("contact", "dfe_preferrededucationphase01").Select(phase => (int?)phase.Id);
+        }
+
+        public IEnumerable<int?> LocationIds()
+        {
+            return _crm.GetPickListItems("contact", "dfe_isinuk").Select(location => (int?)location.Id);
+        }
+
+        public IEnumerable<int?> InitialTeacherTrainingYearIds()
+        {
+            return _crm.GetPickListItems("contact", "dfe_ittyear").Select(year => (int?)year.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -8,17 +8,19 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public ExistingCandidateRequestValidator()
         {
-            RuleFor(request => request.Email).NotEmpty().EmailAddress();
+            RuleFor(request => request.FirstName).MaximumLength(256);
+            RuleFor(request => request.LastName).MaximumLength(256);
+            RuleFor(request => request.Email).NotEmpty().EmailAddress().MaximumLength(100);
             RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.Now);
             RuleFor(request => request)
-                .Must(request => SpecifyTwoAdditionalRequiredAttributes(request))
+                .Must(SpecifyTwoAdditionalRequiredAttributes)
                 .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
         }
 
-        private Boolean SpecifyTwoAdditionalRequiredAttributes(ExistingCandidateRequest request)
+        private static bool SpecifyTwoAdditionalRequiredAttributes(ExistingCandidateRequest request)
         {
-            var additionalRequiredAttributes = new Object[] { request.DateOfBirth, request.FirstName, request.LastName };
-            return additionalRequiredAttributes.Where(attribute => attribute != null).Count() >= 2;
+            var additionalRequiredAttributes = new object[] { request.DateOfBirth, request.FirstName, request.LastName };
+            return additionalRequiredAttributes.Count(attribute => attribute != null) >= 2;
         }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -11,6 +11,7 @@ namespace GetIntoTeachingApi.Services
     {       
         public enum PrivacyPolicyType { Web = 222750001 }
         private readonly int MaximumNumberOfCandidatesToMatch = 20;
+        private readonly int MaximumNumberOfPrivacyPolicies = 3;
         private readonly IOrganizationServiceAdapter _organizationalService;
 
         public CrmService(IOrganizationServiceAdapter organizationalService)
@@ -32,6 +33,11 @@ namespace GetIntoTeachingApi.Services
 
         public PrivacyPolicy GetLatestPrivacyPolicy()
         {
+            return GetPrivacyPolicies().FirstOrDefault();
+        }
+
+        public IEnumerable<PrivacyPolicy> GetPrivacyPolicies()
+        {
             return _organizationalService.CreateQuery(ConnectionString(), "dfe_privacypolicy")
                 .Where((entity) =>
                     entity.GetAttributeValue<OptionSetValue>("dfe_policytype").Value == (int) PrivacyPolicyType.Web &&
@@ -39,7 +45,7 @@ namespace GetIntoTeachingApi.Services
                 )
                 .OrderByDescending((policy) => policy.GetAttributeValue<DateTime>("createdon"))
                 .Select((entity) => new PrivacyPolicy(entity))
-                .First();
+                .Take(MaximumNumberOfPrivacyPolicies);
         }
 
         public Candidate GetCandidate(ExistingCandidateRequest request)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -8,6 +8,7 @@ namespace GetIntoTeachingApi.Services
         public IEnumerable<TypeEntity> GetLookupItems(string entityName);
         public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         public PrivacyPolicy GetLatestPrivacyPolicy();
+        public IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         public Candidate GetCandidate(ExistingCandidateRequest request);
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -66,5 +66,18 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 
             response.Should().BeOfType<NotFoundResult>();
         }
+
+        [Fact]
+        public void Upsert_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var candidate = new Candidate { Email = "invalid-email@" };
+            _controller.ModelState.AddModelError("Email", "Email is invalid.");
+
+            var response = _controller.Upsert(candidate);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/AddressValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/AddressValidatorTests.cs
@@ -1,0 +1,96 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class AddressValidatorTests
+    {
+        private readonly AddressValidator _validator;
+
+        public AddressValidatorTests()
+        {
+            _validator = new AddressValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var address = new Address
+            {
+                Line1 = "line1", 
+                Line2 = "line2", 
+                Line3 = "line3",
+                City = "city", 
+                State = "state", 
+                Postcode = "postcode"
+            };
+
+            var result = _validator.TestValidate(address);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_Line1IsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Line1, "");
+        }
+
+        [Fact]
+        public void Validate_Line1IsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Line1, new string('a', 1025));
+        }
+
+        [Fact]
+        public void Validate_Line2IsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Line2, new string('a', 1025));
+        }
+
+        [Fact]
+        public void Validate_Line3IsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Line3, new string('a', 1025));
+        }
+
+        [Fact]
+        public void Validate_CityIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.City, "");
+        }
+
+        [Fact]
+        public void Validate_CityIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.City, new string('a', 129));
+        }
+
+        [Fact]
+        public void Validate_StateIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.State, "");
+        }
+
+        [Fact]
+        public void Validate_StateIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.State, new string('a', 129));
+        }
+
+        [Fact]
+        public void Validate_PostcodeIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Postcode, "");
+        }
+
+        [Fact]
+        public void Validate_PostcodeIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(address => address.Postcode, new string('a', 41));
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidatePastTeachingPositionValidatorTests
+    {
+        private readonly CandidatePastTeachingPositionValidator _validator;
+        private readonly Mock<ICrmService> _mockCrm;
+
+        public CandidatePastTeachingPositionValidatorTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _validator = new CandidatePastTeachingPositionValidator(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockSubject = NewMock(Guid.NewGuid());
+            var mockPhase = NewMock(123);
+
+            _mockCrm
+                .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
+                .Returns(new[] { mockSubject });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"))
+                .Returns(new[] { mockPhase });
+
+            var position = new CandidatePastTeachingPosition
+            {
+                SubjectTaughtId = mockSubject.Id,
+                EducationPhaseId = mockPhase.Id,
+            };
+
+            var result = _validator.TestValidate(position);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_SubjectTaughtIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(position => position.SubjectTaughtId, Guid.NewGuid());
+        }
+
+        [Fact]
+        public void Validate_SubjectTaughtIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(position => position.SubjectTaughtId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_EducationPhaseIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(position => position.EducationPhaseId, 123);
+        }
+
+        [Fact]
+        public void Validate_EducationPhaseIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(position => position.EducationPhaseId, null as int?);
+        }
+
+        private TypeEntity NewMock(dynamic id)
+        {
+            return new TypeEntity { Id = id };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidateQualificationValidatorTests
+    {
+        private readonly CandidateQualificationValidator _validator;
+        private readonly Mock<ICrmService> _mockCrm;
+
+        public CandidateQualificationValidatorTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _validator = new CandidateQualificationValidator(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockCategory = NewMock(111);
+            var mockType = NewMock(222);
+            var mockDegreeStatus = NewMock(333);
+
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_category"))
+                .Returns(new[] { mockCategory });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_type"))
+                .Returns(new[] { mockType });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus"))
+                .Returns(new[] { mockDegreeStatus });
+
+            var qualification = new CandidateQualification()
+            {
+                TypeId = mockType.Id,
+                CategoryId = mockCategory.Id,
+                DegreeStatusId = mockDegreeStatus.Id,
+            };
+
+            var result = _validator.TestValidate(qualification);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_TypeIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(qualification => qualification.TypeId, 123);
+        }
+
+        [Fact]
+        public void Validate_TypeIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(qualification => qualification.TypeId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_CategoryIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(qualification => qualification.CategoryId, 123);
+        }
+
+        [Fact]
+        public void Validate_CategoryIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(qualification => qualification.CategoryId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(qualification => qualification.DegreeStatusId, 123);
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(qualification => qualification.DegreeStatusId, null as int?);
+        }
+
+        private TypeEntity NewMock(dynamic id)
+        {
+            return new TypeEntity { Id = id };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+using Guid = System.Guid;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidateValidatorTests
+    {
+        private readonly CandidateValidator _validator;
+        private readonly Mock<ICrmService> _mockCrm;
+
+        public CandidateValidatorTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _validator = new CandidateValidator(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+            var mockPreferredTeachingSubject = NewMock(Guid.NewGuid());
+            var mockPreferredEducationPhase = NewMock(111);
+            var mockLocation = NewMock(222);
+            var mockInitialTeacherTrainingYear = NewMock(333);
+
+            _mockCrm
+                .Setup(mock => mock.GetPrivacyPolicies())
+                .Returns(new[] { mockPrivacyPolicy });
+            _mockCrm
+                .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
+                .Returns(new[] { mockPreferredTeachingSubject });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01"))
+                .Returns(new[] { mockPreferredEducationPhase });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_isinuk"))
+                .Returns(new[] { mockLocation });
+            _mockCrm
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear"))
+                .Returns(new[] { mockInitialTeacherTrainingYear });
+
+            var candidate = new Candidate()
+            {
+                FirstName = "first",
+                LastName = "last",
+                Email = "email@address.com",
+                DateOfBirth = DateTime.Now.AddYears(-18),
+                Telephone = "07584 734 576",
+                PhoneCallScheduledStartAt = DateTime.Now.AddDays(2),
+                AcceptedPrivacyPolicyId = mockPrivacyPolicy.Id,
+                PreferredTeachingSubjectId = mockPreferredTeachingSubject.Id,
+                PreferredEducationPhaseId = mockPreferredEducationPhase.Id,
+                LocationId = mockLocation.Id,
+                InitialTeacherTrainingYearId = mockInitialTeacherTrainingYear.Id,
+            };
+
+            var result = _validator.TestValidate(candidate);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_AddressIsInvalid_HasError()
+        {
+            var candidate = new Candidate {Address = new Address {Line1 = ""}};
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.Address.Line1);
+        }
+
+        [Fact]
+        public void Validate_QualificationIsInvalid_HasError()
+        {
+            var candidate = new Candidate { Qualifications = new [] { new CandidateQualification { TypeId = 123 } } };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor("Qualifications[0].TypeId");
+        }
+
+        [Fact]
+        public void Validate_PastTeachingPositionIsInvalid_HasError()
+        {
+            var candidate = new Candidate { PastTeachingPositions = 
+                new[]
+                {
+                    new CandidatePastTeachingPosition() { SubjectTaughtId = Guid.NewGuid() }
+                }
+            };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor("PastTeachingPositions[0].SubjectTaughtId");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, "");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Email, "valid@email.com");
+        }
+
+        [Fact]
+        public void Validate_DateOfBirthIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.DateOfBirth, null as DateTime?);
+        }
+
+        [Fact]
+        public void Validate_DateOfBirthInFuture_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.DateOfBirth, DateTime.Now.AddDays(1));
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FirstName, "");
+        }
+
+        [Fact]
+        public void Validate_FirstNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FirstName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_LastNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.LastName, "");
+        }
+
+        [Fact]
+        public void Validate_LastNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.LastName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_TelephoneIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, "");
+        }
+
+        [Fact]
+        public void Validate_TelephoneTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('a', 51));
+        }
+
+        [Fact]
+        public void Validate_PhoneCallScheduledStartAtIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PhoneCallScheduledStartAt, null as DateTime?);
+        }
+
+        [Fact]
+        public void Validate_PhoneCallScheduledStartAtInPast_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PhoneCallScheduledStartAt, DateTime.Now.AddDays(-1));
+        }
+
+        [Fact]
+        public void Validate_AcceptedPrivacyPolicyIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AcceptedPrivacyPolicyId, Guid.NewGuid());
+        }
+
+        [Fact]
+        public void Validate_AcceptedPrivacyPolicyIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AcceptedPrivacyPolicyId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PreferredTeachingSubjectId, Guid.NewGuid());
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PreferredTeachingSubjectId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_PreferredEducationPhaseIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PreferredEducationPhaseId, 123);
+        }
+
+        [Fact]
+        public void Validate_PreferredEducationPhaseIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PreferredEducationPhaseId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_LocationIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.LocationId, 123);
+        }
+
+        [Fact]
+        public void Validate_LocationIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.LocationId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_InitialTeacherTrainingYearIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.InitialTeacherTrainingYearId, 123);
+        }
+
+        [Fact]
+        public void Validate_InitialTeacherTrainingYearIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.InitialTeacherTrainingYearId, null as int?);
+        }
+
+        private TypeEntity NewMock(dynamic id)
+        {
+            return new TypeEntity { Id = id };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -27,12 +27,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_EmailAddressIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-        }
-
-        [Fact]
         public void Validate_EmailAddressIsEmpty_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.Email, "");
@@ -42,6 +36,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_EmailAddressIsInvalid_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
         }
 
         [Fact]
@@ -57,9 +57,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_DateOfBirthInPast_HasNoError()
+        public void Validate_FirstNameTooLong_HasError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.DateOfBirth, DateTime.Now.AddDays(-1));
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_LastNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, new string('a', 257));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -84,6 +84,19 @@ namespace GetIntoTeachingApiTests.Services
             result.Text.Should().Be("Latest Active Web");
         }
 
+        [Fact]
+        public void GetPrivacyPolicies_Returns3MostRecentActiveWebPrivacyPolicies()
+        {
+            IQueryable<Entity> queryablePrivacyPolicies = MockPrivacyPolicies().AsQueryable();
+            _mockOrganizationalService.Setup(mock => mock.CreateQuery(ConnectionString, "dfe_privacypolicy"))
+                .Returns(queryablePrivacyPolicies);
+
+            var result = _crm.GetPrivacyPolicies();
+
+            result.Count().Should().Be(3);
+            result.Select(policy => policy.Text).Should().BeEquivalentTo(new string[] { "Latest Active Web", "Not Latest 1", "Not Latest 2" });
+        }
+
         [Theory]
         [InlineData("john@doe.com", "New John", "Doe", "New John")]
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
@@ -212,12 +225,24 @@ namespace GetIntoTeachingApiTests.Services
             policy3.Attributes["dfe_active"] = false;
 
             var policy4 = new Entity("dfe_privacypolicy");
-            policy4.Attributes["dfe_details"] = "Not Latest";
+            policy4.Attributes["dfe_details"] = "Not Latest 1";
             policy4.Attributes["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
             policy4.Attributes["createdon"] = DateTime.UtcNow.AddDays(-15);
             policy4.Attributes["dfe_active"] = true;
 
-            return new[] { policy1, policy2, policy3, policy4 };
+            var policy5 = new Entity("dfe_privacypolicy");
+            policy5.Attributes["dfe_details"] = "Not Latest 2";
+            policy5.Attributes["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy5.Attributes["createdon"] = DateTime.UtcNow.AddDays(-20);
+            policy5.Attributes["dfe_active"] = true;
+
+            var policy6 = new Entity("dfe_privacypolicy");
+            policy6.Attributes["dfe_details"] = "Not Latest 3";
+            policy6.Attributes["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy6.Attributes["createdon"] = DateTime.UtcNow.AddDays(-25);
+            policy6.Attributes["dfe_active"] = true;
+
+            return new[] { policy1, policy2, policy3, policy4, policy5, policy6 };
         }
 
         private IEnumerable<Entity> MockCountries()


### PR DESCRIPTION
Add validators for the `Candidate` model and all associated models.

When a model attribute links to a preset list of Dynamics `Entity` objects we call out to the CRM to ensure that the `Id` of the association matches a record. The `CdsServiceClient` will maintain a cache of the Dynamics metadata, meaning these calls should almost always be satisfied in-memory.

Add additional method to `CrmService` to get recent privacy policies; we validate that the user is accepting one of the 3 most recent privacy policies to account for the CRM potentially being down and a policy update happening in quick succession (while our jobs to register a new candidate are queued). We may want to make this 2 going forward; I've raised it as a question.