### PR TITLE
Upsert candidate details to CRM

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -1,13 +1,20 @@
-﻿using Microsoft.Xrm.Sdk;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
+using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public interface IOrganizationServiceAdapter
     {
         public IQueryable<Entity> CreateQuery(string connectionString, string entityName);
-        public IEnumerable<PickListItem> GetPickListItemsForAttribute(string connectionString, string entityName, string attributeName);
+        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string connectionString, string entityName, string attributeName);
+        public OrganizationServiceContext Context(string connectionString);
+        public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
+        public Entity NewEntity(string entityName, OrganizationServiceContext context);
+        public void SaveChanges(OrganizationServiceContext context);
+        public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.PowerPlatform.Cds.Client;
-using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Client;
 using System.Collections.Generic;
 using System.Linq;
-using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
+using System;
 
 namespace GetIntoTeachingApi.Adapters
 {
@@ -22,23 +22,53 @@ namespace GetIntoTeachingApi.Adapters
             return context.CreateQuery(entityName);
         }
 
-        public IEnumerable<PickListItem> GetPickListItemsForAttribute(
-            string connectionString, 
-            string entityName, 
+        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(
+            string connectionString,
+            string entityName,
             string attributeName
         )
         {
-            var client = Client(connectionString);
-            PickListMetaElement metaElement = client.GetPickListElementFromMetadataEntity(entityName, attributeName);
+            var client = RetrieveClient(connectionString);
+            var metaElement = client.GetPickListElementFromMetadataEntity(entityName, attributeName);
             return metaElement.Items;
         }
 
-        private OrganizationServiceContext Context(string connectionString)
+        public OrganizationServiceContext Context(string connectionString)
         {
-            return new OrganizationServiceContext(Client(connectionString));
+            return ConstructContext(connectionString);
         }
 
-        private CdsServiceClient Client(string connectionString)
+        public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context)
+        {
+            var existingEntity = new Entity(entityName, id);
+            context.Attach(existingEntity);
+            context.UpdateObject(existingEntity);
+            return existingEntity;
+        }
+
+        public Entity NewEntity(string entityName, OrganizationServiceContext context)
+        {
+            var newEntity = new Entity(entityName);
+            context.AddObject(newEntity);
+            return newEntity;
+        }
+
+        public void SaveChanges(OrganizationServiceContext context)
+        {
+            context.SaveChanges();
+        }
+
+        public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            context.AddLink(source, relationship, target);
+        }
+
+        private OrganizationServiceContext ConstructContext(string connectionString)
+        {
+            return new OrganizationServiceContext(RetrieveClient(connectionString));
+        }
+
+        private CdsServiceClient RetrieveClient(string connectionString)
         {
             if (!_clients.ContainsKey(connectionString))
             {

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
+using System.Linq;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -35,7 +36,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
             OperationId = "UpsertTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" }
         )]
-        [ProducesResponseType(typeof(Candidate), 200)]
+        [ProducesResponseType(204)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         public IActionResult Upsert(
             [FromBody, SwaggerRequestBody("Candidate to upsert for the Teacher Training Adviser service.", Required = true)] Candidate candidate
@@ -46,7 +47,9 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 return BadRequest(this.ModelState);
             }
 
-            return Ok(new Object());
+            _crm.UpsertCandidate(candidate);
+
+            return NoContent();
         }
 
         [HttpPost]
@@ -78,6 +81,9 @@ exchanged for your token matches the request payload here).",
             {
                 return NotFound();
             }
+
+            candidate.Qualifications = _crm.GetCandidateQualifications(candidate).ToList();
+            candidate.PastTeachingPositions = _crm.GetCandidatePastTeachingPositions(candidate).ToList();
 
             return Ok(candidate);
         }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Xrm.Sdk;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -17,14 +18,18 @@ namespace GetIntoTeachingApi.Models
         public DateTime? DateOfBirth { get; set; }
         public string Telephone { get; set; }
         public Address Address { get; set; }
