### PR TITLE
Expose Hangfire dashboard on dev/staging

### DIFF
--- a/GetIntoTeachingApi/Auth/HangfireDashboardAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardAuthorizationFilter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq;
+using Hangfire.Dashboard;
+
+namespace GetIntoTeachingApi.Auth
+{
+    public class HangfireDashboardAuthroizationFilter : IDashboardAuthorizationFilter
+    {
+        public bool Authorize(DashboardContext context)
+        {
+            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            return new[] {"Development", "Staging"}.Contains(environment);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -17,7 +17,6 @@ using GetIntoTeachingApi.Services;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
-using Microsoft.Crm.Sdk.Messages;
 
 namespace GetIntoTeachingApi
 {
@@ -142,7 +141,10 @@ The GIT API aims to provide:
 
             app.UseRouting();
 
-            app.UseHangfireDashboard();
+            app.UseHangfireDashboard("/hangfire", new DashboardOptions
+            {
+                Authorization = new[] { new HangfireDashboardAuthroizationFilter() }
+            });
 
             app.UseSwagger();
 

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardAuthorizationFilterTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Auth;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Auth
+{
+    public class HangfireDashboardAuthorizationFilterTests : IDisposable
+    {
+        private readonly HangfireDashboardAuthroizationFilter _filter;
+        private readonly string _previousEnvironment;
+
+        public HangfireDashboardAuthorizationFilterTests()
+        {
+            _filter = new HangfireDashboardAuthroizationFilter();
+            _previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        }
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", _previousEnvironment);
+        }
+
+        [Fact]
+        public void Authorize_Staging_IsTrue()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            _filter.Authorize(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Authorize_Development_IsTrue()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+            _filter.Authorize(null).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("Production")]
+        [InlineData("Development1")]
+        [InlineData("prod")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Authorize_Other_IsFalse(string environment)
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+
+            _filter.Authorize(null).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
The Hangfire dashboard gives visibility of the jobs and their states; it will be useful to have it available in staging as well as development (which is the default).

Add custom authorization filter to check the running environment and expose the dashboard on staging/development.