### PR TITLE
JsonIgnore teaching event building coordinate

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -21,6 +22,7 @@ namespace GetIntoTeachingApi.Models
         public string AddressState { get; set; }
         [EntityField(Name = "msevtmgt_postalcode")]
         public string AddressPostcode { get; set; }
+        [JsonIgnore]
         [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }
 


### PR DESCRIPTION
The Point type is a complex object so it's best not to serialize it; it also clutters the Swagger documentation.