### PR TITLE
Add in-memory cache for CrmService

### DIFF
--- a/GetIntoTeachingApi/Services/CrmCache.cs
+++ b/GetIntoTeachingApi/Services/CrmCache.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CrmCache : ICrmCache
+    {
+        private readonly IDictionary<string, CacheEntry> _store;
+        private readonly ILogger<CrmCache> _logger;
+
+        public CrmCache(ILogger<CrmCache> logger)
+        {
+            _store = new Dictionary<string, CacheEntry>();
+            _logger = logger;
+        }
+
+        public TItem GetOrCreate<TItem>(string key, DateTime expiresAt, Func<TItem> create)
+        {
+            CreateEntryIfNew(key, expiresAt, create);
+            RefreshEntryIfExpired(key, expiresAt, create);
+
+            return (TItem) _store[key].Entry;
+        }
+
+        private void CreateEntryIfNew<TItem>(string key, DateTime expiresAt, Func<TItem> create)
+        {
+            if (_store.ContainsKey(key)) return;
+            
+            _store[key] = new CacheEntry(create(), expiresAt);
+        }
+
+        private void RefreshEntryIfExpired<TItem>(string key, DateTime expiresAt, Func<TItem> create)
+        {
+            if (!_store.ContainsKey(key) || !_store[key].Expired()) return;
+
+            try
+            {
+                _store[key] = new CacheEntry(create(), expiresAt);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning($"CrmCache - Failed to refresh cache ({key}): {e.Message}");
+            }
+        }
+    }
+
+    internal class CacheEntry
+    {
+        public DateTime ExpiresAt { get; set; }
+        public object Entry { get; set; }
+
+        public CacheEntry(object entry, DateTime expiresAt)
+        {
+            Entry = entry;
+            ExpiresAt = expiresAt;
+        }
+
+        public bool Expired()
+        {
+            return DateTime.Now > ExpiresAt;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICrmCache.cs
+++ b/GetIntoTeachingApi/Services/ICrmCache.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICrmCache
+    {
+        TItem GetOrCreate<TItem>(string key, DateTime expiresAt, Func<TItem> create);
+    }
+}

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -25,7 +25,8 @@ namespace GetIntoTeachingApi.Services
                 email,
                 templateId,
                 personalisation
-            ).ContinueWith(task => _logger.LogWarning(task.Exception?.Message), TaskContinuationOptions.OnlyOnFaulted);
+            ).ContinueWith(task => _logger.LogWarning($"NotifyService - Failed to send email: {task.Exception?.Message}"), 
+                TaskContinuationOptions.OnlyOnFaulted);
         }
 
         private static string ApiKey()

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -34,6 +34,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
             services.AddSingleton<ICrmService, CrmService>();
             services.AddSingleton<INotifyService, NotifyService>();
