### PR TITLE
Add support for Task-based asynchronous pattern

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -1,0 +1,23 @@
+﻿using GetIntoTeachingApi.Utils;
+using Microsoft.PowerPlatform.Cds.Client;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public class CdsServiceClientWrapper
+    {
+        public readonly CdsServiceClient CdsServiceClient;
+
+        public CdsServiceClientWrapper(IEnv env)
+        {
+            CdsServiceClient = new CdsServiceClient(ConnectionString(env));
+        }
+
+        private static string ConnectionString(IEnv env)
+        {
+            var instanceUrl = env.CrmServiceUrl;
+            var clientId = env.CrmClientId;
+            var clientSecret = env.CrmClientSecret;
+            return $"AuthType=ClientSecret; url={instanceUrl}; ClientId={clientId}; ClientSecret={clientSecret}";
+        }
+    }
+}

--- a/GetIntoTeachingApi/Adapters/INotificationClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/INotificationClientAdapter.cs
@@ -5,6 +5,6 @@ namespace GetIntoTeachingApi.Adapters
 {
     public interface INotificationClientAdapter
     {
-        public Task SendEmailAsync(string apiKey, string email, string templateId, Dictionary<string, dynamic> personalisation);
+        Task SendEmailAsync(string apiKey, string email, string templateId, Dictionary<string, dynamic> personalisation);
     }
 }

--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -10,15 +10,15 @@ namespace GetIntoTeachingApi.Adapters
 {
     public interface IOrganizationServiceAdapter
     {
-        public IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
-        public IEnumerable<Entity> RetrieveMultiple(QueryBase query);
-        public void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
-        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
-        public IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
-        public OrganizationServiceContext Context();
-        public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
-        public Entity NewEntity(string entityName, OrganizationServiceContext context);
-        public void SaveChanges(OrganizationServiceContext context);
-        public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
+        IEnumerable<Entity> RetrieveMultiple(QueryBase query);
+        void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
+        IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
+        IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
+        OrganizationServiceContext Context();
+        Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
+        Entity NewEntity(string entityName, OrganizationServiceContext context);
+        void SaveChanges(OrganizationServiceContext context);
+        void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -11,11 +11,11 @@ namespace GetIntoTeachingApi.Adapters
     public interface IOrganizationServiceAdapter
     {
         public IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
-        public IEnumerable<Entity> RetrieveMultiple(string connectionString, QueryBase query);
+        public IEnumerable<Entity> RetrieveMultiple(QueryBase query);
         public void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
-        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string connectionString, string entityName, string attributeName);
+        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
         public IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
-        public OrganizationServiceContext Context(string connectionString);
+        public OrganizationServiceContext Context();
         public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
         public Entity NewEntity(string entityName, OrganizationServiceContext context);
         public void SaveChanges(OrganizationServiceContext context);

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -56,7 +56,8 @@ that can then be used for verification.",
 
             var token = _tokenService.GenerateToken(request);
             var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
-            _notifyService.SendEmail(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
+            // We respond immediately/assume this will be successful.
+            _notifyService.SendEmailAsync(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Models;
+﻿using System.Threading.Tasks;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -29,9 +30,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Privacy Policies" }
         )]
         [ProducesResponseType(typeof(PrivacyPolicy), 200)]
-        public IActionResult GetLatest()
+        public async Task<IActionResult> GetLatest()
         {
-            var privacyPolicy = _store.GetLatestPrivacyPolicy();
+            var privacyPolicy = await _store.GetLatestPrivacyPolicyAsync();
             return Ok(privacyPolicy);
         }
     }

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -30,10 +32,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetCountries()
+        public async Task<IActionResult> GetCountries()
         {
-            var countries = _store.GetLookupItems("dfe_country");
-            return Ok(countries);
+            return Ok(await _store.GetLookupItems("dfe_country").ToListAsync());
         }
 
         [HttpGet]
@@ -44,10 +45,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetTeachingSubjects()
+        public async Task<IActionResult> GetTeachingSubjects()
         {
-            var subjects = _store.GetLookupItems("dfe_teachingsubjectlist");
-            return Ok(subjects);
+            return Ok(await _store.GetLookupItems("dfe_teachingsubjectlist").ToListAsync());
         }
 
         [HttpGet]
@@ -58,10 +58,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetCandidateInitialTeacherTrainingYears()
+        public async Task<IActionResult> GetCandidateInitialTeacherTrainingYears()
         {
-            var years = _store.GetPickListItems("contact", "dfe_ittyear");
-            return Ok(years);
+            return Ok(await _store.GetPickListItems("contact", "dfe_ittyear").ToListAsync());
         }
 
         [HttpGet]
@@ -72,10 +71,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetCandidatePreferredEducationPhases()
+        public async Task<IActionResult> GetCandidatePreferredEducationPhases()
         {
-            var educationPhases = _store.GetPickListItems("contact", "dfe_preferrededucationphase01");
-            return Ok(educationPhases);
+            return Ok(await _store.GetPickListItems("contact", "dfe_preferrededucationphase01").ToListAsync());
         }
 
         [HttpGet]
@@ -86,10 +84,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetCandidateLocations()
+        public async Task<IActionResult> GetCandidateLocations()
         {
-            var locations = _store.GetPickListItems("contact", "dfe_isinuk");
-            return Ok(locations);
+            return Ok(await _store.GetPickListItems("contact", "dfe_isinuk").ToListAsync());
         }
 
         [HttpGet]
@@ -100,10 +97,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetCandidateChannels()
+        public async Task<IActionResult> GetCandidateChannels()
         {
-            var channels = _store.GetPickListItems("contact", "dfe_channelcreation");
-            return Ok(channels);
+            return Ok(await _store.GetPickListItems("contact", "dfe_channelcreation").ToListAsync());
         }
 
         [HttpGet]
@@ -114,10 +110,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetQualificationDegreeStatus()
+        public async Task<IActionResult> GetQualificationDegreeStatus()
         {
-            var status = _store.GetPickListItems("dfe_qualification", "dfe_degreestatus");
-            return Ok(status);
+            return Ok(await _store.GetPickListItems("dfe_qualification", "dfe_degreestatus").ToListAsync());
         }
 
         [HttpGet]
@@ -128,10 +123,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetQualificationCategories()
+        public async Task<IActionResult> GetQualificationCategories()
         {
-            var categories = _store.GetPickListItems("dfe_qualification", "dfe_category");
-            return Ok(categories);
+            return Ok(await _store.GetPickListItems("dfe_qualification", "dfe_category").ToListAsync());
         }
 
         [HttpGet]
@@ -142,10 +136,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetQualificationTypes()
+        public async Task<IActionResult> GetQualificationTypes()
         {
-            var types = _store.GetPickListItems("dfe_qualification", "dfe_type");
-            return Ok(types);
+            return Ok(await _store.GetPickListItems("dfe_qualification", "dfe_type").ToListAsync());
         }
 
         [HttpGet]
@@ -156,10 +149,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetPastTeachingPositionEducationPhases()
+        public async Task<IActionResult> GetPastTeachingPositionEducationPhases()
         {
-            var educationPhases = _store.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase");
-            return Ok(educationPhases);
+            return Ok(await _store.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase").ToListAsync());
         }
 
         [HttpGet]
@@ -170,10 +162,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetTeachingEventTypes()
+        public async Task<IActionResult> GetTeachingEventTypes()
         {
-            var eventTypes = _store.GetPickListItems("msevtmgt_event", "dfe_event_type");
-            return Ok(eventTypes);
+            return Ok(await _store.GetPickListItems("msevtmgt_event", "dfe_event_type").ToListAsync());
         }
 
         [HttpGet]
@@ -184,10 +175,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Types" }
         )]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public IActionResult GetPhoneCallChannels()
