### PR TITLE
Enable new candidates to register for events

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -106,19 +106,11 @@ maximum of 50 using the `limit` query parameter.",
                 return BadRequest(this.ModelState);
 
             var teachingEvent = _crm.GetTeachingEvent(id);
-            var candidate = _crm.GetCandidate(attendee);
 
-            if (teachingEvent == null || candidate == null)
+            if (teachingEvent == null)
                 return NotFound();
 
-            var registration = new TeachingEventRegistration()
-            {
-                CandidateId = (Guid) candidate.Id, 
-                EventId = (Guid) teachingEvent.Id,
-                CandidateEmail = candidate.Email
-            };
-
-            _jobClient.Enqueue<TeachingEventRegistrationJob>((x) => x.Run(registration, null));
+            _jobClient.Enqueue<TeachingEventRegistrationJob>((x) => x.Run(attendee, id, null));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -12,7 +12,6 @@ namespace GetIntoTeachingApi.Models
         public Guid CandidateId { get; set; }
         [EntityField(Name = "msevtmgt_eventid", Type = typeof(EntityReference))]
         public Guid EventId { get; set; }
-        public string CandidateEmail { get; set; }
 
         public TeachingEventRegistration() : base() { }
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -150,8 +150,9 @@ namespace GetIntoTeachingApi.Services
         public void Save(BaseModel model)
         {
             using var context = Context();
-            model.ToEntity(this, context);
+            var entity = model.ToEntity(this, context);
             _service.SaveChanges(context);
+            model.Id = entity.Id;
         }
 
         private IEnumerable<TeachingEvent> GetTeachingEvents()

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -326,12 +326,15 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void Save_MapsEntityAndSavesContext()
         {
+            var entity = new Entity() {Id = Guid.NewGuid()};
             var mockCandidate = new Mock<Candidate>();
+            // The id is actually set on SaveChanges, but mocked here for ease.
+            mockCandidate.Setup(mock => mock.ToEntity(_crm, _context)).Returns(entity);
 
             _crm.Save(mockCandidate.Object);
 
-            mockCandidate.Verify(mock => mock.ToEntity(_crm, _context));
-            _mockService.Verify(mock => mock.SaveChanges(_context));
+            _mockService.Verify(mock => mock.SaveChanges(_context), Times.Once);
+            mockCandidate.Object.Id.Should().Be(entity.Id);
         }
 
         [Fact]


### PR DESCRIPTION
Previously we only checked for existing candidates when registering a candidate for an event. Instead, we attempt to get the matching, existing candidate if they exist and if not then a new candidate entry
is created and registered with the event.

If the registration job fails after creating a candidate then on the next run the candidate will be matched, so we won't end up creating a bunch of duplicate candidates in the event of job failures.