### PR TITLE
Add upcoming events endpoint

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -147,5 +147,19 @@ namespace GetIntoTeachingApi.Controllers
             var educationPhases = _crm.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase");
             return Ok(educationPhases);
         }
+
+        [HttpGet]
+        [Route("teaching_event/types")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of teaching event types.",
+            OperationId = "GetTeachingEventTypes",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetTeachingEventTypes()
+        {
+            var eventTypes = _crm.GetPickListItems("msevtmgt_event", "dfe_event_type");
+            return Ok(eventTypes);
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    [Entity(LogicalName = "msevtmgt_event")]
+    public class TeachingEvent : BaseModel
+    {
+        [EntityField(Name = "dfe_event_type", Type = typeof(OptionSetValue))]
+        public int TypeId { get; set; }
+        [EntityField(Name = "msevtmgt_name")]
+        public string Name { get; set; }
+        [EntityField(Name = "msevtmgt_description")]
+        public string Description { get; set; }
+        [EntityField(Name = "msevtmgt_eventstartdate")]
+        public DateTime StartAt { get; set; }
+        [EntityField(Name = "msevtmgt_eventenddate")]
+        public DateTime EndAt { get; set; }
+
+        public TeachingEvent() : base() { }
+
+        public TeachingEvent(Entity entity, ICrmService crm) : base(entity, crm) { }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Services
         public PrivacyPolicy GetLatestPrivacyPolicy();
         public IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         public Candidate GetCandidate(ExistingCandidateRequest request);
+        public IEnumerable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
         public bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         public void Save(BaseModel model);
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -138,6 +138,18 @@ namespace GetIntoTeachingApiTests.Controllers
             ok.Value.Should().Be(mockEntities);
         }
 
+        [Fact]
+        public void GetTeachingEventTypes_ReturnsAllTypes()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockCrm.Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_event_type")).Returns(mockEntities);
+
+            var response = _controller.GetTeachingEventTypes();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
         private static IEnumerable<TypeEntity> MockTypeEntities()
         {
             return new []

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class TeachingEventTests
+    {
+        [Fact]
+        public void EntityAttributes()
+        {
+            var type = typeof(TeachingEvent);
+
+            type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_event");
+
+            type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_event_type" && a.Type == typeof(OptionSetValue));
+
+            type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
+            type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
+            type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventstartdate");
+            type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventenddate");
+        }
+    }
+}


### PR DESCRIPTION
- Add endpoint to retrieve teaching event types
- Add initial `TeachingEvent` model
- Add `UpcomingTeachingEvents` to `CrmService`
- Plumb in upcoming teaching events endpoint to `CrmService`

All events are currently loaded into the in-memory cache, however it is TBC if events need to be available whilst the CRM is offline.