### PR TITLE
Add ability to register attendee for events

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -48,15 +48,11 @@ that can then be used for verification.",
         public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
             if (!ModelState.IsValid)
-            {
                 return BadRequest(this.ModelState);
-            }
 
             var candidate = _crm.GetCandidate(request);
             if (candidate == null)
-            {
                 return NotFound();
-            }
 
             var token = _tokenService.GenerateToken(request);
             var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -32,9 +32,7 @@ namespace GetIntoTeachingApi.Controllers
         public IActionResult AddMember([FromBody, SwaggerRequestBody("Member to add to the mailing list.", Required = true)] ExistingCandidateRequest member)
         {
             if (!ModelState.IsValid)
-            {
                 return BadRequest(this.ModelState);
-            }
 
             // TODO:
             return Ok(new Object());

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
-using System.Linq;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -43,9 +41,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         )
         {
             if (!ModelState.IsValid)
-            {
                 return BadRequest(this.ModelState);
-            }
 
             _crm.Save(candidate);
 
@@ -71,16 +67,12 @@ exchanged for your token matches the request payload here).",
         )
         { 
             if (!_tokenService.IsValid(accessToken, request))
-            {
                 return Unauthorized();
-            }
 
             var candidate = _crm.GetCandidate(request);
 
             if (candidate == null)
-            {
                 return NotFound();
-            }
 
             return Ok(candidate);
         }

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -90,7 +90,7 @@ maximum of 50 using the `limit` query parameter.",
             OperationId = "AddTeachingEventAttendee",
             Tags = new[] { "Teaching Events" }
         )]
