### PR TITLE
Ensure Postgres provider is ran at design-time

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Utils;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Npgsql;
@@ -24,6 +25,17 @@ namespace GetIntoTeachingApi.Database
 
         public static string HangfireConnectionString() => 
             GenerateConnectionString(Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME"));
+
+        public static void ConfigPostgres(DbContextOptionsBuilder builder)
+        {
+            builder.UseNpgsql(DbConfiguration.DatabaseConnectionString(), x => x.UseNetTopologySuite());
+        }
+
+        public static void ConfigSqLite(DbContextOptionsBuilder builder, SqliteConnection keepAliveConnection)
+        {
+            keepAliveConnection.Open();
+            builder.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite());
+        }
 
         public void Configure()
         {

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace GetIntoTeachingApi.Database
+{
+    public class GetIntoTeachingDbContextFactory : IDesignTimeDbContextFactory<GetIntoTeachingDbContext>
+    {
+        public GetIntoTeachingDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
+
+            DbConfiguration.ConfigPostgres(optionsBuilder);
+
+            return new GetIntoTeachingDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -20,7 +20,6 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 
 namespace GetIntoTeachingApi
 {
@@ -50,14 +49,11 @@ namespace GetIntoTeachingApi
             if (Env.IsDevelopment)
             {
                 var keepAliveConnection = new SqliteConnection("DataSource=:memory:");
-                keepAliveConnection.Open();
-                services.AddDbContext<GetIntoTeachingDbContext>(options => 
-                    options.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite()));
+                services.AddDbContext<GetIntoTeachingDbContext>(builder => DbConfiguration.ConfigSqLite(builder, keepAliveConnection));
             }
             else
             {
-                services.AddDbContext<GetIntoTeachingDbContext>(options =>
-                    options.UseNpgsql(DbConfiguration.DatabaseConnectionString(), x => x.UseNetTopologySuite()));
+                services.AddDbContext<GetIntoTeachingDbContext>(DbConfiguration.ConfigPostgres);
             }
 
             services.AddAuthorization(options =>

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -7,20 +7,20 @@ namespace GetIntoTeachingApiTests.Helpers
 {
     public abstract class DatabaseTests : IDisposable
     {
-        private readonly SqliteConnection _connection;
+        private readonly SqliteConnection _keepAliveConnection;
         protected readonly GetIntoTeachingDbContext DbContext;
 
         protected DatabaseTests()
         {
-            _connection = new SqliteConnection("DataSource=:memory:");
-            _connection.Open();
+            _keepAliveConnection = new SqliteConnection("DataSource=:memory:");
 
-            var options = new DbContextOptionsBuilder<GetIntoTeachingDbContext>()
-                .UseSqlite(_connection, x => x.UseNetTopologySuite()).Options;
-            DbContext = new GetIntoTeachingDbContext(options);
+            var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
+            DbConfiguration.ConfigSqLite(builder, _keepAliveConnection);
+
+            DbContext = new GetIntoTeachingDbContext(builder.Options);
             new DbConfiguration(DbContext).Configure();
         }
 
-        public void Dispose() => _connection.Dispose();
+        public void Dispose() => _keepAliveConnection.Dispose();
     }
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ DATABASE_INSTANCE_NAME=****
 HANGFIRE_INSTANCE_NAME=****
 ```
 
-The Postgres connections (for Hangfire and our database) are setup in `appsettings.json` and not used in development (they are replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:
+The Postgres connections (for Hangfire and our database) are setup dynamically from the `VCAP_SERVICES` environment variable provided by GOV.UK PaaS and not used in development (they are replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:
 
 ```
 cf conduit get-into-teaching-api-dev-pg-svc
@@ -102,9 +102,9 @@ The Hangfire web dashboard can be accessed at `/hangfire` in development.
 
 ### Database
 
-We run Entity Framework Core in order to persist some models/data to a Postgres database. Currently this is being used to store and query the UK postcode geolocation information that is used when searching for events within a given radius of another postcode.
+We run Entity Framework Core in order to persist models/data to a Postgres database.
 
-Migrations are applied from code when the application starts (see `DbConfiguration.cs`). You can add a migration by modifying the models and running `dotnet ef migrations add MyNewMigration`.
+Migrations are applied from code when the application starts (see `DbConfiguration.cs`). You can add a migration by modifying the models and running `Add-Migration MyNewMigration` from the package manager console. As we run SQLite in development and Postgres in production we need to tell EF Core which provider to use at design-time; the `GetIntoTeachingDbContextFactory` takes care of this.
 
 ### Deployment
 


### PR DESCRIPTION
The SQLite provider was being ran at design-time by default, causing the migrations to not work in production. This PR adds a DbContext factory that will be used at design-time to load the Postgres provider, avoiding any future issues.