+            services.AddSingleton<ICrmCache, CrmCache>();
 
             services.AddAuthorization(options =>
             {

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -43,11 +43,13 @@ namespace GetIntoTeachingApiTests.Models
     public class BaseModelTests
     {
         private readonly Mock<IOrganizationServiceAdapter> _mockService;
+        private readonly Mock<ICrmCache> _mockCrmCache;
         private readonly OrganizationServiceContext _context;
 
         public BaseModelTests()
         {
             _mockService = new Mock<IOrganizationServiceAdapter>();
+            _mockCrmCache = new Mock<ICrmCache>();
             _context = _mockService.Object.Context("mock-connection-string");
         }
 
@@ -70,7 +72,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockService.Setup(m => m.RelatedEntities(entity, "dfe_mock_dfe_relatedmock_mocks"))
                 .Returns(new List<Entity> { relatedEntity2 });
 
-            var mock = new MockModel(entity, new CrmService(_mockService.Object));
+            var mock = new MockModel(entity, new CrmService(_mockService.Object, _mockCrmCache.Object));
 
             mock.Id.Should().Be(entity.Id);
             mock.Field1.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_field1").Id);
@@ -92,7 +94,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockService.Setup(m => m.RelatedEntities(entity, "dfe_mock_dfe_relatedmock_mock")).Returns(new List<Entity>());
             _mockService.Setup(m => m.RelatedEntities(entity, "dfe_mock_dfe_relatedmock_mocks")).Returns(new List<Entity>());
 
-            var mock = new MockModel(entity, new CrmService(_mockService.Object));
+            var mock = new MockModel(entity, new CrmService(_mockService.Object, _mockCrmCache.Object));
 
             mock.Id.Should().Be(entity.Id);
             mock.Field1.Should().Be(entity.GetAttributeValue<EntityReference>("dfe_field1").Id);
@@ -126,7 +128,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockService.Setup(m => m.BlankExistingEntity("relatedMock", 
                 (Guid)mock.RelatedMocks.First().Id, _context)).Returns(relatedMockEntity);
 
-            mock.ToEntity(new CrmService(_mockService.Object), _context);
+            mock.ToEntity(new CrmService(_mockService.Object, _mockCrmCache.Object), _context);
 
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").Id.Should().Be((Guid)mock.Field1);
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").LogicalName.Should().Be("dfe_list");
@@ -157,7 +159,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockService.Setup(m => m.NewEntity("mock", _context)).Returns(mockEntity);
             _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns(relatedMockEntity);
 
-            mock.ToEntity(new CrmService(_mockService.Object), _context);
+            mock.ToEntity(new CrmService(_mockService.Object, _mockCrmCache.Object), _context);
 
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").Id.Should().Be((Guid)mock.Field1);
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").LogicalName.Should().Be("dfe_list");
@@ -189,7 +191,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockService.Setup(m => m.BlankExistingEntity("mock", mockEntity.Id, _context)).Returns(mockEntity);
             _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns(relatedMockEntity);
 
-            mock.ToEntity(new CrmService(_mockService.Object), _context);
+            mock.ToEntity(new CrmService(_mockService.Object, _mockCrmCache.Object), _context);
 
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").Id.Should().Be((Guid)mock.Field1);
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").LogicalName.Should().Be("dfe_list");

--- a/GetIntoTeachingApiTests/Services/CrmCacheTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmCacheTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Utils;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class CrmCacheTests
+    {
+        private readonly Mock<ILogger<CrmCache>> _mockLogger;
+        private readonly CrmCache _cache;
+
+        public CrmCacheTests()
+        {
+            _mockLogger = new Mock<ILogger<CrmCache>>();
+            _cache = new CrmCache(_mockLogger.Object);
+        }
+
+        [Fact]
+        public void GetOrCreate_WhenStoreIsEmpty_Creates()
+        {
+            var result = _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () => "value");
+
+            result.Should().Be("value");
+        }
+
+        [Fact]
+        public void GetOrCreate_WhenEntryExpired_Refreshes()
+        {
+            _cache.GetOrCreate("key", DateTime.Now.AddSeconds(-30), () => "value");
+
+            var result = _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () => "new-value");
+
+            result.Should().Be("new-value");
+        }
+
+        [Fact]
+        public void GetOrCreate_WhenEntryFresh_Gets()
+        {
+            _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () => "value");
+
+            var result = _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () => "new-value");
+
+            result.Should().Be("value");
+        }
+
+        [Fact]
+        public void GetOrCreate_WhenRefreshFails_ReturnsStaleData()
+        {
+            _cache.GetOrCreate("key", DateTime.Now.AddSeconds(-30), () => "value");
+
+            var result = _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () =>
+            { 
+                throw new Exception("bang");
+                return "";
+            });
+
+            result.Should().Be("value");
+            _mockLogger.VerifyWarningWasCalled("CrmCache - Failed to refresh cache (key): bang");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
@@ -58,11 +58,11 @@ namespace GetIntoTeachingApiTests.Services
                     NotifyService.NewPinCodeEmailTemplateId, 
                     _personalisation
                 )
-            ).ThrowsAsync(new Exception("Unable to send email!"));
+            ).ThrowsAsync(new Exception("bang"));
 
             _service.SendEmail("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation);
 
-            _mockLogger.VerifyWarningWasCalled("Unable to send email!");
+            _mockLogger.VerifyWarningWasCalled("NotifyService - Failed to send email");
         }
     }
 }


### PR DESCRIPTION
The in-memory cache will store responses from the CRM that are used in validation logic, so that we can still accept requests from a client when the CRM is offline. This covers:

- Lookup items
- PickList items
- Privacy policy entities

The cache will be refreshed every 3 hours, however if the CRM is offline when a refresh is attempted the stale data will remain available in the cache so that the API can continue to function.

As this cache is in-memory, if the API server restarts when the CRM is offline it will not be able to function until the CRM comes back online. We expect the chance of this happening to be slim and will monitor our logs to see if it is worth the effort of implementing a persistent cache.