### PR TITLE
Fix postgres in production

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -26,9 +26,11 @@ namespace GetIntoTeachingApi.Database
             _dbContext = dbContext;
         }
 
-        public static string DatabaseConnectionString() => GenerateConnectionString(Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME"));
+        public static string DatabaseConnectionString() => 
+            GenerateConnectionString(Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME"));
 
-        public static string HangfireConnectionString() => GenerateConnectionString(Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME"));
+        public static string HangfireConnectionString() => 
+            GenerateConnectionString(Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME"));
 
         public void Configure()
         {

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -16,8 +16,19 @@ namespace GetIntoTeachingApi.Database
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Location>().Property(m => m.Coordinate).HasSrid(DbConfiguration.Wgs84Srid);
-            modelBuilder.Entity<TeachingEventBuilding>().Property(m => m.Coordinate).HasSrid(DbConfiguration.Wgs84Srid);
+            switch (Database.ProviderName)
+            {
+                case "Microsoft.EntityFrameworkCore.Sqlite":
+                    modelBuilder.Entity<Location>().Property(m => m.Coordinate)
+                        .HasSrid(DbConfiguration.Wgs84Srid);
+                    modelBuilder.Entity<TeachingEventBuilding>().Property(m => m.Coordinate)
+                        .HasSrid(DbConfiguration.Wgs84Srid);
+                    break;
+                case "Npgsql.EntityFrameworkCore.PostgreSQL":
+                    modelBuilder.HasPostgresExtension("postgis");
+                    break;
+            }
+
             modelBuilder.Entity<TeachingEvent>().HasOne(c => c.Building);
             modelBuilder.Entity<TypeEntity>().HasKey(t => new {t.Id, t.EntityName, t.AttributeName});
         }

--- a/GetIntoTeachingApi/Migrations/20200606193812_InitialCreate.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20200606193812_InitialCreate.Designer.cs
@@ -6,27 +6,30 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    [Migration("20200605130657_InitialCreate")]
+    [Migration("20200606193812_InitialCreate")]
     partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "3.1.4");
+                .HasAnnotation("Npgsql:PostgresExtension:postgis", ",,")
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .HasAnnotation("ProductVersion", "3.1.4")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("GetIntoTeachingApi.Models.Location", b =>
                 {
                     b.Property<string>("Postcode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Point>("Coordinate")
-                        .HasColumnType("POINT")
-                        .HasAnnotation("Sqlite:Srid", 4326);
+                        .HasColumnType("geography");
 
                     b.HasKey("Postcode");
 
@@ -36,13 +39,13 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.PrivacyPolicy", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -52,25 +55,25 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TeachingEvent", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("BuildingId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("EndAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("StartAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<int>("TypeId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -82,29 +85,28 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TeachingEventBuilding", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AddressCity")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine1")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine2")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine3")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressPostcode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Point>("Coordinate")
-                        .HasColumnType("POINT")
-                        .HasAnnotation("Sqlite:Srid", 4326);
+                        .HasColumnType("geography");
 
                     b.HasKey("Id");
 
@@ -114,16 +116,16 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TypeEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EntityName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AttributeName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Value")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id", "EntityName", "AttributeName");
 

--- a/GetIntoTeachingApi/Migrations/20200606193812_InitialCreate.cs
+++ b/GetIntoTeachingApi/Migrations/20200606193812_InitialCreate.cs
@@ -9,15 +9,14 @@ namespace GetIntoTeachingApi.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterDatabase()
-                .Annotation("Sqlite:InitSpatialMetaData", true);
+                .Annotation("Npgsql:PostgresExtension:postgis", ",,");
 
             migrationBuilder.CreateTable(
                 name: "Locations",
                 columns: table => new
                 {
                     Postcode = table.Column<string>(nullable: false),
-                    Coordinate = table.Column<Point>(nullable: true)
-                        .Annotation("Sqlite:Srid", 4326)
+                    Coordinate = table.Column<Point>(type: "geography", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -48,8 +47,7 @@ namespace GetIntoTeachingApi.Migrations
                     AddressCity = table.Column<string>(nullable: true),
                     AddressState = table.Column<string>(nullable: true),
                     AddressPostcode = table.Column<string>(nullable: true),
-                    Coordinate = table.Column<Point>(nullable: true)
-                        .Annotation("Sqlite:Srid", 4326)
+                    Coordinate = table.Column<Point>(type: "geography", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/GetIntoTeachingApi/Migrations/GetIntoTeachingDbContextModelSnapshot.cs
+++ b/GetIntoTeachingApi/Migrations/GetIntoTeachingDbContextModelSnapshot.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GetIntoTeachingApi.Migrations
 {
@@ -15,16 +16,18 @@ namespace GetIntoTeachingApi.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "3.1.4");
+                .HasAnnotation("Npgsql:PostgresExtension:postgis", ",,")
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .HasAnnotation("ProductVersion", "3.1.4")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("GetIntoTeachingApi.Models.Location", b =>
                 {
                     b.Property<string>("Postcode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Point>("Coordinate")
-                        .HasColumnType("POINT")
-                        .HasAnnotation("Sqlite:Srid", 4326);
+                        .HasColumnType("geography");
 
                     b.HasKey("Postcode");
 
@@ -34,13 +37,13 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.PrivacyPolicy", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -50,25 +53,25 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TeachingEvent", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("BuildingId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("EndAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("StartAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp without time zone");
 
                     b.Property<int>("TypeId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -80,29 +83,28 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TeachingEventBuilding", b =>
                 {
                     b.Property<Guid?>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AddressCity")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine1")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine2")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressLine3")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressPostcode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AddressState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Point>("Coordinate")
-                        .HasColumnType("POINT")
-                        .HasAnnotation("Sqlite:Srid", 4326);
+                        .HasColumnType("geography");
 
                     b.HasKey("Id");
 
@@ -112,16 +114,16 @@ namespace GetIntoTeachingApi.Migrations
             modelBuilder.Entity("GetIntoTeachingApi.Models.TypeEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EntityName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AttributeName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Value")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id", "EntityName", "AttributeName");
 

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.RegularExpressions;
 using NetTopologySuite.Geometries;
 
@@ -8,6 +9,7 @@ namespace GetIntoTeachingApi.Models
     {
         [Key]
         public string Postcode { get; set; }
+        [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }
 
         public static string SanitizePostcode(string postcode)

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -22,6 +23,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField(Name = "msevtmgt_postalcode")]
         public string AddressPostcode { get; set; }
         [JsonIgnore]
+        [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }
 
         public TeachingEventBuilding() : base() { }


### PR DESCRIPTION
The migrations were mixing SQLite (used for dev/test) and Postgres configuration options. This PR separates them depending on the active provider and re-generates the migrations from scratch.

Enables the Postgis extension that is needed for running the spatial queries in Postgres.

Re-instates the geography column type; I had removed this in a previous PR believing it to be unsupported by Postgres, but it is actually compatible.