### PR TITLE
Add additional fields to Candidate model

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -93,6 +93,20 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [Route("candidate/channels")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of candidate channels.",
+            OperationId = "GetCandidateChannels",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetCandidateChannels()
+        {
+            var channels = _store.GetPickListItems("contact", "dfe_channelcreation");
+            return Ok(channels);
+        }
+
+        [HttpGet]
         [Route("qualification/degree_status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of qualification degree status.",

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -175,5 +175,19 @@ namespace GetIntoTeachingApi.Controllers
             var eventTypes = _store.GetPickListItems("msevtmgt_event", "dfe_event_type");
             return Ok(eventTypes);
         }
+
+        [HttpGet]
+        [Route("phone_call/channels")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of phone call channels.",
+            OperationId = "GetPhoneCallChannels",
+            Tags = new[] { "Types" }
+        )]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public IActionResult GetPhoneCallChannels()
+        {
+            var channels = _store.GetPickListItems("phonecall", "dfe_channelcreation");
+            return Ok(channels);
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Client;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -19,6 +18,8 @@ namespace GetIntoTeachingApi.Models
         public int? LocationId { get; set; }
         [EntityField(Name = "dfe_ittyear", Type = typeof(OptionSetValue))]
         public int? InitialTeacherTrainingYearId { get; set; }
+        [EntityField(Name = "dfe_channelcreation", Type = typeof(OptionSetValue))]
+        public int? ChannelId { get; set; }
         [EntityField(Name = "emailaddress1")]
         public string Email { get; set; }
         [EntityField(Name = "firstname")]
@@ -27,7 +28,7 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         [EntityField(Name = "birthdate")]
         public DateTime? DateOfBirth { get; set; }
-        [EntityField(Name = "telephone1")]
+        [EntityField(Name = "address1_telephone1")]
         public string Telephone { get; set; }
         [EntityField(Name = "address1_line1")]
         public string AddressLine1 { get; set; }
@@ -41,7 +42,9 @@ namespace GetIntoTeachingApi.Models
         public string AddressState { get; set; }
         [EntityField(Name = "address1_postalcode")]
         public string AddressPostcode { get; set; }
-        [EntityRelationship(Name = "dfe_contact_dfe_candidatequalification_ContactId", Type = typeof(CandidateQualification))]
+
+        [EntityRelationship(Name = "dfe_contact_dfe_candidatequalification_ContactId",
+            Type = typeof(CandidateQualification))]
         public List<CandidateQualification> Qualifications { get; set; }
         [EntityRelationship(Name = "dfe_contact_dfe_candidatepastteachingposition_ContactId", Type = typeof(CandidatePastTeachingPosition))]
         public List<CandidatePastTeachingPosition> PastTeachingPositions { get; set; }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -8,6 +8,8 @@ namespace GetIntoTeachingApi.Models
     [Entity(LogicalName = "phonecall")]
     public class PhoneCall : BaseModel
     {
+        [EntityField(Name = "dfe_channelcreation", Type = typeof(OptionSetValue))]
+        public int? ChannelId { get; set; }
         [EntityField(Name = "scheduledstart")]
         public DateTime ScheduledAt { get; set; }
         [EntityField(Name = "phonenumber")]

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -47,6 +47,9 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Must(id => InitialTeacherTrainingYearIds().Contains(id.ToString()))
                 .Unless(candidate => candidate.InitialTeacherTrainingYearId == null)
                 .WithMessage("Must be a valid candidate initial teacher training year.");
+            RuleFor(candidate => candidate.ChannelId)
+                .Must(id => ChannelIds().Contains(id.ToString()))
+                .WithMessage("Must be a valid candidate channel.");
         }
 
         private IEnumerable<string> PreferredTeachingSubjectIds()
@@ -67,6 +70,11 @@ namespace GetIntoTeachingApi.Models.Validators
         private IEnumerable<string> InitialTeacherTrainingYearIds()
         {
             return _store.GetPickListItems("contact", "dfe_ittyear").Select(year => year.Id);
+        }
+
+        private IEnumerable<string> ChannelIds()
+        {
+            return _store.GetPickListItems("contact", "dfe_channelcreation").Select(channel => channel.Id);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressState).NotEmpty().MaximumLength(128);
             RuleFor(candidate => candidate.AddressPostcode).NotEmpty().MaximumLength(40);
 
-            RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator()).Unless(candidate => candidate.PhoneCall == null);
+            RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator(store)).Unless(candidate => candidate.PhoneCall == null);
             RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(store)).Unless(candidate => candidate.PrivacyPolicy == null);
             RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(store));
             RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(store));

