### PR TITLE
Read postgres instance names from ENV variables

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -26,9 +26,9 @@ namespace GetIntoTeachingApi.Database
             _dbContext = dbContext;
         }
 
-        public static string DatabaseConnectionString() => GenerateConnectionString("get-into-teaching-api-dev-pg-svc-2");
+        public static string DatabaseConnectionString() => GenerateConnectionString(Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME"));
 
-        public static string HangfireConnectionString() => GenerateConnectionString("get-into-teaching-api-dev-pg-svc");
+        public static string HangfireConnectionString() => GenerateConnectionString(Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME"));
 
         public void Configure()
         {

--- a/GetIntoTeachingApiTests/Database/DbConfigurationTests.cs
+++ b/GetIntoTeachingApiTests/Database/DbConfigurationTests.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApiTests.Database
         {
             using StreamReader reader = new StreamReader("./Fixtures/vcap_services.json");
             var json = reader.ReadToEnd();
+            Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", "get-into-teaching-api-dev-pg-svc-2");
+            Environment.SetEnvironmentVariable("HANGFIRE_INSTANCE_NAME", "get-into-teaching-api-dev-pg-svc");
             Environment.SetEnvironmentVariable("VCAP_SERVICES", json);
         }
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ CRM_CLIENT_SECRET=****
 
 # GOV.UK Notify Service credentials
 NOTIFY_API_KEY=****
+
+# Postgres instance names
+DATABASE_INSTANCE_NAME=****
+HANGFIRE_INSTANCE_NAME=****
 ```
 
 The Postgres connections (for Hangfire and our database) are setup in `appsettings.json` and not used in development (they are replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:


### PR DESCRIPTION
The database instance names are unique per environment, so we are reading them in from env variables instead of hardcoding them.