-        public CandidateQualification[] Qualifications { get; set; }
-        public CandidatePastTeachingPosition[] PastTeachingPositions { get; set; }
+        public List<CandidateQualification> Qualifications { get; set; }
+        public List<CandidatePastTeachingPosition> PastTeachingPositions { get; set; }
         [SwaggerSchema("Set to schedule a phone call.", WriteOnly = true)]
-        public DateTime? PhoneCallScheduledStartAt { get; set; }
+        public PhoneCall PhoneCall { get; set; }
         [SwaggerSchema("Set to update the accepted privacy policy.", WriteOnly = true)]
-        public Guid? AcceptedPrivacyPolicyId { get; set; }
+        public CandidatePrivacyPolicy PrivacyPolicy { get; set; }
 
-        public Candidate() { }
+        public Candidate()
+        {
+            Qualifications = new List<CandidateQualification>();
+            PastTeachingPositions = new List<CandidatePastTeachingPosition>();
+        }
 
         public Candidate(Entity entity)
         {
@@ -49,65 +54,35 @@ namespace GetIntoTeachingApi.Models
             };
         }
 
-        public Entity ToEntity()
+        public Entity PopulateEntity(Entity entity)
         {
-            var entity = new Entity("contact");
-
-            if (Id != null) entity.Id = (Guid) Id;
-
             if (PreferredTeachingSubjectId != null)
-            {
-                entity.Attributes.Add("dfe_preferredteachingsubject01",
-                    new EntityReference("dfe_teachingsubjectlist", (Guid) PreferredTeachingSubjectId));
-            }
+                entity["dfe_preferredteachingsubject01"] = new EntityReference("dfe_teachingsubjectlist", (Guid) PreferredTeachingSubjectId);
 
             if (PreferredEducationPhaseId != null)
-            {
-                entity.Attributes.Add("dfe_preferrededucationphase01", new OptionSetValue((int) PreferredEducationPhaseId));
-            }
+                entity["dfe_preferrededucationphase01"] = new OptionSetValue((int) PreferredEducationPhaseId);
 
             if (LocationId != null)
-            {
-                entity.Attributes.Add("dfe_isinuk", new OptionSetValue((int)LocationId));
-            }
+                entity["dfe_isinuk"] = new OptionSetValue((int)LocationId);
 
             if (InitialTeacherTrainingYearId != null)
+                entity["dfe_ittyear"] = new OptionSetValue((int) InitialTeacherTrainingYearId);
+
+            entity["emailaddress1"] = Email;
+            entity["firstname"] = FirstName;
+            entity["lastname"] = LastName;
+            entity["birthdate"] = DateOfBirth;
+            entity["telephone1"] = Telephone;
+
+            if (Address != null)
             {
-                entity.Attributes.Add("dfe_ittyear", new OptionSetValue((int) InitialTeacherTrainingYearId));
+                entity["address1_line1"] = Address.Line1;
+                entity["address1_line2"] = Address.Line2;
+                entity["address1_line3"] = Address.Line3;
+                entity["address1_city"] = Address.City;
+                entity["address1_stateorprovince"] = Address.State;
+                entity["address1_postalcode"] = Address.Postcode;
             }
-
-            entity.Attributes.Add("emailaddress1", Email);
-            entity.Attributes.Add("firstname", FirstName);
-            entity.Attributes.Add("lastname", LastName);
-            entity.Attributes.Add("birthdate", DateOfBirth);
-            entity.Attributes.Add("telephone1", Telephone);
-            entity.Attributes.Add("address1_line1", Address.Line1);
-            entity.Attributes.Add("address1_line2", Address.Line2);
-            entity.Attributes.Add("address1_line3", Address.Line3);
-            entity.Attributes.Add("address1_city", Address.City);
-            entity.Attributes.Add("address1_stateorprovince", Address.State);
-            entity.Attributes.Add("address1_postalcode", Address.Postcode);
-
-            return entity;
-        }
-
-        public Entity ToPhoneCallEntity()
-        {
-            var entity = new Entity("phonecall");
-
-            entity.Attributes.Add("regardingobjectid", new EntityReference("contact", (Guid)Id));
-            entity.Attributes.Add("phonenumber", Telephone);
-            entity.Attributes.Add("scheduledstart", PhoneCallScheduledStartAt);
-
-            return entity;
-        }
-
-        public Entity ToCandidatePrivacyPolicyEntity()
-        {
-            var entity = new Entity("dfe_candidateprivacypolicy");
-
-            entity.Attributes.Add("dfe_candidate", new EntityReference("contact", (Guid)Id));
-            entity.Attributes.Add("dfe_privacypolicynumber", new EntityReference("dfe_privacypolicy", (Guid)AcceptedPrivacyPolicyId));
 
             return entity;
         }

