### PR TITLE
Split location sync into multiple jobs

### DIFF
--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using GetIntoTeachingApi.Database;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Location = GetIntoTeachingApi.Models.Location;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class LocationBatchJob : BaseJob
+    {
+        private readonly GetIntoTeachingDbContext _dbContext;
+
+        public LocationBatchJob(GetIntoTeachingDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task RunAsync(string batchJson)
+        {
+            var batchLocations = JsonConvert.DeserializeObject<List<ExpandoObject>>(
+                    batchJson, new ExpandoObjectConverter()).Select(l => (dynamic) l).ToList();
+            var batchPostcodes = batchLocations.Select(l => l.Postcode);
+            var existingPostcodes = await _dbContext.Locations
+                .Where(l => batchPostcodes.Contains(l.Postcode))
+                .Select(l => l.Postcode)
+                .ToListAsync();
+            var newBatchLocations = batchLocations.Where(l => !existingPostcodes.Contains(l.Postcode));
+
+            await _dbContext.Locations.AddRangeAsync(newBatchLocations.Select(CreateLocation));
+            await _dbContext.SaveChangesAsync();
+        }
+
+        private static Location CreateLocation(dynamic location)
+        {
+            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
+            var coordinate = geometryFactory.CreatePoint(new Coordinate(location.Longitude, location.Latitude));
+
+            return new Location() { Postcode = location.Postcode, Coordinate = coordinate };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApiTests.Helpers;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using Newtonsoft.Json;
+using Xunit;
+using Location = GetIntoTeachingApi.Models.Location;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class LocationBatchJobTests : DatabaseTests
+    {
+        private readonly LocationBatchJob _job;
+
+        public LocationBatchJobTests()
+        {
+            _job = new LocationBatchJob(DbContext);
+        }
+
+        [Fact]
+        public async void RunAsync_InsertsNewLocations()
+        {
+            var batch = new List<dynamic>
+            {
+                new { Postcode = "ky119yu", Latitude = 56.02748, Longitude = -3.35870 },
+                new { Postcode = "ca48le", Latitude = 54.89014, Longitude = -2.84000 },
+                new { Postcode = "ky62nj", Latitude = 56.182790, Longitude = -3.178240 },
+                new { Postcode = "kw14yl", Latitude = 58.64102, Longitude = -3.10075 },
+                new { Postcode = "tr182ab", Latitude = 50.12279, Longitude = -5.53987 },
+            };
+
+            await _job.RunAsync(JsonConvert.SerializeObject(batch));
+            await _job.RunAsync(JsonConvert.SerializeObject(batch));
+
+            DbContext.Locations.Count().Should().Be(batch.Count());
+            DbContext.Locations.ToList().All(l => 
+                batch.Any(b => BatchLocationMatchesExistingLocation(b, l))).Should().BeTrue();
+        }
+
+        private static bool BatchLocationMatchesExistingLocation(dynamic batchLocation, Location existingLocation)
+        {
+            var postcodeMatch = batchLocation.Postcode == existingLocation.Postcode;
+            var batchCoordinate = Coordinate(batchLocation.Latitude, batchLocation.Longitude);
+            var coordinateMatch = batchCoordinate == existingLocation.Coordinate;
+
+            return postcodeMatch && coordinateMatch;
+        }
+
+        private static Point Coordinate(double latitude, double longitude)
+        {
+            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
+            var coordinate = new Coordinate(longitude, latitude);
+
+            return geometryFactory.CreatePoint(coordinate);
+        }
+    }
+}


### PR DESCRIPTION
Currently all 1.7 million postcodes are inserted into our database in a single job; this takes longer than 30 minutes, which is the Hangfire job timeout and as a result the job never finishes. This PR splits this job into multiple, smaller jobs where each worker inserts 100 postcodes into the database (this results in around 17,000 individual jobs running with some parallelisation - testing this locally it takes 2-3 minutes to do a full sync of all postcodes).

The 100 postcodes with geolocation data are serialised with the job at the moment; it may be better to store that data elsewhere in the future and just pass a reference to the postcodes to the job.