+        public async Task<IActionResult> GetPhoneCallChannels()
         {
-            var channels = _store.GetPickListItems("phonecall", "dfe_channelcreation");
-            return Ok(channels);
+            return Ok(await _store.GetPickListItems("phonecall", "dfe_channelcreation").ToListAsync());
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -26,7 +26,8 @@ namespace GetIntoTeachingApi.Jobs
             if (IsLastAttempt(context, _contextAdapter))
             {
                 var personalisation = new Dictionary<string, dynamic>();
-                _notifyService.SendEmail(candidate.Email, NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
+                // We fire and forget the email, ensuring the job succeeds.
+                _notifyService.SendEmailAsync(candidate.Email, NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
             }
             else
                 _crm.Save(candidate);

--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Services;
+﻿using System.Threading.Tasks;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -13,9 +14,9 @@ namespace GetIntoTeachingApi.Jobs
             _store = store;
         }
 
-        public void Run()
+        public async Task RunAsync()
         {
-            _store.Sync(_crm);
+            await _store.SyncAsync(_crm);
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -44,7 +44,8 @@ namespace GetIntoTeachingApi.Jobs
 
         private void NotifyAttendeeOfFailure(ExistingCandidateRequest attendee)
         {
-            _notifyService.SendEmail(
+            // We fire and forget the email, ensuring the job succeeds.
+            _notifyService.SendEmailAsync(
                 attendee.Email,
                 NotifyService.TeachingEventRegistrationFailedTemplateId,
                 new Dictionary<string, dynamic>());

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Services
         // (VerificationWindow * StepsInSeconds) + Remaining Seconds in Current Step
         public static readonly int VerificationWindow = 2;
         public static readonly int StepInSeconds = 30;
-        private static readonly int Length = 6;
+        private const int Length = 6;
         private readonly IEnv _env;
 
         public CandidateAccessTokenService(IEnv env)

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
-using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -15,14 +14,12 @@ namespace GetIntoTeachingApi.Services
         public enum PrivacyPolicyType { Web = 222750001 }
 
         private readonly IOrganizationServiceAdapter _service;
-        private readonly IEnv _env;
         private const int MaximumNumberOfCandidatesToMatch = 20;
         private const int MaximumNumberOfPrivacyPolicies = 3;
 
-        public CrmService(IOrganizationServiceAdapter service, IEnv env)
+        public CrmService(IOrganizationServiceAdapter service)
         {
             _service = service;
-            _env = env;
         }
 
         public IEnumerable<TypeEntity> GetLookupItems(string entityName)
@@ -32,7 +29,7 @@ namespace GetIntoTeachingApi.Services
 
         public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName)
         {
-            return _service.GetPickListItemsForAttribute(ConnectionString(), entityName, attributeName)
+            return _service.GetPickListItemsForAttribute(entityName, attributeName)
                 .Select((pickListItem) => new TypeEntity(pickListItem, entityName, attributeName));
         }
 
@@ -132,22 +129,14 @@ namespace GetIntoTeachingApi.Services
             link.Columns.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEventBuilding)));
             link.EntityAlias = "msevtmgt_event_building";
 
-            var entities = _service.RetrieveMultiple(ConnectionString(), query);
+            var entities = _service.RetrieveMultiple(query);
 
             return entities.Select((entity) => new TeachingEvent(entity, this)).ToList();
         }
 
         private OrganizationServiceContext Context()
         {
-            return _service.Context(ConnectionString());
-        }
-
-        private string ConnectionString()
-        {
-            var instanceUrl = _env.CrmServiceUrl;
-            var clientId = _env.CrmClientId;
-            var clientSecret = _env.CrmClientSecret;
-            return $"AuthType=ClientSecret; url={instanceUrl}; ClientId={clientId}; ClientSecret={clientSecret}";
+            return _service.Context();
         }
     }
 }

--- a/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
@@ -5,8 +5,8 @@ namespace GetIntoTeachingApi.Services
 {
     public interface ICandidateAccessTokenService
     {
-        public string GenerateToken(ExistingCandidateRequest request);
-        public bool IsValid(string token, ExistingCandidateRequest request, DateTime timestamp);
-        public bool IsValid(string token, ExistingCandidateRequest request);
+        string GenerateToken(ExistingCandidateRequest request);
+        bool IsValid(string token, ExistingCandidateRequest request, DateTime timestamp);
+        bool IsValid(string token, ExistingCandidateRequest request);
     }
 }

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -8,16 +8,16 @@ namespace GetIntoTeachingApi.Services
 {
     public interface ICrmService
     {
-        public IEnumerable<TypeEntity> GetLookupItems(string entityName);
-        public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
-        public IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
-        public Candidate GetCandidate(ExistingCandidateRequest request);
-        public IEnumerable<TeachingEvent> GetTeachingEvents();
-        public bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
-        public bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
-        public void Save(BaseModel model);
-        public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
-        public IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName, string logicalName);
-        public Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
+        IEnumerable<TypeEntity> GetLookupItems(string entityName);
+        IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
+        IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
+        Candidate GetCandidate(ExistingCandidateRequest request);
+        IEnumerable<TeachingEvent> GetTeachingEvents();
+        bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId); 
+        bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
+        void Save(BaseModel model);
+        void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName, string logicalName);
+        Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Services/INotifyService.cs
+++ b/GetIntoTeachingApi/Services/INotifyService.cs
@@ -5,6 +5,6 @@ namespace GetIntoTeachingApi.Services
 {
     public interface INotifyService
     {
-        public Task SendEmail(string email, string templateId, Dictionary<string, dynamic> personalisation);
+        public Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation);
     }
 }