--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -18,22 +18,10 @@ namespace GetIntoTeachingApi.Models
             EducationPhaseId = entity.GetAttributeValue<OptionSetValue>("dfe_educationphase")?.Value;
         }
 
-        public Entity ToEntity()
+        public Entity PopulateEntity(Entity entity)
         {
-            var entity = new Entity("dfe_candidatepastteachingposition");
-
-            if (Id != null) entity.Id = (Guid)Id;
-
-            if (SubjectTaughtId != null)
-            {
-                entity.Attributes.Add("dfe_subjecttaught",
-                    new EntityReference("dfe_teachingsubjectlist", (Guid)SubjectTaughtId));
-            }
-
-            if (EducationPhaseId != null)
-            {
-                entity.Attributes.Add("dfe_educationphase", new OptionSetValue((int)EducationPhaseId));
-            }
+            if (SubjectTaughtId != null) entity["dfe_subjecttaught"] = new EntityReference("dfe_teachingsubjectlist", (Guid)SubjectTaughtId);
+            if (EducationPhaseId != null) entity["dfe_educationphase"] = new OptionSetValue((int)EducationPhaseId);
 
             return entity;
         }

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidatePrivacyPolicy
+    {
+        public Guid AcceptedPolicyId { get; set; }
+
+        public Entity PopulateEntity(Entity entity)
+        {
+            entity["dfe_privacypolicynumber"] = new EntityReference("dfe_privacypolicy", AcceptedPolicyId);
+
+            return entity;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApi.Models
         public int? TypeId { get; set; }
         public int? DegreeStatusId { get; set; }
 
-        public CandidateQualification() {}
+        public CandidateQualification() { }
 
         public CandidateQualification(Entity entity)
         {
@@ -20,14 +20,11 @@ namespace GetIntoTeachingApi.Models
             DegreeStatusId = entity.GetAttributeValue<OptionSetValue>("dfe_degreestatus")?.Value;
         }
 
-        public Entity ToEntity()
+        public Entity PopulateEntity(Entity entity)
         {
-            var entity = new Entity("dfe_candidatequalification");
-
-            if (Id != null) entity.Id = (Guid)Id;
-            if (CategoryId != null) entity.Attributes.Add("dfe_category", new OptionSetValue((int)CategoryId));
-            if (TypeId != null) entity.Attributes.Add("dfe_type", new OptionSetValue((int)TypeId));
-            if (DegreeStatusId != null) entity.Attributes.Add("dfe_degreestatus", new OptionSetValue((int)DegreeStatusId));
+            if (CategoryId != null) entity["dfe_category"] = new OptionSetValue((int)CategoryId);
+            if (TypeId != null) entity["dfe_type"] = new OptionSetValue((int)TypeId);
+            if (DegreeStatusId != null) entity["dfe_degreestatus"] = new OptionSetValue((int)DegreeStatusId);
 
             return entity;
         }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class PhoneCall
+    {
+        public DateTime ScheduledAt { get; set; }
+
+        public Entity PopulateEntity(Entity entity, string telephone)
+        {
+            entity["phonenumber"] = telephone;
+            entity["scheduledstart"] = ScheduledAt;
+
+            return entity;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
@@ -22,12 +22,12 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be a valid teaching subject.");
         }
 
-        public IEnumerable<Guid?> TeachingSubjectIds()
+        private IEnumerable<Guid?> TeachingSubjectIds()
         {
             return _crm.GetLookupItems("dfe_teachingsubjectlist").Select(subject => (Guid?)subject.Id);
         }
 
-        public IEnumerable<int?> EducationPhaseIds()
+        private IEnumerable<int?> EducationPhaseIds()
         {
             return _crm.
                 GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase")

--- a/GetIntoTeachingApi/Models/Validators/CandidatePrivacyPolicyValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidatePrivacyPolicyValidator.cs
@@ -1,0 +1,27 @@
+﻿using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class CandidatePrivacyPolicyValidator : AbstractValidator<CandidatePrivacyPolicy>
+    {
+        private readonly ICrmService _crm;
+
+        public CandidatePrivacyPolicyValidator(ICrmService crm)
+        {
+            _crm = crm;
+
+            RuleFor(privacyPolicy => privacyPolicy.AcceptedPolicyId)
+                .Must(id => PrivacyPolicyIds().Contains(id))
+                .WithMessage("Must be a valid privacy policy.");
+        }
+
+        private IEnumerable<Guid?> PrivacyPolicyIds()
+        {
+            return _crm.GetPrivacyPolicies().Select(policy => (Guid?)policy.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
@@ -26,17 +26,17 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be a valid qualification degree status.");
         }
 
-        public IEnumerable<int?> CategoryIds()
+        private IEnumerable<int?> CategoryIds()
         {
             return _crm.GetPickListItems("dfe_qualification", "dfe_category").Select(category => (int?)category.Id);
         }
 
-        public IEnumerable<int?> TypeIds()
+        private IEnumerable<int?> TypeIds()
         {
             return _crm.GetPickListItems("dfe_qualification", "dfe_type").Select(type => (int?)type.Id);
         }
 
-        public IEnumerable<int?> StatusIds()
+        private IEnumerable<int?> StatusIds()
         {
             return _crm.GetPickListItems("dfe_qualification", "dfe_degreestatus").Select(status => (int?)status.Id);
         }

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -19,17 +19,14 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress().MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).NotNull().LessThan(candidate => DateTime.Now);
             RuleFor(candidate => candidate.Telephone).NotEmpty().MaximumLength(50);
-            RuleFor(candidate => candidate.PhoneCallScheduledStartAt).NotNull().GreaterThan(candidate => DateTime.Now);
 
-            RuleFor(candidate => candidate.Address)
-                .SetValidator(new AddressValidator())
-                .Unless(candidate => candidate.Address == null);
+            RuleFor(candidate => candidate.Address).SetValidator(new AddressValidator()).Unless(candidate => candidate.Address == null);
+            RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator()).Unless(candidate => candidate.PhoneCall == null);
+            RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(crm)).Unless(candidate => candidate.PrivacyPolicy == null);
+            RuleFor(candidate => candidate.Address).SetValidator(new AddressValidator()).Unless(candidate => candidate.Address == null);
             RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(crm));
             RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(crm));
 
-            RuleFor(candidate => candidate.AcceptedPrivacyPolicyId)
-                .Must(id => PrivacyPolicyIds().Contains(id))
-                .WithMessage("Must be a valid privacy policy.");
             RuleFor(candidate => candidate.PreferredTeachingSubjectId)
                 .Must(id => PreferredTeachingSubjectIds().Contains(id))
                 .Unless(candidate => candidate.PreferredTeachingSubjectId == null)
@@ -48,27 +45,22 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be a valid candidate initial teacher training year.");
         }
 
