### PR TITLE
Move transactions to background jobs

### DIFF
--- a/GetIntoTeachingApi/Adapters/IPerformContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IPerformContextAdapter.cs
@@ -1,0 +1,9 @@
+﻿using Hangfire.Server;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public interface IPerformContextAdapter
+    {
+        int GetRetryCount(PerformContext context);
+    }
+}

--- a/GetIntoTeachingApi/Adapters/PerformContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/PerformContextAdapter.cs
@@ -1,0 +1,12 @@
+﻿using Hangfire.Server;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public class PerformContextAdapter : IPerformContextAdapter
+    {
+        public int GetRetryCount(PerformContext context)
+        {
+            return context.GetJobParameter<int>("RetryCount");
+        }
+    }
+}

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -8,6 +8,10 @@
 		<PackageReference Include="CsvHelper" Version="15.0.5" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
 		<PackageReference Include="GeoCoordinate.NetStandard1" Version="1.0.1" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.11" />
+		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
+		<PackageReference Include="Hangfire.PostgreSql" Version="1.6.4.2" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.1" />
 		<PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.2.1-Alpha" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />

--- a/GetIntoTeachingApi/Jobs/BaseJob.cs
+++ b/GetIntoTeachingApi/Jobs/BaseJob.cs
@@ -1,0 +1,14 @@
+﻿using GetIntoTeachingApi.Adapters;
+using Hangfire.Server;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public abstract class BaseJob
+    {
+        protected bool IsLastAttempt(PerformContext context, IPerformContextAdapter adapter)
+        {
+            var retryCount = adapter.GetRetryCount(context);
+            return retryCount >= JobConfiguration.Attempts;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Hangfire.Server;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class CandidateRegistrationJob : BaseJob
+    {
+        private readonly ICrmService _crm;
+        private readonly INotifyService _notifyService;
+        private readonly IPerformContextAdapter _contextAdapter;
+
+        public CandidateRegistrationJob(ICrmService crm, INotifyService notifyService,
+            IPerformContextAdapter contextAdapter)
+        {
+            _crm = crm;
+            _notifyService = notifyService;
+            _contextAdapter = contextAdapter;
+        }
+
+        public void Run(Candidate candidate, PerformContext context)
+        {
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                var personalisation = new Dictionary<string, dynamic>();
+                _notifyService.SendEmail(candidate.Email, NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
+            }
+            else
+                _crm.Save(candidate);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public static class JobConfiguration
+    {
+        private static bool IsDevelopment =>
+            Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
+        public static int Attempts => IsDevelopment ? 5 : 24;
+        public static int RetryIntervalInSeconds => IsDevelopment ? 60 : 3600;
+        public static TimeSpan ExpirationTimeout => TimeSpan.FromHours(24);
+    }
+}

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Hangfire.Server;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class TeachingEventRegistrationJob : BaseJob
+    {
+        private readonly ICrmService _crm;
+        private readonly INotifyService _notifyService;
+        private readonly IPerformContextAdapter _contextAdapter;
+
+        public TeachingEventRegistrationJob(ICrmService crm, INotifyService notifyService,
+            IPerformContextAdapter contextAdapter)
+        {
+            _crm = crm;
+            _notifyService = notifyService;
+            _contextAdapter = contextAdapter;
+        }
+
+        public void Run(TeachingEventRegistration registration, PerformContext context)
+        {
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                var personalisation = new Dictionary<string, dynamic>();
+                _notifyService.SendEmail(
+                    registration.CandidateEmail,
+                    NotifyService.TeachingEventRegistrationFailedTemplateId, 
+                    personalisation);
+            }
+            else
+                _crm.Save(registration);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Models
         public Guid CandidateId { get; set; }
         [EntityField(Name = "msevtmgt_eventid", Type = typeof(EntityReference))]
         public Guid EventId { get; set; }
+        public string CandidateEmail { get; set; }
 
         public TeachingEventRegistration() : base() { }
 

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -9,6 +9,8 @@ namespace GetIntoTeachingApi.Services
     public class NotifyService : INotifyService
     {
         public static readonly string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
+        public static readonly string CandidateRegistrationFailedTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
+        public static readonly string TeachingEventRegistrationFailedTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
         private readonly ILogger<NotifyService> _logger;
         private readonly INotificationClientAdapter _client;
 

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -1,9 +1,13 @@
 {
+  "ConnectionStrings": {
+    "PostgresConnectionString": "Server=get-into-teaching-api-dev-pg-svc;SSL Mode=Require;Trust Server Certificate=true;Port=7080;Database=rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Hangfire": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class CandidateRegistrationJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly Candidate _candidate;
+        private readonly CandidateRegistrationJob _job;
+
+        public CandidateRegistrationJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockNotifyService = new Mock<INotifyService>();
+            _candidate = new Candidate() { Email = "test@test.com" };
+            _job = new CandidateRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, _mockContext.Object);
+        }
+
+        [Fact]
+        public void Run_OnSuccess_SavesCandidate()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _job.Run(_candidate, null);
+
+            _mockCrm.Verify(mock => mock.Save(_candidate), Times.Once);
+        }
+
+        [Fact]
+        public void Run_OnFailure_EmailsCandidate()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts);
+
+            _job.Run(_candidate, null);
+
+            _mockCrm.Verify(mock => mock.Save(_candidate), Times.Never);
+            _mockNotifyService.Verify(mock => mock.SendEmail(_candidate.Email, 
+                NotifyService.CandidateRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class TeachingEventRegistrationJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly TeachingEventRegistration _registration;
+        private readonly TeachingEventRegistrationJob _job;
+
+        public TeachingEventRegistrationJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockNotifyService = new Mock<INotifyService>();
+            _registration = new TeachingEventRegistration() { CandidateEmail = "test@test.com" };
+            _job = new TeachingEventRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, _mockContext.Object);
+        }
+
+        [Fact]
+        public void Run_OnSuccess_SavesCandidate()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _job.Run(_registration, null);
+
+            _mockCrm.Verify(mock => mock.Save(_registration), Times.Once);
+        }
+
+        [Fact]
+        public void Run_OnFailure_EmailsCandidate()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts);
+
+            _job.Run(_registration, null);
+
+            _mockCrm.Verify(mock => mock.Save(_registration), Times.Never);
+            _mockNotifyService.Verify(mock => mock.SendEmail(_registration.CandidateEmail,
+                NotifyService.TeachingEventRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ CRM_CLIENT_SECRET=****
 NOTIFY_API_KEY=****
 ```
 
+The Postgres connection is setup in `appsettings.json` and not used in development (it is replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:
+
+```
+cf conduit get-into-teaching-api-dev-pg-svc
+```
+
+You then need to replace the connection string to include the username/password for your conduit session and point it to localhost:
+
+```
+Server=127.0.0.1;SSL Mode=Require;Trust Server Certificate=true;Port=7080;Database=rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e;User Id=******;Password=******;
+```
+
 ### Documentation
 
 [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) is used for generating Swagger documentation. We use the swagger-ui middleware to expose interactive documentation when the application runs.
@@ -75,3 +87,9 @@ public void UnitOfWork_StateUnderTest_ExpectedBehavior()
 ### Emails
 
 We send emails using the [GOV.UK Notify](https://www.notifications.service.gov.uk/) service; leveraging the [.Net Client](https://github.com/alphagov/notifications-net-client).
+
+### Background Jobs
+
+[Hangfire](https://www.hangfire.io/) is used for queueing and processing background jobs; an in-memory storage is used for development and PostgreSQL is used in production (the PRO version is required to use Redis as the storage provider). Failed jobs get retries on a 60 minute interval a maximum of 24 times before they are deleted (in development this is reduced to 1 minute interval a maximum of 5 times) - if this happens we attempt to inform the user by sending them an email.
+
+The Hangfire web dashboard can be accessed at `/hangfire` in development.


### PR DESCRIPTION
We currently send data to dynamics within the request/response cycle. This is fine if Dynamics is online, however it can be offline for maintenance for reasonably long periods of time. To ensure the transactions complete this commit adds Hangfire to queue the transaction requests and retry them in the event of failure.

The jobs will be retried once per hour, a maximum of 24 times. If the job is not successful it will be removed from storage and we will attempt to email the candidate informing them that the transaction has failed.

Hangfire is configured to use in-memory storage for development (and also runs a shorter retry/give up cycle). In production we are using PostgreSQL as this is supported by the free version of Hangfire (Redis requires a Hangfire susbcription).

The entire candidate/event registration object is serialized as part of the job for simplicity - this should be fine given the size of those models just now, but in the future we may want to store them separately in Postgres and only pass the ID of the object to the job.

`PerformContextAdapter` enables the mocking and unit testing of the retry/give up behavior.