--- a/GetIntoTeachingApi/Services/INotifyService.cs
+++ b/GetIntoTeachingApi/Services/INotifyService.cs
@@ -5,6 +5,6 @@ namespace GetIntoTeachingApi.Services
 {
     public interface INotifyService
     {
-        public Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation);
+        Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation);
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -8,7 +8,7 @@ namespace GetIntoTeachingApi.Services
 {
     public interface IStore
     {
-        void Sync(ICrmService crm);
+        Task SyncAsync(ICrmService crm);
         IQueryable<TypeEntity> GetLookupItems(string entityName);
         IQueryable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GetIntoTeachingApi.Models;
 
 namespace GetIntoTeachingApi.Services
@@ -7,10 +8,10 @@ namespace GetIntoTeachingApi.Services
     public interface IStore
     {
         void Sync(ICrmService crm);
-        public IEnumerable<TypeEntity> GetLookupItems(string entityName);
-        public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
-        public PrivacyPolicy GetLatestPrivacyPolicy();
-        public IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
+        IQueryable<TypeEntity> GetLookupItems(string entityName);
+        IQueryable<TypeEntity> GetPickListItems(string entityName, string attributeName);
+        PrivacyPolicy GetLatestPrivacyPolicy();
+        IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         IEnumerable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
         IEnumerable<TeachingEvent> SearchTeachingEvents(TeachingEventSearchRequest request);
         TeachingEvent GetTeachingEvent(Guid id);

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -11,8 +11,8 @@ namespace GetIntoTeachingApi.Services
         void Sync(ICrmService crm);
         IQueryable<TypeEntity> GetLookupItems(string entityName);
         IQueryable<TypeEntity> GetPickListItems(string entityName, string attributeName);
-        PrivacyPolicy GetLatestPrivacyPolicy();
-        IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
+        Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();
+        IQueryable<PrivacyPolicy> GetPrivacyPolicies();
         IQueryable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GetIntoTeachingApi.Models;
 
 namespace GetIntoTeachingApi.Services
@@ -12,9 +13,9 @@ namespace GetIntoTeachingApi.Services
         IQueryable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         PrivacyPolicy GetLatestPrivacyPolicy();
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
-        IEnumerable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
-        IEnumerable<TeachingEvent> SearchTeachingEvents(TeachingEventSearchRequest request);
-        TeachingEvent GetTeachingEvent(Guid id);
+        IQueryable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
+        Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
+        Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         bool IsValidPostcode(string postcode);
     }
 }

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -23,7 +23,7 @@ namespace GetIntoTeachingApi.Services
             _env = env;
         }
 
-        public Task SendEmail(string email, string templateId, Dictionary<string, dynamic> personalisation)
+        public Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation)
         {
             return _client.SendEmailAsync(
                 ApiKey(),

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -31,12 +31,12 @@ namespace GetIntoTeachingApi.Services
             SyncTypeEntities(crm);
         }
 
-        public IEnumerable<TypeEntity> GetLookupItems(string entityName)
+        public IQueryable<TypeEntity> GetLookupItems(string entityName)
         {
             return _dbContext.TypeEntities.Where(t => t.EntityName == entityName);
         }
 
-        public IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName)
+        public IQueryable<TypeEntity> GetPickListItems(string entityName, string attributeName)
         {
             return _dbContext.TypeEntities.Where(t => t.EntityName == entityName && t.AttributeName == attributeName);
         }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -42,12 +42,12 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TypeEntities.Where(t => t.EntityName == entityName && t.AttributeName == attributeName);
         }
 
-        public PrivacyPolicy GetLatestPrivacyPolicy()
+        public async Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync()
         {
-            return GetPrivacyPolicies().OrderByDescending(p => p.CreatedAt).FirstOrDefault();
+            return await GetPrivacyPolicies().OrderByDescending(p => p.CreatedAt).FirstOrDefaultAsync();
         }
 
-        public IEnumerable<PrivacyPolicy> GetPrivacyPolicies()
+        public IQueryable<PrivacyPolicy> GetPrivacyPolicies()
         {
             return _dbContext.PrivacyPolicies;
         }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -20,6 +20,8 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.Data.Sqlite;