-        public IEnumerable<Guid?> PreferredTeachingSubjectIds()
+        private IEnumerable<Guid?> PreferredTeachingSubjectIds()
         {
             return _crm.GetLookupItems("dfe_teachingsubjectlist").Select(subject => (Guid?)subject.Id);
         }
 
-        public IEnumerable<Guid?> PrivacyPolicyIds()
-        {
-            return _crm.GetPrivacyPolicies().Select(policy => (Guid?)policy.Id);
-        }
-
-        public IEnumerable<int?> PreferredEducationPhaseIds()
+        private IEnumerable<int?> PreferredEducationPhaseIds()
         {
             return _crm.GetPickListItems("contact", "dfe_preferrededucationphase01").Select(phase => (int?)phase.Id);
         }
 
-        public IEnumerable<int?> LocationIds()
+        private IEnumerable<int?> LocationIds()
         {
             return _crm.GetPickListItems("contact", "dfe_isinuk").Select(location => (int?)location.Id);
         }
 
-        public IEnumerable<int?> InitialTeacherTrainingYearIds()
+        private IEnumerable<int?> InitialTeacherTrainingYearIds()
         {
             return _crm.GetPickListItems("contact", "dfe_ittyear").Select(year => (int?)year.Id);
         }

--- a/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+using System;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class PhoneCallValidator : AbstractValidator<PhoneCall>
+    {
+        public PhoneCallValidator()
+        {
+            RuleFor(phoneCall => phoneCall.ScheduledAt).GreaterThan(candidate => DateTime.Now);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -10,5 +10,8 @@ namespace GetIntoTeachingApi.Services
         public PrivacyPolicy GetLatestPrivacyPolicy();
         public IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         public Candidate GetCandidate(ExistingCandidateRequest request);
+        public IEnumerable<CandidateQualification> GetCandidateQualifications(Candidate candidate);
+        public IEnumerable<CandidatePastTeachingPosition> GetCandidatePastTeachingPositions(Candidate candidate);
+        public void UpsertCandidate(Candidate candidate);
     }
 }