-        [ProducesResponseType(typeof(TeachingEvent), 200)]
+        [ProducesResponseType(204)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         [ProducesResponseType(404)]
         public IActionResult AddAttendee(
@@ -107,8 +107,15 @@ maximum of 50 using the `limit` query parameter.",
             if (teachingEvent == null || candidate == null)
                 return NotFound();
 
-            // TODO:
-            return Ok(new Object());
+            var registration = new TeachingEventRegistration()
+            {
+                CandidateId = (Guid) candidate.Id, 
+                EventId = (Guid) teachingEvent.Id
+            };
+
+            _crm.Save(registration);
+
+            return NoContent();
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -58,9 +58,7 @@ maximum of 50 using the `limit` query parameter.",
         public IActionResult Search([FromQuery, SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request)
         {
             if (!ModelState.IsValid)
-            {
                 return BadRequest(this.ModelState);
-            }
 
             var teachingEvents = _crm.SearchTeachingEvents(request);
             return Ok(teachingEvents);
@@ -96,14 +94,18 @@ maximum of 50 using the `limit` query parameter.",
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         [ProducesResponseType(404)]
         public IActionResult AddAttendee(
-            [FromRoute, SwaggerParameter("The `id` of the `TeachingEvent`.", Required = true)] string id,
+            [FromRoute, SwaggerParameter("The `id` of the `TeachingEvent`.", Required = true)] Guid id,
             [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] ExistingCandidateRequest attendee
         )
         {
             if (!ModelState.IsValid)
-            {
                 return BadRequest(this.ModelState);
-            }
+
+            var teachingEvent = _crm.GetTeachingEvent(id);
+            var candidate = _crm.GetCandidate(attendee);
+
+            if (teachingEvent == null || candidate == null)
+                return NotFound();
 
             // TODO:
             return Ok(new Object());

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -25,6 +25,8 @@ namespace GetIntoTeachingApi.Models
 
         public virtual Entity ToEntity(ICrmService crm, OrganizationServiceContext context)
         {
+            if (!ShouldMap(crm)) return null;
+
             var entity = crm.MappableEntity(LogicalName(), Id, context);
             MapFieldAttributesToEntity(entity);
             MapRelationshipAttributesToEntity(entity, crm, context);
@@ -41,6 +43,12 @@ namespace GetIntoTeachingApi.Models
         }
 
         protected virtual bool ShouldMapRelationship(string propertyName, dynamic value, ICrmService crm)
+        {
+            // Hook.
+            return true;
+        }
+
+        protected virtual bool ShouldMap(ICrmService crm)
         {
             // Hook.
             return true;

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    [Entity(LogicalName = "msevtmgt_eventregistration")]
+    public class TeachingEventRegistration : BaseModel
+    {
+        [EntityField(Name = "msevtmgt_contactid", Type = typeof(EntityReference))]
+        public Guid CandidateId { get; set; }
+        [EntityField(Name = "msevtmgt_eventid", Type = typeof(EntityReference))]
+        public Guid EventId { get; set; }
+
+        public TeachingEventRegistration() : base() { }
+
+        public TeachingEventRegistration(Entity entity, ICrmService crm) : base(entity, crm) { }
+
+        protected override bool ShouldMap(ICrmService crm)
+        {
+            return crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -5,7 +5,6 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
-using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 
 namespace GetIntoTeachingApi.Services
@@ -108,6 +107,13 @@ namespace GetIntoTeachingApi.Services
             return _service.CreateQuery("dfe_candidateprivacypolicy", Context()).FirstOrDefault(entity => 
                 entity.GetAttributeValue<EntityReference>("dfe_candidate").Id == candidateId && 
                 entity.GetAttributeValue<EntityReference>("dfe_privacypolicynumber").Id == privacyPolicyId) == null;
+        }
+
+        public bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId)
+        {
+            return _service.CreateQuery("msevtmgt_eventregistration", Context()).FirstOrDefault(entity =>
+                entity.GetAttributeValue<EntityReference>("msevtmgt_contactid").Id == candidateId &&
+                entity.GetAttributeValue<EntityReference>("msevtmgt_eventid").Id == teachingEventId) == null;
         }
 
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -17,6 +17,7 @@ namespace GetIntoTeachingApi.Services
         public IEnumerable<TeachingEvent> SearchTeachingEvents(TeachingEventSearchRequest request);
         public TeachingEvent GetTeachingEvent(Guid id);
         public bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
+        public bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         public void Save(BaseModel model);
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         public IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName, string logicalName);

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -69,6 +69,22 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void AddAttendee_ValidRequest_RespondsWithNoContent()
+        {
+            var attendee = new ExistingCandidateRequest() { Email = "test@test.com", FirstName = "John", LastName = "Doe" };
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.GetTeachingEvent((Guid)teachingEvent.Id)).Returns(teachingEvent);
+            _mockCrm.Setup(mock => mock.GetCandidate(attendee)).Returns(candidate);
+
+            var response = _controller.AddAttendee((Guid)teachingEvent.Id, attendee);
+
+            response.Should().BeOfType<NoContentResult>();
+            _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(
+                registration => registration.CandidateId == candidate.Id && registration.EventId == teachingEvent.Id)));
+        }
+
+        [Fact]
         public void Search_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new TeachingEventSearchRequest() { Postcode = null};

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -5,7 +5,6 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Client;
 using Moq;
 using Xunit;
 

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class TeachingEventRegistrationTests
+    {
+        [Fact]
+        public void EntityAttributes()
+        {
+            var type = typeof(TeachingEventRegistration);
+
+            type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_eventregistration");
+
+            type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "msevtmgt_contactid" && a.Type == typeof(EntityReference));
+            type.GetProperty("EventId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "msevtmgt_eventid" && a.Type == typeof(EntityReference));
+        }
+
+        [Fact]
+        public void ToEntity_WhenRegistrationAlreadyExistsForCandidate_ReturnsNull()
+        {
+            var mockService = new Mock<IOrganizationServiceAdapter>();
+            var context = mockService.Object.Context("mock-connection-string");
+            var mockCrm = new Mock<ICrmService>();
+
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
+            var registration = new TeachingEventRegistration()
+            {
+                CandidateId = (Guid) candidate.Id, 
+                EventId = (Guid) teachingEvent.Id
+            };
+
+            mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent((Guid)candidate.Id, (Guid)teachingEvent.Id)).Returns(false);
+
+            var entity = registration.ToEntity(mockCrm.Object, context);
+
+            entity.Should().BeNull();
+            mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Never);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -255,10 +255,46 @@ namespace GetIntoTeachingApiTests.Services
             entity["dfe_candidate"] = new EntityReference("dfe_candidate", (Guid)candidate.Id);
             entity["dfe_privacypolicynumber"] = new EntityReference("dfe_privacypolicynumber", policy.AcceptedPolicyId);
 
-            _mockService.Setup(m => m.CreateQuery("dfe_candidateprivacypolicy", It.IsAny<OrganizationServiceContext>()))
+            _mockService.Setup(m => m.CreateQuery("dfe_candidateprivacypolicy", _context))
                 .Returns(new List<Entity> { entity }.AsQueryable());
 
             var result = _crm.CandidateYetToAcceptPrivacyPolicy((Guid)candidate.Id, Guid.NewGuid());
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void CandidateYetToRegisterForTeachingEvent_WhenAlreadyRegistered_ReturnsFalse()
+        {
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
+
+            var entity = new Entity();
+            entity["msevtmgt_contactid"] = new EntityReference("dfe_candidate", (Guid)candidate.Id);
+            entity["msevtmgt_eventid"] = new EntityReference("msevtmgt_event", (Guid)teachingEvent.Id);
+
+            _mockService.Setup(m => m.CreateQuery("msevtmgt_eventregistration", _context))
+                .Returns(new List<Entity> { entity }.AsQueryable());
+
+            var result = _crm.CandidateYetToRegisterForTeachingEvent((Guid)candidate.Id, (Guid)teachingEvent.Id);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CandidateYetToRegisterForTeachingEvent_WhenNotYetRegistered_ReturnsTrue()
+        {
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
+
+            var entity = new Entity();
+            entity["msevtmgt_contactid"] = new EntityReference("dfe_candidate", (Guid)candidate.Id);
+            entity["msevtmgt_eventid"] = new EntityReference("msevtmgt_event", (Guid)teachingEvent.Id);
+
+            _mockService.Setup(m => m.CreateQuery("dfe_candidateprivacypolicy", _context))
+                .Returns(new List<Entity> { entity }.AsQueryable());
+
+            var result = _crm.CandidateYetToRegisterForTeachingEvent((Guid)candidate.Id, Guid.NewGuid());
 
             result.Should().BeTrue();
         }


### PR DESCRIPTION
Add a new `TeachingEventRegistration` model that maps a candidate to an event.

Add a method to the CRM to check if a candidate is already registered for an event.

Update `BaseModel` with hook to prevent an entity being mapped - implement the hook in `TeachingEventRegistration` to ensure candidates are not re-registered for the same event again.

Plumb in `TeachingEventsController` create action to lookup the attendee and event then save the `EventRegistration`.