+using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi
 {
@@ -35,16 +37,20 @@ namespace GetIntoTeachingApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<CdsServiceClientWrapper, CdsServiceClientWrapper>();
+            services.AddTransient<IOrganizationService>(sp => sp.GetService<CdsServiceClientWrapper>().CdsServiceClient.Clone());
+            services.AddTransient<IOrganizationServiceAdapter, OrganizationServiceAdapter>();
+            services.AddTransient<ICrmService, CrmService>();
+
+            services.AddScoped<IStore, Store>();
+            services.AddScoped<DbConfiguration, DbConfiguration>();
+
             services.AddSingleton<IAuthorizationHandler, SharedSecretHandler>();
             services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
-            services.AddSingleton<IOrganizationServiceAdapter, OrganizationServiceAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
-            services.AddScoped<ICrmService, CrmService>();
             services.AddSingleton<INotifyService, NotifyService>();
-            services.AddScoped<IStore, Store>();
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<IEnv, Env>();
-            services.AddScoped<DbConfiguration, DbConfiguration>();
 
             if (Env.IsDevelopment)
             {

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -20,7 +20,6 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.Data.Sqlite;
-using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -159,7 +159,7 @@ The GIT API aims to provide:
             app.UseAuthorization();
 
             // Configure recurring jobs.
-            RecurringJob.AddOrUpdate<CrmSyncJob>("crm-sync", (x) => x.Run(), Cron.Daily());
+            RecurringJob.AddOrUpdate<CrmSyncJob>("crm-sync", (x) => x.RunAsync(), Cron.Daily());
             RecurringJob.AddOrUpdate<LocationSyncJob>("location-sync", (x) => 
                 x.RunAsync("https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip"), Cron.Weekly());
 

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -2,13 +2,13 @@
 {
     public interface IEnv
     {
-        public string EnvironmentName { get; }
-        public string TotpSecretKey { get; }
-        public string VcapServices { get; }
-        public string CrmServiceUrl { get; }
-        public string CrmClientId { get; }
-        public string CrmClientSecret { get; }
-        public string NotifyApiKey { get; }
-        public string SharedSecret { get; }
+        string EnvironmentName { get; }
+        string TotpSecretKey { get; }
+        string VcapServices { get; }
+        string CrmServiceUrl { get; }
+        string CrmClientId { get; }
+        string CrmClientSecret { get; }
+        string NotifyApiKey { get; }
+        string SharedSecret { get; }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -59,7 +59,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             response.Should().BeOfType<NoContentResult>();
             _mockNotifyService.Verify(
-                mock => mock.SendEmail(
+                mock => mock.SendEmailAsync(
                     "email@address.com",
                     NotifyService.NewPinCodeEmailTemplateId,
                     It.Is<Dictionary<string, dynamic>>(personalisation => personalisation["pin_code"] as string == "123456")
@@ -77,7 +77,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             response.Should().BeOfType<NotFoundResult>();
             _mockNotifyService.Verify(mock => 
-                mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()), 
+                mock.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()), 
                 Times.Never()
             );
         }

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -31,12 +31,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetLatest_ReturnsLatestPrivacyPolicy()
+        public async void GetLatest_ReturnsLatestPrivacyPolicy()
         {
             var mockPolicy = MockPrivacyPolicy();
-            _mockStore.Setup(mock => mock.GetLatestPrivacyPolicy()).Returns(mockPolicy);
+            _mockStore.Setup(mock => mock.GetLatestPrivacyPolicyAsync()).ReturnsAsync(mockPolicy);
 
-            var response = _controller.GetLatest();
+            var response = await _controller.GetLatest();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().Be(mockPolicy);

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Controllers
@@ -31,155 +30,157 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetCountries_ReturnsAllCountries()
+        public async void GetCountries_ReturnsAllCountries()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetLookupItems("dfe_country")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetLookupItems("dfe_country")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetCountries();
+            var response = await _controller.GetCountries();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetTeachingSubjects_ReturnsAllSubjects()
+        public async void GetTeachingSubjects_ReturnsAllSubjects()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetTeachingSubjects();
+            var response = await _controller.GetTeachingSubjects();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetCandidateInitialTeacherTrainingYears_ReturnsAllYears()
+        public async void GetCandidateInitialTeacherTrainingYears_ReturnsAllYears()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetCandidateInitialTeacherTrainingYears();
+            var response = await _controller.GetCandidateInitialTeacherTrainingYears();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetCandidatePreferredEducationPhases_ReturnsAllPhases()
+        public async void GetCandidatePreferredEducationPhases_ReturnsAllPhases()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01"))
+                .Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetCandidatePreferredEducationPhases();
+            var response = await _controller.GetCandidatePreferredEducationPhases();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetCandidateLocations_ReturnsAllLocations()
+        public async void GetCandidateLocations_ReturnsAllLocations()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_isinuk")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_isinuk")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetCandidateLocations();
+            var response = await _controller.GetCandidateLocations();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetCandidateChannels_ReturnsAllChannels()
+        public async void GetCandidateChannels_ReturnsAllChannels()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetCandidateChannels();
+            var response = await _controller.GetCandidateChannels();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetQualificationDegreeStatus_ReturnsAllStatus()
+        public async void GetQualificationDegreeStatus_ReturnsAllStatus()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetQualificationDegreeStatus();
+            var response = await _controller.GetQualificationDegreeStatus();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetQualificationCategories_ReturnsAllCategories()
+        public async void GetQualificationCategories_ReturnsAllCategories()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_category")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_category")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetQualificationCategories();
+            var response = await _controller.GetQualificationCategories();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetQualificatioTypes_ReturnsAllTypes()
+        public async void GetQualificatioTypes_ReturnsAllTypes()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_type")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_type")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetQualificationTypes();
+            var response = await _controller.GetQualificationTypes();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetPastTeachingPositionEducationPhases_ReturnsAllPhases()
+        public async void GetPastTeachingPositionEducationPhases_ReturnsAllPhases()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"))
+                .Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetPastTeachingPositionEducationPhases();
+            var response = await _controller.GetPastTeachingPositionEducationPhases();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetTeachingEventTypes_ReturnsAllTypes()
+        public async void GetTeachingEventTypes_ReturnsAllTypes()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_event_type")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_event_type")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetTeachingEventTypes();
+            var response = await _controller.GetTeachingEventTypes();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
         [Fact]
-        public void GetPhoneCallChannels_ReturnsAllChannels()
+        public async void GetPhoneCallChannels_ReturnsAllChannels()
         {
             var mockEntities = MockTypeEntities();
-            _mockStore.Setup(mock => mock.GetPickListItems("phonecall", "dfe_channelcreation")).Returns(mockEntities);
+            _mockStore.Setup(mock => mock.GetPickListItems("phonecall", "dfe_channelcreation")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = _controller.GetPhoneCallChannels();
+            var response = await _controller.GetPhoneCallChannels();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockEntities);
+            ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
-        private static IEnumerable<TypeEntity> MockTypeEntities()
+        private static TypeEntity[] MockTypeEntities()
         {
-            return new []
+            return new[]
             {
-                new TypeEntity { Id = Guid.NewGuid().ToString(), Value = "Type 1" },
-                new TypeEntity { Id = Guid.NewGuid().ToString(), Value = "Type 2" },
+                new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 1"},
+                new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 2"},
             };
         }
     }

--- a/GetIntoTeachingApiTests/Helpers/QueryableExtensions.cs
+++ b/GetIntoTeachingApiTests/Helpers/QueryableExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public static class QueryableExtensions
+    {
+        public static IQueryable<T> AsAsyncQueryable<T>(this IEnumerable<T> input)
+        {
+            return new NotInDbSet<T>(input);
+        }
+    }
+
+    internal class NotInDbSet<T> : IQueryable<T>, IAsyncEnumerable<T>
+    {
+        private readonly List<T> _innerCollection;
+        public Type ElementType => typeof(T);
+        public Expression Expression => Expression.Empty();
+        public IQueryProvider Provider => new EnumerableQuery<T>(Expression);
+
+        public NotInDbSet(IEnumerable<T> innerCollection)
+        {
+            _innerCollection = innerCollection.ToList();
+        }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return new AsyncEnumerator(GetEnumerator());
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _innerCollection.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public class AsyncEnumerator : IAsyncEnumerator<T>
+        {
+            private readonly IEnumerator<T> _enumerator;
+            public AsyncEnumerator(IEnumerator<T> enumerator)
+            {
+                _enumerator = enumerator;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return new ValueTask();
+            }
+
+            public ValueTask<bool> MoveNextAsync()
+            {
+                return new ValueTask<bool>(_enumerator.MoveNext());
+            }
+
+            public T Current => _enumerator.Current;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
@@ -43,7 +43,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _job.Run(_candidate, null);
 
             _mockCrm.Verify(mock => mock.Save(_candidate), Times.Never);
-            _mockNotifyService.Verify(mock => mock.SendEmail(_candidate.Email, 
+            _mockNotifyService.Verify(mock => mock.SendEmailAsync(_candidate.Email, 
                 NotifyService.CandidateRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
         }
     }

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -19,11 +19,11 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_CallsSync()
+        public async void RunAsync_CallsSync()
         {
-            _job.Run();
+            await _job.RunAsync();
 
-            _mockStore.Verify(mock => mock.Sync(_mockCrm.Object), Times.Once);
+            _mockStore.Verify(mock => mock.SyncAsync(_mockCrm.Object), Times.Once);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _job.Run(_attendee, _teachingEventId, null);
 
             _mockCrm.Verify(mock => mock.Save(It.IsAny<TeachingEventRegistration>()), Times.Never);
-            _mockNotifyService.Verify(mock => mock.SendEmail(_attendee.Email,
+            _mockNotifyService.Verify(mock => mock.SendEmailAsync(_attendee.Email,
                 NotifyService.TeachingEventRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
         }
     }

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -8,7 +8,6 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
-using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Mocks;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
@@ -26,9 +25,8 @@ namespace GetIntoTeachingApiTests.Models
         public BaseModelTests()
         {
             _mockService = new Mock<IOrganizationServiceAdapter>();
-            _context = _mockService.Object.Context("mock-connection-string");
-            var mockEnv = new Mock<IEnv>();
-            _crm = new CrmService(_mockService.Object, mockEnv.Object);
+            _context = _mockService.Object.Context();
+            _crm = new CrmService(_mockService.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApiTests.Models
         public void ToEntity_WhenPrivacyPolicyAlreadyAccepted_DoesNotCreatePrivacyPolicyEntity()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context("mock-connection-string");
+            var context = mockService.Object.Context();
             var mockCrm = new Mock<ICrmService>();
 
             var candidate = new Candidate()
@@ -90,7 +90,7 @@ namespace GetIntoTeachingApiTests.Models
         public void ToEntity_WhenPrivacyPolicyIsNull_DoesNotCreatePrivacyPolicyEntity()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context("mock-connection-string");
+            var context = mockService.Object.Context();
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate()  { Id = Guid.NewGuid(), PrivacyPolicy = null };
             mockService.Setup(m => m.BlankExistingEntity("candidate", (Guid)candidate.Id, context))

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApiTests.Models
         public void ToEntity_WhenRegistrationAlreadyExistsForCandidate_ReturnsNull()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context("mock-connection-string");
+            var context = mockService.Object.Context();
             var mockCrm = new Mock<ICrmService>();
 
             var candidate = new Candidate() { Id = Guid.NewGuid() };

--- a/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -28,10 +29,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             _mockStore
                 .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
-                .Returns(new[] { mockSubject });
+                .Returns(new[] { mockSubject }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"))
-                .Returns(new[] { mockPhase });
+                .Returns(new[] { mockPhase }.AsQueryable());
 
             var position = new CandidatePastTeachingPosition
             {

--- a/GetIntoTeachingApiTests/Models/Validators/CandidatePrivacyPolicyValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidatePrivacyPolicyValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -27,7 +28,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             _mockStore
                 .Setup(mock => mock.GetPrivacyPolicies())
-                .Returns(new[] { mockPrivacyPolicy });
+                .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
 
             var policy = new CandidatePrivacyPolicy()
             {

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Validators;
@@ -28,13 +29,13 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             _mockStore
                 .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_category"))
-                .Returns(new[] { mockCategory });
+                .Returns(new[] { mockCategory }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_type"))
-                .Returns(new[] { mockType });
+                .Returns(new[] { mockType }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus"))
-                .Returns(new[] { mockDegreeStatus });
+                .Returns(new[] { mockDegreeStatus }.AsQueryable());
 
             var qualification = new CandidateQualification()
             {

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -32,19 +33,19 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             _mockStore
                 .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
-                .Returns(new[] { mockPreferredTeachingSubject });
+                .Returns(new[] { mockPreferredTeachingSubject }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01"))
-                .Returns(new[] { mockPreferredEducationPhase });
+                .Returns(new[] { mockPreferredEducationPhase }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_isinuk"))
-                .Returns(new[] { mockLocation });
+                .Returns(new[] { mockLocation }.AsQueryable());
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear"))
-                .Returns(new[] { mockInitialTeacherTrainingYear });
+                .Returns(new[] { mockInitialTeacherTrainingYear }.AsQueryable);
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
-                .Returns(new[] { mockChannel });
+                .Returns(new[] { mockChannel }.AsQueryable());
 
             var candidate = new Candidate()
             {

--- a/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -26,7 +27,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var mockChannel = new TypeEntity { Id = "123" };
             _mockStore
                 .Setup(mock => mock.GetPickListItems("phonecall", "dfe_channelcreation"))
-                .Returns(new[] { mockChannel });
+                .Returns(new[] { mockChannel }.AsQueryable());
 
             var phoneCall = new PhoneCall()
             {

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -27,7 +28,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             _mockStore
                 .Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_event_type"))
-                .Returns(new[] { mockType });
+                .Returns(new[] { mockType }.AsQueryable());
 
             _mockStore.Setup(mock => mock.IsValidPostcode("KY11 9HF")).Returns(true);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -7,7 +7,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Xunit;
@@ -17,7 +16,6 @@ namespace GetIntoTeachingApiTests.Services
 {
     public class CrmServiceTests
     {
-        private const string ConnectionString = "AuthType=ClientSecret; url=service_url; ClientId=client_id; ClientSecret=client_secret";
         private static readonly Guid JaneDoeGuid = new Guid("bf927e43-5650-44aa-859a-8297139b8ddd");
         private readonly Mock<IOrganizationServiceAdapter> _mockService;
         private readonly OrganizationServiceContext _context;
@@ -25,14 +23,10 @@ namespace GetIntoTeachingApiTests.Services
 
         public CrmServiceTests()
         {
-            var mockEnv = new Mock<IEnv>();
-            mockEnv.Setup(m => m.CrmServiceUrl).Returns("service_url");
-            mockEnv.Setup(m => m.CrmClientId).Returns("client_id");
-            mockEnv.Setup(m => m.CrmClientSecret).Returns("client_secret");
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _context = new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
-            _mockService.Setup(mock => mock.Context(ConnectionString)).Returns(_context);
-            _crm = new CrmService(_mockService.Object, mockEnv.Object);
+            _mockService.Setup(mock => mock.Context()).Returns(_context);
+            _crm = new CrmService(_mockService.Object);
         }
 
         [Fact]
@@ -54,7 +48,7 @@ namespace GetIntoTeachingApiTests.Services
         public void GetPickListItems_ReturnsAll()
         {
             var initialTeacherTrainingYears = MockInitialTeacherTrainingYears();
-            _mockService.Setup(mock => mock.GetPickListItemsForAttribute(ConnectionString, "contact", "dfe_ittyear"))
+            _mockService.Setup(mock => mock.GetPickListItemsForAttribute("contact", "dfe_ittyear"))
                 .Returns(initialTeacherTrainingYears);
 
             var result = _crm.GetPickListItems("contact", "dfe_ittyear").ToList();
@@ -68,7 +62,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void GetTeachingEvents_ReturnsAllTeachingEvents()
         {
-            _mockService.Setup(mock => mock.RetrieveMultiple(ConnectionString, It.Is<QueryExpression>(
+            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
                 q => q.EntityName == "msevtmgt_event"))).Returns(MockTeachingEvents());
 
             var result = _crm.GetTeachingEvents();

--- a/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
@@ -30,7 +30,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void SendEmail_SendsAnEmail()
         {
-            _service.SendEmail("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation);
+            _service.SendEmailAsync("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation);
 
             _mockNotificationClient.Verify(
                 mock => mock.SendEmailAsync(
@@ -54,7 +54,7 @@ namespace GetIntoTeachingApiTests.Services
                 )
             ).ThrowsAsync(new Exception("bang"));
 
-            _service.SendEmail("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation).Wait();
+            _service.SendEmailAsync("email@address.com", NotifyService.NewPinCodeEmailTemplateId, _personalisation).Wait();
 
             _mockLogger.VerifyWarningWasCalled("NotifyService - Failed to send email");
         }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -294,12 +294,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void SearchTeachingEvents_WithoutFilters_ReturnsAll()
+        public async void SearchTeachingEvents_WithoutFilters_ReturnsAll()
         {
             SeedMockTeachingEvents();
             var request = new TeachingEventSearchRequest() { };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(
                 new string[] { "Event 2", "Event 4", "Event 1", "Event 3", "Event 5", "Event 6" },
@@ -307,7 +307,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void SearchTeachingEvents_WithFilters_ReturnsMatching()
+        public async void SearchTeachingEvents_WithFilters_ReturnsMatching()
         {
             SeedMockLocations();
             SeedMockTeachingEvents();
@@ -320,7 +320,7 @@ namespace GetIntoTeachingApiTests.Services
                 StartBefore = DateTime.Now.AddDays(3)
             };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(
                 new string[] { "Event 2" },
@@ -328,60 +328,60 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void SearchTeachingEvents_FilteredByRadius_ReturnsMatching()
+        public async void SearchTeachingEvents_FilteredByRadius_ReturnsMatching()
         {
             SeedMockLocations();
             SeedMockTeachingEvents();
             var request = new TeachingEventSearchRequest() { Postcode = "KY6 2NJ", Radius = 15 };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 3" },
                 options => options.WithStrictOrdering());
         }
 
         [Fact]
-        public void SearchTeachingEvents_FilteredByType_ReturnsMatching()
+        public async void SearchTeachingEvents_FilteredByType_ReturnsMatching()
         {
             SeedMockLocations();
             SeedMockTeachingEvents();
             var request = new TeachingEventSearchRequest() { TypeId = 123 };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4" },
                 options => options.WithStrictOrdering());
         }
 
         [Fact]
-        public void SearchTeachingEvents_FilteredByStartAfter_ReturnsMatching()
+        public async void SearchTeachingEvents_FilteredByStartAfter_ReturnsMatching()
         {
             SeedMockTeachingEvents();
             var request = new TeachingEventSearchRequest() { StartAfter = DateTime.Now.AddDays(6) };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 3", "Event 5", "Event 6" },
                 options => options.WithStrictOrdering());
         }
 
         [Fact]
-        public void SearchTeachingEvents_FilteredByStartBefore_ReturnsMatching()
+        public async void SearchTeachingEvents_FilteredByStartBefore_ReturnsMatching()
         {
             SeedMockTeachingEvents();
             var request = new TeachingEventSearchRequest() { StartBefore = DateTime.Now.AddDays(6) };
 
-            var result = _store.SearchTeachingEvents(request);
+            var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4", "Event 1" },
                 options => options.WithStrictOrdering());
         }
 
         [Fact]
-        public void GetTeachingEvents_ReturnsMatchingEvent()
+        public async void GetTeachingEvents_ReturnsMatchingEvent()
         {
             SeedMockTeachingEvents();
-            var result = _store.GetTeachingEvent(FindEventGuid);
+            var result = await _store.GetTeachingEventAsync(FindEventGuid);
 
             result.Id.Should().Be(FindEventGuid);
         }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Models;
@@ -26,14 +27,14 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_WithFailure_RetainsExistingData()
+        public async void SyncAsync_WithFailure_RetainsExistingData()
         {
-            SeedMockPrivacyPolicies();
+            await SeedMockPrivacyPoliciesAsync();
             var countBefore = DbContext.PrivacyPolicies.Count();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPrivacyPolicies()).Throws<Exception>();
 
-            _store.Invoking(s => s.Sync(mockCrm.Object))
+            _store.Invoking(s => s.SyncAsync(mockCrm.Object))
                 .Should().Throw<Exception>();
 
             var countAfter = DbContext.PrivacyPolicies.Count();
@@ -42,13 +43,13 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_InsertsNewTeachingEvents()
+        public async void SyncAsync_InsertsNewTeachingEvents()
         {
             var mockTeachingEvents = MockTeachingEvents().ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(mockTeachingEvents);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var ids = DbContext.TeachingEvents.Select(te => te.Id);
             ids.Should().BeEquivalentTo(mockTeachingEvents.Select(te => te.Id));
@@ -57,9 +58,9 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_UpdatesExistingTeachingEvents()
+        public async void SyncAsync_UpdatesExistingTeachingEvents()
         {
-            var updatedTeachingEvents = SeedMockTeachingEvents().ToList();
+            var updatedTeachingEvents = (await SeedMockTeachingEventsAsync()).ToList();
             updatedTeachingEvents.ForEach(te =>
             {
                 te.Name += "Updated";
@@ -68,7 +69,7 @@ namespace GetIntoTeachingApiTests.Services
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(updatedTeachingEvents);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var teachingEvents = DbContext.TeachingEvents.Include(te => te.Building).ToList();
             teachingEvents.Select(te => te.Name).ToList().ForEach(name => name.Should().Contain("Updated"));
@@ -79,13 +80,13 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_DeletesOrphanedTeachingEventsAndBuildings()
+        public async void SyncAsync_DeletesOrphanedTeachingEventsAndBuildings()
         {
-            var teachingEvents = SeedMockTeachingEvents().ToList();
+            var teachingEvents = (await SeedMockTeachingEventsAsync()).ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(teachingEvents.GetRange(0, 1));
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             DbContext.TeachingEvents.Should().BeEquivalentTo(teachingEvents.GetRange(0, 1));
             DbContext.TeachingEventBuildings.Should()
@@ -93,26 +94,26 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_PopulatesTeachingEventBuildingCoordinates()
+        public async void SyncAsync_PopulatesTeachingEventBuildingCoordinates()
         {
             SeedMockLocations();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(MockTeachingEvents);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var teachingEvent = DbContext.TeachingEvents.Include(te => te.Building).First(te => te.Id == FindEventGuid);
             teachingEvent.Building.Coordinate.Should().Be(new Point(new Coordinate(-3.3587, 56.02748)));
         }
 
         [Fact]
-        public void Sync_InsertsNewPrivacyPolicies()
+        public async void SyncAsync_InsertsNewPrivacyPolicies()
         {
             var mockPolicies = MockPrivacyPolicies().ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPrivacyPolicies()).Returns(mockPolicies);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var ids = DbContext.PrivacyPolicies.Select(p => p.Id);
             ids.Should().BeEquivalentTo(mockPolicies.Select(p => p.Id));
@@ -120,14 +121,14 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_UpdatesExistingPrivacyPolicies()
+        public async void SyncAsync_UpdatesExistingPrivacyPolicies()
         {
-            var updatedPolicies = SeedMockPrivacyPolicies().ToList();
+            var updatedPolicies = (await SeedMockPrivacyPoliciesAsync()).ToList();
             updatedPolicies.ForEach(te => te.Text += "Updated");
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPrivacyPolicies()).Returns(updatedPolicies);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var policies = DbContext.PrivacyPolicies.ToList();
             policies.Select(te => te.Text).ToList().ForEach(name => name.Should().Contain("Updated"));
@@ -135,26 +136,26 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_DeletesOrphanedPrivacyPolicies()
+        public async void SyncAsync_DeletesOrphanedPrivacyPolicies()
         {
-            var policies = SeedMockPrivacyPolicies().ToList();
+            var policies = (await SeedMockPrivacyPoliciesAsync()).ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPrivacyPolicies()).Returns(policies.GetRange(0, 2));
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var remainingPolicies = DbContext.PrivacyPolicies.ToArray();
             remainingPolicies.Should().BeEquivalentTo(policies.GetRange(0, 2));
         }
 
         [Fact]
-        public void Sync_InsertsNewLookupItems()
+        public async void SyncAsync_InsertsNewLookupItems()
         {
             var mockCountries = MockCountries().ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetLookupItems("dfe_country")).Returns(mockCountries);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var ids = DbContext.TypeEntities.Select(e => e.Id);
             ids.Should().BeEquivalentTo(mockCountries.Select(e => e.Id));
@@ -162,14 +163,14 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_UpdatesExistingLookupItems()
+        public async void SyncAsync_UpdatesExistingLookupItems()
         {
-            var updatedCountries = SeedMockCountries().ToList();
+            var updatedCountries = (await SeedMockCountriesAsync()).ToList();
             updatedCountries.ForEach(c => c.Value += "Updated");
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetLookupItems("dfe_country")).Returns(updatedCountries);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var countries = DbContext.TypeEntities.ToList();
             countries.Select(c => c.Value).ToList().ForEach(value => value.Should().Contain("Updated"));
@@ -177,26 +178,26 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_DeletesOrphanedLookupItems()
+        public async void SyncAsync_DeletesOrphanedLookupItems()
         {
-            var countries = SeedMockCountries().ToList();
+            var countries = (await SeedMockCountriesAsync()).ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetLookupItems("dfe_country")).Returns(countries.GetRange(0, 2));
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var remainingCountries = DbContext.TypeEntities.Where(te => te.EntityName == "dfe_country").ToArray();
             remainingCountries.Should().BeEquivalentTo(countries.GetRange(0, 2));
         }
 
         [Fact]
-        public void Sync_InsertsNewPickListItems()
+        public async void SyncAsync_InsertsNewPickListItems()
         {
             var mockYears = MockInitialTeacherTrainingYears().ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_ittyear")).Returns(mockYears);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var ids = DbContext.TypeEntities.Select(e => e.Id);
             ids.Should().BeEquivalentTo(mockYears.Select(e => e.Id));
@@ -204,14 +205,14 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_UpdatesExistingPickListItems()
+        public async void Sync_UpdatesExistingPickListItems()
         {
-            var updatedYears = SeedMockInitialTeacherTrainingYears().ToList();
+            var updatedYears = (await SeedMockInitialTeacherTrainingYearsAsync()).ToList();
             updatedYears.ForEach(c => c.Value += "Updated");
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_ittyear")).Returns(updatedYears);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var countries = DbContext.TypeEntities.ToList();
             countries.Select(c => c.Value).ToList().ForEach(value => value.Should().Contain("Updated"));
@@ -219,13 +220,13 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_DeletesOrphanedPickListItems()
+        public async void SyncAsync_DeletesOrphanedPickListItems()
         {
-            var years = SeedMockInitialTeacherTrainingYears().ToList();
+            var years = (await SeedMockInitialTeacherTrainingYearsAsync()).ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_ittyear")).Returns(years.GetRange(0, 2));
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             var remainingCountries = DbContext.TypeEntities
                 .Where(te => te.EntityName == "contact" && te.AttributeName == "dfe_ittyear").ToArray();
@@ -233,11 +234,11 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Sync_SyncsAllTypeEntities()
+        public async void SyncAsync_SyncsAllTypeEntities()
         {
             var mockCrm = new Mock<ICrmService>();
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             mockCrm.Verify(m => m.GetLookupItems("dfe_country"));
             mockCrm.Verify(m => m.GetLookupItems("dfe_teachingsubjectlist"));
@@ -254,9 +255,9 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetLookupItems_ReturnsMatching()
+        public async void GetLookupItems_ReturnsMatching()
         {
-            SeedMockCountries();
+            await SeedMockCountriesAsync();
 
             var result = _store.GetLookupItems("dfe_country");
 
@@ -264,9 +265,9 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetPickListItems_ReturnsMatching()
+        public async void GetPickListItems_ReturnsMatching()
         {
-            SeedMockInitialTeacherTrainingYears();
+            await SeedMockInitialTeacherTrainingYearsAsync();
 
             var result = _store.GetPickListItems("contact", "dfe_ittyear");
 
@@ -274,9 +275,9 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetPrivacyPolicies_ReturnsAll()
+        public async void GetPrivacyPolicies_ReturnsAll()
         {
-            SeedMockPrivacyPolicies();
+            await SeedMockPrivacyPoliciesAsync();
 
             var result = _store.GetPrivacyPolicies();
 
@@ -286,7 +287,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void GetLatestPrivacyPolicy_ReturnsMostRecent()
         {
-            SeedMockPrivacyPolicies();
+            await SeedMockPrivacyPoliciesAsync();
 
             var result = await _store.GetLatestPrivacyPolicyAsync();
 
@@ -296,7 +297,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_WithoutFilters_ReturnsAll()
         {
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest() { };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -310,7 +311,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_WithFilters_ReturnsMatching()
         {
             SeedMockLocations();
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest()
             {
                 Postcode = "KY6 2NJ", 
@@ -331,7 +332,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByRadius_ReturnsMatching()
         {
             SeedMockLocations();
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest() { Postcode = "KY6 2NJ", Radius = 15 };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -344,7 +345,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByType_ReturnsMatching()
         {
             SeedMockLocations();
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest() { TypeId = 123 };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -356,7 +357,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_FilteredByStartAfter_ReturnsMatching()
         {
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest() { StartAfter = DateTime.Now.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -368,7 +369,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_FilteredByStartBefore_ReturnsMatching()
         {
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var request = new TeachingEventSearchRequest() { StartBefore = DateTime.Now.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -380,16 +381,16 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void GetTeachingEvents_ReturnsMatchingEvent()
         {
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var result = await _store.GetTeachingEventAsync(FindEventGuid);
 
             result.Id.Should().Be(FindEventGuid);
         }
 
         [Fact]
-        public void GetUpcomingTeachingEvents_ReturnsUpcomingEventsInOrder()
+        public async void GetUpcomingTeachingEvents_ReturnsUpcomingEventsInOrder()
         {
-            SeedMockTeachingEvents();
+            await SeedMockTeachingEventsAsync();
             var result = _store.GetUpcomingTeachingEvents(3);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] {"Event 2", "Event 4", "Event 1"},
@@ -498,14 +499,14 @@ namespace GetIntoTeachingApiTests.Services
             return new TeachingEvent[] { event1, event2, event3, event4, event5, event6 };
         }
 
-        private IEnumerable<TeachingEvent> SeedMockTeachingEvents()
+        private async Task<IEnumerable<TeachingEvent>> SeedMockTeachingEventsAsync()
         {
             var teachingEvents = MockTeachingEvents().ToList();
             var mockCrm = new Mock<ICrmService>();
 
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(teachingEvents);
             
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             return teachingEvents;
         }
@@ -519,14 +520,14 @@ namespace GetIntoTeachingApiTests.Services
             return new PrivacyPolicy[] { policy1, policy2, policy3 };
         }
 
-        private IEnumerable<PrivacyPolicy> SeedMockPrivacyPolicies()
+        private async Task<IEnumerable<PrivacyPolicy>> SeedMockPrivacyPoliciesAsync()
         {
             var privacyPolicies = MockPrivacyPolicies().ToList();
             var mockCrm = new Mock<ICrmService>();
 
             mockCrm.Setup(m => m.GetPrivacyPolicies()).Returns(privacyPolicies);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             return privacyPolicies;
         }
@@ -540,14 +541,14 @@ namespace GetIntoTeachingApiTests.Services
             return new TypeEntity[] { country1, country2, country3 };
         }
 
-        private IEnumerable<TypeEntity> SeedMockCountries()
+        private async Task<IEnumerable<TypeEntity>> SeedMockCountriesAsync()
         {
             var types = MockCountries().ToList();
             var mockCrm = new Mock<ICrmService>();
 
             mockCrm.Setup(m => m.GetLookupItems("dfe_country")).Returns(types);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             return types;
         }
@@ -561,14 +562,14 @@ namespace GetIntoTeachingApiTests.Services
             return new TypeEntity[] { year1, year2, year3 };
         }
 
-        private IEnumerable<TypeEntity> SeedMockInitialTeacherTrainingYears()
+        private async Task<IEnumerable<TypeEntity>> SeedMockInitialTeacherTrainingYearsAsync()
         {
             var types = MockInitialTeacherTrainingYears().ToList();
             var mockCrm = new Mock<ICrmService>();
 
             mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_ittyear")).Returns(types);
 
-            _store.Sync(mockCrm.Object);
+            await _store.SyncAsync(mockCrm.Object);
 
             return types;
         }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -284,11 +284,11 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetLatestPrivacyPolicy_ReturnsMostRecent()
+        public async void GetLatestPrivacyPolicy_ReturnsMostRecent()
         {
             SeedMockPrivacyPolicies();
 
-            var result = _store.GetLatestPrivacyPolicy();
+            var result = await _store.GetLatestPrivacyPolicyAsync();
 
             result.Text.Should().Be("Policy 2");
         }


### PR DESCRIPTION
- Make store interactions utilise async/await for better throughput.
- Register CdsClientService as transient/cloned

The CdsServiceClient is not asynchronous and there is overhead in creating a new instance (as it will go off and authenticate then download the Dynamics metadata each time its created). To ensure that we can handle multiple async requests hitting the CRM this PR registers a singleton CdsServiceClient that we then clone as a transient dependency.