--- a/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
@@ -10,13 +10,12 @@ namespace GetIntoTeachingApiTests.Auth
     public class SharedSecretHandlerTests
     {
         private readonly SharedSecretHandler _handler;
-        private readonly Mock<IHttpContextAccessor> _mockHttpHandler;
 
         public SharedSecretHandlerTests()
         {
-            _mockHttpHandler = new Mock<IHttpContextAccessor>();
-            _mockHttpHandler.Setup(mock => mock.HttpContext.Request.Headers["Authorization"]).Returns("Bearer shared_secret");
-            _handler = new SharedSecretHandler(_mockHttpHandler.Object);
+            var mockHttpHandler = new Mock<IHttpContextAccessor>();
+            mockHttpHandler.Setup(mock => mock.HttpContext.Request.Headers["Authorization"]).Returns("Bearer shared_secret");
+            _handler = new SharedSecretHandler(mockHttpHandler.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
@@ -13,36 +13,32 @@ namespace GetIntoTeachingApiTests.Models
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
-            entity.Attributes["dfe_subjecttaught"] = new EntityReference("dfe_teachingsubjectlist", Guid.NewGuid());
-            entity.Attributes["dfe_educationphase"] = new OptionSetValue { Value = 1 };
+            entity["dfe_subjecttaught"] = new EntityReference("dfe_teachingsubjectlist", Guid.NewGuid());
+            entity["dfe_educationphase"] = new OptionSetValue { Value = 1 };
 
-            var teachingPosition = new CandidatePastTeachingPosition(entity);
+            var position = new CandidatePastTeachingPosition(entity);
 
-            teachingPosition.Id.Should().Be(entity.Id);
-            teachingPosition.SubjectTaughtId.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id);
-            teachingPosition.EducationPhaseId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value);
+            position.Id.Should().Be(entity.Id);
+            position.SubjectTaughtId.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id);
+            position.EducationPhaseId.Should().Be(entity.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value);
         }
 
         [Fact]
