### PR TITLE
Update README with correct db instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ The Postgres connections (for Hangfire and our database) are setup in `appsettin
 cf conduit get-into-teaching-api-dev-pg-svc
 ```
 
-You then need to replace the connection string to include the username/password for your conduit session and point it to localhost:
+You then need to add a connection string containing the details for your conduit session and point it to localhost:
 
 ```
 Server=127.0.0.1;SSL Mode=Require;Trust Server Certificate=true;Port=7080;Database=rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e;User Id=******;Password=******;
 ```
+
+Finally, update `Startup.cs` to use your connection string instead of the builder in `DbConfiguration.cs`.
 
 ### Documentation
 
@@ -97,3 +99,5 @@ The Hangfire web dashboard can be accessed at `/hangfire` in development.
 ### Database
 
 We run Entity Framework Core in order to persist some models/data to a Postgres database. Currently this is being used to store and query the UK postcode geolocation information that is used when searching for events within a given radius of another postcode.
+
+Migrations are applied from code when the application starts (see `DbConfiguration.cs`). You can add a migration by modifying the models and running `dotnet ef migrations add MyNewMigration`.


### PR DESCRIPTION
We migrated from connection string to reading in the VCAP_SERVICES environment variables containing postgres credentials.