### PR TITLE
Suppress unreachable code warning

### DIFF
--- a/GetIntoTeachingApiTests/Services/CrmCacheTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmCacheTests.cs
@@ -55,7 +55,9 @@ namespace GetIntoTeachingApiTests.Services
             var result = _cache.GetOrCreate("key", DateTime.Now.AddSeconds(30), () =>
             { 
                 throw new Exception("bang");
+                #pragma warning disable 0162
                 return "";
+                #pragma warning restore 0162
             });
 
             result.Should().Be("value");


### PR DESCRIPTION
We are testing that a functional parameter throws an exception; the function requires a string return type but it will never be reached as we always throw the exception. This commit suppresses the build warning about unreachable code.