-        public void ToEntity_ReverseMapsCorrectly()
+        public void PopulateEntity_ReverseMapsCorrectly()
         {
-            var teachingPosition = new CandidatePastTeachingPosition()
+            var position = new CandidatePastTeachingPosition()
             {
                 Id = Guid.NewGuid(),
                 SubjectTaughtId = Guid.NewGuid(),
                 EducationPhaseId = 1,
             };
 
-            var entity = teachingPosition.ToEntity();
+            var entity = new Entity("dfe_candidatepastteachingposition", (Guid) position.Id);
+            position.PopulateEntity(entity);
 
-            entity.LogicalName.Should().Be("dfe_candidatepastteachingposition");
-            entity.Id.Should().Be((Guid)teachingPosition.Id);
-            entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id.Should()
-                .Be((Guid)teachingPosition.SubjectTaughtId);
-            entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").LogicalName.Should()
-                .Be("dfe_teachingsubjectlist");
-            entity.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value.Should()
-                .Be(teachingPosition.EducationPhaseId);
+            entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").Id.Should().Be((Guid)position.SubjectTaughtId);
+            entity.GetAttributeValue<EntityReference>("dfe_subjecttaught").LogicalName.Should().Be("dfe_teachingsubjectlist");
+            entity.GetAttributeValue<OptionSetValue>("dfe_educationphase").Value.Should().Be(position.EducationPhaseId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidatePrivacyPolicyTests
+    {
+        [Fact]
+        public void PopulateEntity_ReverseMapsCorrectly()
+        {
+            var privacyPolicy = new CandidatePrivacyPolicy()
+            {
+                AcceptedPolicyId = Guid.NewGuid(),
+            };
+
+            var entity = new Entity("dfe_candidateprivacypolicy");
+            privacyPolicy.PopulateEntity(entity);
+
+            entity.GetAttributeValue<EntityReference>("dfe_privacypolicynumber").Id.Should()
+                .Be((Guid)privacyPolicy.AcceptedPolicyId);
+            entity.GetAttributeValue<EntityReference>("dfe_privacypolicynumber").LogicalName.Should()
+                .Be("dfe_privacypolicy");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
@@ -13,9 +13,9 @@ namespace GetIntoTeachingApiTests.Models
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
-            entity.Attributes["dfe_category"] = new OptionSetValue { Value = 1 };
-            entity.Attributes["dfe_type"] = new OptionSetValue { Value = 2 };
-            entity.Attributes["dfe_degreestatus"] = new OptionSetValue { Value = 3 };
+            entity["dfe_category"] = new OptionSetValue { Value = 1 };
+            entity["dfe_type"] = new OptionSetValue { Value = 2 };
+            entity["dfe_degreestatus"] = new OptionSetValue { Value = 3 };
 
             var qualification = new CandidateQualification(entity);
 
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void ToEntity_ReverseMapsCorrectly()
+        public void PopulateEntity_ReverseMapsCorrectly()
         {
             var qualification = new CandidateQualification()
             {
@@ -36,10 +36,9 @@ namespace GetIntoTeachingApiTests.Models
                 DegreeStatusId = 3,
             };
 
-            var entity = qualification.ToEntity();
+            var entity = new Entity("dfe_candidatequalification", (Guid) qualification.Id);
+            qualification.PopulateEntity(entity);
 
-            entity.LogicalName.Should().Be("dfe_candidatequalification");
-            entity.Id.Should().Be((Guid)qualification.Id);
             entity.GetAttributeValue<OptionSetValue>("dfe_category").Value.Should().Be(qualification.CategoryId);
             entity.GetAttributeValue<OptionSetValue>("dfe_type").Value.Should().Be(qualification.TypeId);
             entity.GetAttributeValue<OptionSetValue>("dfe_degreestatus").Value.Should().Be(qualification.DegreeStatusId);

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -13,20 +13,20 @@ namespace GetIntoTeachingApiTests.Models
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
-            entity.Attributes["dfe_preferredteachingsubject01"] = new EntityReference { Id = Guid.NewGuid() };
-            entity.Attributes["dfe_preferrededucationphase01"] = new OptionSetValue { Value = 1 };
-            entity.Attributes["dfe_isinuk"] = new OptionSetValue { Value = 2 };
-            entity.Attributes["dfe_ittyear"] = new OptionSetValue { Value = 3 };
-            entity.Attributes["emailaddress1"] = "email@address.com";
-            entity.Attributes["firstname"] = "first";
-            entity.Attributes["lastname"] = "last";
-            entity.Attributes["birthdate"] = new DateTime(1967, 3, 10);
-            entity.Attributes["address1_line1"] = "line1";
-            entity.Attributes["address1_line2"] = "line2";
-            entity.Attributes["address1_line3"] = "line3";
-            entity.Attributes["address1_stateorprovince"] = "state";
-            entity.Attributes["address1_postalcode"] = "postcode";
-            entity.Attributes["telephone1"] = "07564 374 624";
+            entity["dfe_preferredteachingsubject01"] = new EntityReference { Id = Guid.NewGuid() };
+            entity["dfe_preferrededucationphase01"] = new OptionSetValue { Value = 1 };
+            entity["dfe_isinuk"] = new OptionSetValue { Value = 2 };
+            entity["dfe_ittyear"] = new OptionSetValue { Value = 3 };
+            entity["emailaddress1"] = "email@address.com";
+            entity["firstname"] = "first";
+            entity["lastname"] = "last";
+            entity["birthdate"] = new DateTime(1967, 3, 10);
+            entity["address1_line1"] = "line1";
+            entity["address1_line2"] = "line2";
+            entity["address1_line3"] = "line3";
+            entity["address1_stateorprovince"] = "state";
+            entity["address1_postalcode"] = "postcode";
+            entity["telephone1"] = "07564 374 624";
 
             var candidate = new Candidate(entity);
 
@@ -73,10 +73,9 @@ namespace GetIntoTeachingApiTests.Models
                 Telephone = "07584 275 483"
             };
 
-            var entity = candidate.ToEntity();
+            var entity = new Entity("contact", (Guid) candidate.Id);
+            candidate.PopulateEntity(entity);
 
-            entity.LogicalName.Should().Be("contact");
-            entity.Id.Should().Be((Guid)candidate.Id);
             entity.GetAttributeValue<EntityReference>("dfe_preferredteachingsubject01").Id.Should()
                 .Be((Guid)candidate.PreferredTeachingSubjectId);
             entity.GetAttributeValue<EntityReference>("dfe_preferredteachingsubject01").LogicalName.Should()
@@ -97,49 +96,6 @@ namespace GetIntoTeachingApiTests.Models
             entity.GetAttributeValue<string>("address1_stateorprovince").Should().Be(candidate.Address.State);
             entity.GetAttributeValue<string>("address1_postalcode").Should().Be(candidate.Address.Postcode);
             entity.GetAttributeValue<string>("telephone1").Should().Be(candidate.Telephone);
-        }
-
-        [Fact]
-        public void ToPhoneCallEntity_ReverseMapsCorrectly()
-        {
-            var candidate = new Candidate()
-            {
-                Id = Guid.NewGuid(),
-                Telephone = "07594 835 274",
-                PhoneCallScheduledStartAt = new DateTime(2021, 2, 13, 10, 34, 12),
-            };
-
-            var entity = candidate.ToPhoneCallEntity();
-
-            entity.LogicalName.Should().Be("phonecall");
-            entity.GetAttributeValue<string>("phonenumber").Should().Be(candidate.Telephone);
-            entity.GetAttributeValue<DateTime?>("scheduledstart").Should().Be(candidate.PhoneCallScheduledStartAt);
-            entity.GetAttributeValue<EntityReference>("regardingobjectid").Id.Should()
-                .Be((Guid)candidate.Id);
-            entity.GetAttributeValue<EntityReference>("regardingobjectid").LogicalName.Should()
-                .Be("contact");
-        }
-
-        [Fact]
-        public void ToCandidatePrivacyPolicyEntity_ReverseMapsCorrectly()
-        {
-            var candidate = new Candidate()
-            {
-                Id = Guid.NewGuid(),
-                AcceptedPrivacyPolicyId = Guid.NewGuid(),
-            };
-
-            var entity = candidate.ToCandidatePrivacyPolicyEntity();
-
-            entity.LogicalName.Should().Be("dfe_candidateprivacypolicy");
-            entity.GetAttributeValue<EntityReference>("dfe_candidate").Id.Should()
-                .Be((Guid)candidate.Id);
-            entity.GetAttributeValue<EntityReference>("dfe_candidate").LogicalName.Should()
-                .Be("contact");
-            entity.GetAttributeValue<EntityReference>("dfe_privacypolicynumber").Id.Should()
-                .Be((Guid)candidate.AcceptedPrivacyPolicyId);
-            entity.GetAttributeValue<EntityReference>("dfe_privacypolicynumber").LogicalName.Should()
-                .Be("dfe_privacypolicy");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class PhoneCallTests
+    {
+        [Fact]
+        public void PopulateEntity_ReverseMapsCorrectly()
+        {
+            var phoneCall = new PhoneCall() { ScheduledAt = new DateTime(2021, 2, 13, 10, 34, 12) };
+            const string telephone = "07594 835 274";
+            var entity = new Entity("phonecall");
+            phoneCall.PopulateEntity(entity, telephone);
+
+            entity.GetAttributeValue<string>("phonenumber").Should().Be(telephone);
+            entity.GetAttributeValue<DateTime?>("scheduledstart").Should().Be(phoneCall.ScheduledAt);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/PrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/PrivacyPolicyTests.cs
@@ -13,7 +13,7 @@ namespace GetIntoTeachingApiTests.Models
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
-            entity.Attributes["dfe_details"] = "text";
+            entity["dfe_details"] = "text";
 
             var privacyPolicy = new PrivacyPolicy(entity);
 

--- a/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
+++ b/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApiTests.Models
         {
             var entity = new Entity();
             entity.Id = Guid.NewGuid();
-            entity.Attributes["dfe_name"] = "name";
+            entity["dfe_name"] = "name";
 
             var typeEntity = new TypeEntity(entity);
 

--- a/GetIntoTeachingApiTests/Models/Validators/CandidatePrivacyPolicyValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidatePrivacyPolicyValidatorTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class CandidatePrivacyPolicyValidatorTests
+    {
+        private readonly CandidatePrivacyPolicyValidator _validator;
+        private readonly Mock<ICrmService> _mockCrm;
+
+        public CandidatePrivacyPolicyValidatorTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _validator = new CandidatePrivacyPolicyValidator(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+
+            _mockCrm
+                .Setup(mock => mock.GetPrivacyPolicies())
+                .Returns(new[] { mockPrivacyPolicy });
+
+            var policy = new CandidatePrivacyPolicy()
+            {
+                AcceptedPolicyId = mockPrivacyPolicy.Id,
+            };
+
+            var result = _validator.TestValidate(policy);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_AcceptedPolicyIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(policy => policy.AcceptedPolicyId, Guid.NewGuid());
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class PhoneCallValidatorTests
+    {
+        private readonly PhoneCallValidator _validator;
+
+        public PhoneCallValidatorTests()
+        {
+            _validator = new PhoneCallValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var phoneCall = new PhoneCall()
+            {
+                ScheduledAt = DateTime.Now.AddDays(2),
+            };
+
+            var result = _validator.TestValidate(phoneCall);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_ScheduledAtInPast_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ScheduledAt, DateTime.Now.AddDays(-1));
+        }
+    }
+}


### PR DESCRIPTION
The general process for upserting an model to the CRM is:

- Create a blank `Entity` in an OrganizationalServiceContext (set `Id` if updating)
- Get the model to populate the fields of the `Entity`
- Configure any relationships between the entities being upserted
- Save the context (upserting in a single transaction)

`IOrganizationServiceAdapter` is used to abstract the interactions with the context so that we can mock out the process in unit tests.

`204` is returned from the controller action to update a candidate as the operation will end up in a background job.

`PhoneCall`/`CandidatePrivacyPolicy` have been pulled out into their own models for consistency.

A privacy policy is only accepted again if it hasn't already been accepted by the candidate previously.