--- a/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
@@ -1,14 +1,30 @@
 ﻿using FluentValidation;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class PhoneCallValidator : AbstractValidator<PhoneCall>
     {
-        public PhoneCallValidator()
+        private readonly IStore _store;
+
+        public PhoneCallValidator(IStore store)
         {
+            _store = store;
+
             RuleFor(phoneCall => phoneCall.ScheduledAt).GreaterThan(candidate => DateTime.Now);
             RuleFor(phoneCall => phoneCall.Telephone).NotEmpty().MaximumLength(50);
+
+            RuleFor(candidate => candidate.ChannelId)
+                .Must(id => ChannelIds().Contains(id.ToString()))
+                .WithMessage("Must be a valid candidate channel.");
+        }
+
+        private IEnumerable<string> ChannelIds()
+        {
+            return _store.GetPickListItems("phonecall", "dfe_channelcreation").Select(channel => channel.Id);
         }
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -138,6 +138,7 @@ namespace GetIntoTeachingApi.Services
             UpsertTypes(crm.GetPickListItems("contact", "dfe_ittyear"));
             UpsertTypes(crm.GetPickListItems("contact", "dfe_preferrededucationphase01"));
             UpsertTypes(crm.GetPickListItems("contact", "dfe_isinuk"));
+            UpsertTypes(crm.GetPickListItems("contact", "dfe_channelcreation"));
             UpsertTypes(crm.GetPickListItems("dfe_qualification", "dfe_degreestatus"));
             UpsertTypes(crm.GetPickListItems("dfe_qualification", "dfe_category"));
             UpsertTypes(crm.GetPickListItems("dfe_qualification", "dfe_type"));

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -144,6 +144,7 @@ namespace GetIntoTeachingApi.Services
             UpsertTypes(crm.GetPickListItems("dfe_qualification", "dfe_type"));
             UpsertTypes(crm.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"));
             UpsertTypes(crm.GetPickListItems("msevtmgt_event", "dfe_event_type"));
+            UpsertTypes(crm.GetPickListItems("phonecall", "dfe_channelcreation"));
             _dbContext.SaveChanges();
         }
 

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -91,6 +91,18 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void GetCandidateChannels_ReturnsAllChannels()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation")).Returns(mockEntities);
+
+            var response = _controller.GetCandidateChannels();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
+        [Fact]
         public void GetQualificationDegreeStatus_ReturnsAllStatus()
         {
             var mockEntities = MockTypeEntities();

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -162,6 +162,18 @@ namespace GetIntoTeachingApiTests.Controllers
             ok.Value.Should().Be(mockEntities);
         }
 
+        [Fact]
+        public void GetPhoneCallChannels_ReturnsAllChannels()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("phonecall", "dfe_channelcreation")).Returns(mockEntities);
+
+            var response = _controller.GetPhoneCallChannels();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockEntities);
+        }
+
         private static IEnumerable<TypeEntity> MockTypeEntities()
         {
             return new []

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -29,12 +29,14 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_isinuk" && a.Type == typeof(OptionSetValue));
             type.GetProperty("InitialTeacherTrainingYearId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_ittyear" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
             type.GetProperty("LastName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "lastname");
             type.GetProperty("DateOfBirth").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "birthdate");
-            type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "telephone1");
+            type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_telephone1");
             type.GetProperty("AddressLine1").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_line1");
             type.GetProperty("AddressLine2").Should()

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
@@ -14,6 +15,9 @@ namespace GetIntoTeachingApiTests.Models
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "phonecall");
 
+            type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));
+            
             type.GetProperty("ScheduledAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "scheduledstart");
             type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "phonenumber");
         }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -28,6 +28,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var mockPreferredEducationPhase = NewMock(111);
             var mockLocation = NewMock(222);
             var mockInitialTeacherTrainingYear = NewMock(333);
+            var mockChannel = NewMock(444);
 
             _mockStore
                 .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
@@ -41,6 +42,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear"))
                 .Returns(new[] { mockInitialTeacherTrainingYear });
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
+                .Returns(new[] { mockChannel });
 
             var candidate = new Candidate()
             {
@@ -59,6 +63,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 PreferredEducationPhaseId = int.Parse(mockPreferredEducationPhase.Id),
                 LocationId = int.Parse(mockLocation.Id),
                 InitialTeacherTrainingYearId = int.Parse(mockInitialTeacherTrainingYear.Id),
+                ChannelId = int.Parse(mockChannel.Id),
             };
 
             var result = _validator.TestValidate(candidate);
@@ -299,6 +304,18 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_InitialTeacherTrainingYearIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.InitialTeacherTrainingYearId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_ChannelIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ChannelId, 123);
+        }
+
+        [Fact]
+        public void Validate_ChannelIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ChannelId, null as int?);
         }
 
         private static TypeEntity NewMock(dynamic id)

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -176,6 +176,7 @@ namespace GetIntoTeachingApiTests.Services
             mockCrm.Verify(m => m.GetPickListItems("dfe_qualification", "dfe_type"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"));
             mockCrm.Verify(m => m.GetPickListItems("msevtmgt_event", "dfe_event_type"));
+            mockCrm.Verify(m => m.GetPickListItems("phonecall", "dfe_channelcreation"));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -170,6 +170,7 @@ namespace GetIntoTeachingApiTests.Services
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_ittyear"));
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_preferrededucationphase01"));
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_isinuk"));
+            mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_channelcreation"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_qualification", "dfe_degreestatus"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_qualification", "dfe_category"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_qualification", "dfe_type"));


### PR DESCRIPTION
Send the channel through to the CRM with the Candidate and PhoneCall models.

Update telephone attribute to point to `address1_telephone1` as instructed by CRM team.