### PR TITLE
Add temporary logging to DbConfiguration

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using CsvHelper;
 using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Newtonsoft.Json;
@@ -98,8 +99,19 @@ namespace GetIntoTeachingApi.Database
 
         private static string GenerateConnectionString(string instanceName)
         {
+            var loggerFactory = new LoggerFactory();
+            var logger = loggerFactory.CreateLogger<DbConfiguration>();
+            logger.LogWarning($"GenerateConnectionString: {instanceName}");
+
+            logger.LogWarning($"VCAP_SERVICES: {Environment.GetEnvironmentVariable("VCAP_SERVICES")}");
+
             var vcap = JsonConvert.DeserializeObject<VcapServices>(Environment.GetEnvironmentVariable("VCAP_SERVICES"));
+
+            logger.LogWarning($"VCAP_SERVICES (deserialized): {vcap}");
+
             var postgres = vcap.Postgres.First(p => p.InstanceName == instanceName);
+
+            logger.LogWarning($"Postgres: {postgres}");
 
             var builder = new NpgsqlConnectionStringBuilder
             {
@@ -111,6 +123,8 @@ namespace GetIntoTeachingApi.Database
                 SslMode = SslMode.Require,
                 TrustServerCertificate = true
             };
+
+            logger.LogWarning($"Connection String: {builder.ConnectionString}");
 
             return builder.ConnectionString;
         }


### PR DESCRIPTION
Add temporary logging to the DbConfiguration so we can see what's going wrong in production. Will be reverted once we have investigated.