### PR TITLE
Ensure BaseModel subtypes have required constructor

### DIFF
--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -14,5 +14,7 @@ namespace GetIntoTeachingApi.Models
         public int? EducationPhaseId { get; set; }
 
         public CandidatePastTeachingPosition() : base() { }
+
+        public CandidatePastTeachingPosition(Entity entity, ICrmService crm) : base(entity, crm) { }
     }
 }

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
@@ -11,5 +12,7 @@ namespace GetIntoTeachingApi.Models
         public Guid AcceptedPolicyId { get; set; }
 
         public CandidatePrivacyPolicy() : base() { }
+
+        public CandidatePrivacyPolicy(Entity entity, ICrmService crm) : base(entity, crm) { }
     }
 }

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -15,5 +15,7 @@ namespace GetIntoTeachingApi.Models
         public int? DegreeStatusId { get; set; }
 
         public CandidateQualification() : base() { }
+
+        public CandidateQualification(Entity entity, ICrmService crm) : base(entity, crm) { }
     }
 }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -12,5 +14,7 @@ namespace GetIntoTeachingApi.Models
         public string Telephone { get; set; }
 
         public PhoneCall() : base() { }
+
+        public PhoneCall(Entity entity, ICrmService crm) : base(entity, crm) { }
     }
 }

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -21,5 +21,7 @@ namespace GetIntoTeachingApi.Models
         public string AddressPostcode { get; set; }
 
         public TeachingEventBuilding() : base() { }
+
+        public TeachingEventBuilding(Entity entity, ICrmService crm) : base(entity, crm) { }
     }
 }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -16,6 +16,8 @@ namespace GetIntoTeachingApi.Models
 
         public TeachingEventRegistration() : base() { }
 
+        public TeachingEventRegistration(Entity entity, ICrmService crm) : base(entity, crm) { }
+
         protected override bool ShouldMap(ICrmService crm)
         {
             return crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Attributes;
@@ -54,6 +55,21 @@ namespace GetIntoTeachingApiTests.Models
             var mockLocationService = new Mock<LocationService>();
             _context = _mockService.Object.Context("mock-connection-string");
             _crm = new CrmService(_mockService.Object, _mockCrmCache.Object, mockLocationService.Object);
+        }
+
+        [Fact]
+        public void AllSubTypes_HaveRequiredConstructor()
+        {
+            var assembly = typeof(BaseModel).Assembly;
+            var subTypes = assembly.GetTypes().Where(t => t.BaseType == typeof(BaseModel));
+
+            foreach (var subType in subTypes)
+            {
+                // Constructor is required for creating related models in BaseModel.MapRelationshipAttributesFromEntity
+                var requiredConstructor = subType.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, 
+                    new Type[] { typeof(Entity), typeof(ICrmService) }, null);
+                requiredConstructor.Should().NotBeNull();
+            }
         }
 
         [Fact]


### PR DESCRIPTION
As part of mapping Dynamics entities to our models we need to dynamically instantiate BaseModel subtypes using reflection; if a subtype doesn't have the constructor we expect a runtime error will
occur. As it's used with reflection we don't get a compile time error if the constructor is missing, so this commit introduces a test that will ensure the constructor is present.