### PR TITLE
Improve logging throughout API

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -13,25 +13,29 @@ namespace GetIntoTeachingApi.Auth
     public class SharedSecretHandler : AuthenticationHandler<SharedSecretSchemeOptions>
     {
         private readonly IEnv _env;
+        private readonly ILogger<SharedSecretHandler> _logger;
 
-        public SharedSecretHandler(IEnv env, IOptionsMonitor<SharedSecretSchemeOptions> options, ILoggerFactory logger,
-            UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+        public SharedSecretHandler(IEnv env, IOptionsMonitor<SharedSecretSchemeOptions> options, ILoggerFactory loggerFactory,
+            UrlEncoder encoder, ISystemClock clock) : base(options, loggerFactory, encoder, clock)
         {
             _env = env;
+            _logger = loggerFactory.CreateLogger<SharedSecretHandler>();
         }
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
             if (!Request.Headers.ContainsKey("Authorization"))
             {
-                return Task.FromResult(AuthenticateResult.Fail("Authorization header not set."));
+                _logger.LogWarning("SharedSecretHandler - Authorization header not set");
+                return Task.FromResult(AuthenticateResult.Fail("Authorization header not set"));
             }
 
             var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
 
             if (token != _env.SharedSecret)
             {
-                return Task.FromResult(AuthenticateResult.Fail("Token is not valid."));
+                _logger.LogWarning("SharedSecretHandler - Token is not valid");
+                return Task.FromResult(AuthenticateResult.Fail("Token is not valid"));
             }
 
             var claims = new[] { new Claim("token", token) };

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -13,19 +13,16 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class CandidatesController : ControllerBase
     {
-        private readonly ILogger<CandidatesController> _logger;
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly INotifyService _notifyService;
         private readonly ICrmService _crm;
 
         public CandidatesController(
-            ILogger<CandidatesController> logger,
             ICandidateAccessTokenService tokenService,
             INotifyService notifyService,
             ICrmService crm
         )
         {
-            _logger = logger;
             _tokenService = tokenService;
             _notifyService = notifyService;
             _crm = crm;

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,7 +1,6 @@
 ﻿using GetIntoTeachingApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System;
 using System.Collections.Generic;
@@ -13,13 +12,6 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class MailingListController : ControllerBase
     {
-        private readonly ILogger<MailingListController> _logger;
-
-        public MailingListController(ILogger<MailingListController> logger)
-        {
-            _logger = logger;
-        }
-
         [HttpPost]
         [Route("members")]
         [SwaggerOperation(

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -13,12 +13,10 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class PrivacyPoliciesController : ControllerBase
     {
-        private readonly ILogger<PrivacyPoliciesController> _logger;
         private readonly IStore _store;
 
-        public PrivacyPoliciesController(ILogger<PrivacyPoliciesController> logger, IStore store)
+        public PrivacyPoliciesController(IStore store)
         {
-            _logger = logger;
             _store = store;
         }
 

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -15,19 +15,16 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
     [Authorize]
     public class CandidatesController : ControllerBase
     {
-        private readonly ILogger<CandidatesController> _logger;
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly ICrmService _crm;
         private readonly IBackgroundJobClient _jobClient;
 
         public CandidatesController(
-            ILogger<CandidatesController> logger, 
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             IBackgroundJobClient jobClient
         )
         {
-            _logger = logger;
             _crm = crm;
             _tokenService = tokenService;
             _jobClient = jobClient;

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -19,14 +19,11 @@ namespace GetIntoTeachingApi.Controllers
     public class TeachingEventsController : ControllerBase
     {
         private const int MaximumUpcomingRequests = 50;
-        private readonly ILogger<TeachingEventsController> _logger;
         private readonly IStore _store;
         private readonly IBackgroundJobClient _jobClient;
 
-        public TeachingEventsController(ILogger<TeachingEventsController> logger, 
-            IStore store, IBackgroundJobClient jobClient)
+        public TeachingEventsController(IStore store, IBackgroundJobClient jobClient)
         {
-            _logger = logger;
             _store = store;
             _jobClient = jobClient;
         }

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -15,12 +15,10 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class TypesController : ControllerBase
     {
-        private readonly ILogger<TypesController> _logger;
         private readonly IStore _store;
 
-        public TypesController(ILogger<TypesController> logger, IStore store)
+        public TypesController(IStore store)
         {
-            _logger = logger;
             _store = store;
         }
 

--- a/GetIntoTeachingApi/Jobs/BaseJob.cs
+++ b/GetIntoTeachingApi/Jobs/BaseJob.cs
@@ -7,8 +7,18 @@ namespace GetIntoTeachingApi.Jobs
     {
         protected bool IsLastAttempt(PerformContext context, IPerformContextAdapter adapter)
         {
-            var retryCount = adapter.GetRetryCount(context);
-            return retryCount >= JobConfiguration.Attempts;
+            var currentAttempt = CurrentAttempt(context, adapter);
+            return currentAttempt >= JobConfiguration.Attempts;
+        }
+
+        protected int CurrentAttempt(PerformContext context, IPerformContextAdapter adapter)
+        {
+            return adapter.GetRetryCount(context) + 1;
+        }
+
+        protected string AttemptInfo(PerformContext context, IPerformContextAdapter adapter)
+        {
+            return $"{CurrentAttempt(context, adapter)}/{JobConfiguration.Attempts}";
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApi.Jobs
                 var personalisation = new Dictionary<string, dynamic>();
                 // We fire and forget the email, ensuring the job succeeds.
                 _notifyService.SendEmailAsync(candidate.Email, 
-                    NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
+                    NotifyService.CandidateRegistrationFailedEmailTemplateId, personalisation);
                 _logger.LogInformation("CandidateRegistrationJob - Deleted");
             }
             else

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Hangfire.Server;
+using Microsoft.Extensions.Logging;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -12,25 +12,34 @@ namespace GetIntoTeachingApi.Jobs
         private readonly ICrmService _crm;
         private readonly INotifyService _notifyService;
         private readonly IPerformContextAdapter _contextAdapter;
+        private readonly ILogger<CandidateRegistrationJob> _logger;
 
         public CandidateRegistrationJob(ICrmService crm, INotifyService notifyService,
-            IPerformContextAdapter contextAdapter)
+            IPerformContextAdapter contextAdapter, ILogger<CandidateRegistrationJob> logger)
         {
             _crm = crm;
             _notifyService = notifyService;
             _contextAdapter = contextAdapter;
+            _logger = logger;
         }
 
         public void Run(Candidate candidate, PerformContext context)
         {
+            _logger.LogInformation($"CandidateRegistrationJob - Started ({AttemptInfo(context, _contextAdapter)})");
+
             if (IsLastAttempt(context, _contextAdapter))
             {
                 var personalisation = new Dictionary<string, dynamic>();
                 // We fire and forget the email, ensuring the job succeeds.
-                _notifyService.SendEmailAsync(candidate.Email, NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
+                _notifyService.SendEmailAsync(candidate.Email, 
+                    NotifyService.CandidateRegistrationFailedTemplateId, personalisation);
+                _logger.LogInformation("CandidateRegistrationJob - Deleted");
             }
             else
+            {
                 _crm.Save(candidate);
+                _logger.LogInformation("CandidateRegistrationJob - Succeeded");
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using GetIntoTeachingApi.Services;
+using Microsoft.Extensions.Logging;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -7,16 +8,20 @@ namespace GetIntoTeachingApi.Jobs
     {
         private readonly ICrmService _crm;
         private readonly IStore _store;
+        private readonly ILogger<CrmSyncJob> _logger;
 
-        public CrmSyncJob(ICrmService crm, IStore store)
+        public CrmSyncJob(ICrmService crm, IStore store, ILogger<CrmSyncJob> logger)
         {
             _crm = crm;
             _store = store;
+            _logger = logger;
         }
 
         public async Task RunAsync()
         {
+            _logger.LogInformation("CrmSyncJob - Started");
             await _store.SyncAsync(_crm);
+            _logger.LogInformation("CrmSyncJob - Succeeded");
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -4,6 +4,7 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Hangfire.Server;
+using Microsoft.Extensions.Logging;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -12,21 +13,31 @@ namespace GetIntoTeachingApi.Jobs
         private readonly ICrmService _crm;
         private readonly INotifyService _notifyService;
         private readonly IPerformContextAdapter _contextAdapter;
+        private readonly ILogger<TeachingEventRegistrationJob> _logger;
 
         public TeachingEventRegistrationJob(ICrmService crm, INotifyService notifyService,
-            IPerformContextAdapter contextAdapter)
+            IPerformContextAdapter contextAdapter, ILogger<TeachingEventRegistrationJob> logger)
         {
             _crm = crm;
+            _logger = logger;
             _notifyService = notifyService;
             _contextAdapter = contextAdapter;
         }
 
         public void Run(ExistingCandidateRequest attendee, Guid teachingEventId, PerformContext context)
         {
+            _logger.LogInformation($"TeachingEventRegistrationJob - Started ({AttemptInfo(context, _contextAdapter)})");
+
             if (IsLastAttempt(context, _contextAdapter))
+            {
                 NotifyAttendeeOfFailure(attendee);
+                _logger.LogInformation("TeachingEventRegistrationJob - Deleted");
+            }
             else
+            {
                 RegisterAttendeeForEvent(attendee, teachingEventId);
+                _logger.LogInformation("TeachingEventRegistrationJob - Succeeded");
+            }
         }
 
         private void RegisterAttendeeForEvent(ExistingCandidateRequest attendee, Guid teachingEventId)

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApi.Jobs
             // We fire and forget the email, ensuring the job succeeds.
             _notifyService.SendEmailAsync(
                 attendee.Email,
-                NotifyService.TeachingEventRegistrationFailedTemplateId,
+                NotifyService.TeachingEventRegistrationFailedEmailTemplateId,
                 new Dictionary<string, dynamic>());
         }
 

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -9,9 +9,9 @@ namespace GetIntoTeachingApi.Services
 {
     public class NotifyService : INotifyService
     {
-        public static readonly string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
-        public static readonly string CandidateRegistrationFailedTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
-        public static readonly string TeachingEventRegistrationFailedTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
+        public const string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
+        public const string CandidateRegistrationFailedEmailTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
+        public const string TeachingEventRegistrationFailedEmailTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
         private readonly ILogger<NotifyService> _logger;
         private readonly INotificationClientAdapter _client;
         private readonly IEnv _env;
@@ -25,6 +25,8 @@ namespace GetIntoTeachingApi.Services
 
         public Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation)
         {
+            _logger.LogInformation($"NotifyService - Sending Email ({TemplateDescription(templateId)})");
+
             return _client.SendEmailAsync(
                 ApiKey(),
                 email,
@@ -35,5 +37,16 @@ namespace GetIntoTeachingApi.Services
         }
 
         private string ApiKey() => _env.NotifyApiKey;
+
+        private static string TemplateDescription(string templateId)
+        {
+            return templateId switch
+            {
+                NewPinCodeEmailTemplateId => "NewPinCodeEmail",
+                CandidateRegistrationFailedEmailTemplateId => "CandidateRegistrationFailedEmail",
+                TeachingEventRegistrationFailedEmailTemplateId => "TeachingEventRegistrationFailedEmail",
+                _ => "UnknownTemplate",
+            };
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApi.Models;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
@@ -13,7 +12,6 @@ namespace GetIntoTeachingApiTests.Controllers
 {
     public class CandidatesControllerTests
     {
-        private readonly Mock<ILogger<CandidatesController>> _mockLogger;
         private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly Mock<ICrmService> _mockCrm;
@@ -21,11 +19,10 @@ namespace GetIntoTeachingApiTests.Controllers
 
         public CandidatesControllerTests()
         {
-            _mockLogger = new Mock<ILogger<CandidatesController>>();
             _mockTokenService = new Mock<ICandidateAccessTokenService>();
             _mockNotifyService = new Mock<INotifyService>();
             _mockCrm = new Mock<ICrmService>();
-            _controller = new CandidatesController(_mockLogger.Object, _mockTokenService.Object, _mockNotifyService.Object, _mockCrm.Object);
+            _controller = new CandidatesController(_mockTokenService.Object, _mockNotifyService.Object, _mockCrm.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Xunit;
 using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApi.Models;
-using Microsoft.Extensions.Logging;
-using Moq;
 using Microsoft.AspNetCore.Mvc;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
@@ -21,8 +19,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CreateCandidateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {
             var member = new ExistingCandidateRequest() { FirstName = null };
-            var mockLogger = new Mock<ILogger<MailingListController>>();
-            var controller = new MailingListController(mockLogger.Object);
+            var controller = new MailingListController();
             controller.ModelState.AddModelError("FirstName", "First name must be specified.");
 
             var response = controller.AddMember(member);

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -14,14 +14,12 @@ namespace GetIntoTeachingApiTests.Controllers
     public class PrivacyPoliciesControllerTests
     {
         private readonly Mock<IStore> _mockStore;
-        private readonly Mock<ILogger<PrivacyPoliciesController>> _mockLogger;
         private readonly PrivacyPoliciesController _controller;
 
         public PrivacyPoliciesControllerTests()
         {
             _mockStore = new Mock<IStore>();
-            _mockLogger = new Mock<ILogger<PrivacyPoliciesController>>();
-            _controller = new PrivacyPoliciesController(_mockLogger.Object, _mockStore.Object);
+            _controller = new PrivacyPoliciesController(_mockStore.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using Microsoft.Extensions.Logging;
 using Moq;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Controllers.TeacherTrainingAdviser;
@@ -29,8 +28,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
             _mockCrm = new Mock<ICrmService>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
-            var mockLogger = new Mock<ILogger<CandidatesController>>();
-            _controller = new CandidatesController(mockLogger.Object, _mockTokenService.Object, _mockCrm.Object, _mockJobClient.Object);
+            _controller = new CandidatesController(_mockTokenService.Object, _mockCrm.Object, _mockJobClient.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using GetIntoTeachingApi.Services;
@@ -25,11 +24,9 @@ namespace GetIntoTeachingApiTests.Controllers
 
         public TeachingEventsControllerTests()
         {
-            var mockLogger = new Mock<ILogger<TeachingEventsController>>();
             _mockStore = new Mock<IStore>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
-            _controller = new TeachingEventsController(mockLogger.Object, 
-                _mockStore.Object, _mockJobClient.Object);
+            _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -20,8 +20,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public TypesControllerTests()
         {
             _mockStore = new Mock<IStore>();
-            var mockLogger = new Mock<ILogger<TypesController>>();
-            _controller = new TypesController(mockLogger.Object, _mockStore.Object);
+            _controller = new TypesController(_mockStore.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
+++ b/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
@@ -6,13 +6,23 @@ namespace GetIntoTeachingApiTests.Helpers
 {
     public static class LoggerTestHelpers
     {
+        public static Mock<ILogger<T>> VerifyInformationWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
+        {
+            return VerifyCalled(logger, LogLevel.Information, expectedMessage);
+        }
+
         public static Mock<ILogger<T>> VerifyWarningWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
         {
-            Func<object, Type, bool> state = (v, t) =>  v.ToString().Contains(expectedMessage);
+            return VerifyCalled(logger, LogLevel.Warning, expectedMessage);
+        }
+
+        private static Mock<ILogger<T>> VerifyCalled<T>(this Mock<ILogger<T>> logger, LogLevel expectedLogLevel, string expectedMessage)
+        {
+            Func<object, Type, bool> state = (v, t) => v.ToString().Contains(expectedMessage);
 
             logger.Verify(
                 mock => mock.Log(
-                    It.Is<LogLevel>(logLevel => logLevel == LogLevel.Warning),
+                    It.Is<LogLevel>(logLevel => logLevel == expectedLogLevel),
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => state(v, t)),
                     It.IsAny<Exception>(),

--- a/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
@@ -51,7 +51,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockCrm.Verify(mock => mock.Save(_candidate), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_candidate.Email, 
-                NotifyService.CandidateRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+                NotifyService.CandidateRegistrationFailedEmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
             _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Deleted");
         }

--- a/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
@@ -3,6 +3,8 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -15,14 +17,17 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly Candidate _candidate;
         private readonly CandidateRegistrationJob _job;
+        private readonly Mock<ILogger<CandidateRegistrationJob>> _mockLogger;
 
         public CandidateRegistrationJobTests()
         {
             _mockContext = new Mock<IPerformContextAdapter>();
             _mockCrm = new Mock<ICrmService>();
             _mockNotifyService = new Mock<INotifyService>();
+            _mockLogger = new Mock<ILogger<CandidateRegistrationJob>>();
             _candidate = new Candidate() { Email = "test@test.com" };
-            _job = new CandidateRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, _mockContext.Object);
+            _job = new CandidateRegistrationJob(_mockCrm.Object, _mockNotifyService.Object,
+                _mockContext.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -33,18 +38,22 @@ namespace GetIntoTeachingApiTests.Jobs
             _job.Run(_candidate, null);
 
             _mockCrm.Verify(mock => mock.Save(_candidate), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Succeeded");
         }
 
         [Fact]
         public void Run_OnFailure_EmailsCandidate()
         {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts - 1);
 
             _job.Run(_candidate, null);
 
             _mockCrm.Verify(mock => mock.Save(_candidate), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_candidate.Email, 
                 NotifyService.CandidateRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+            _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Started (24/24)");
+            _mockLogger.VerifyInformationWasCalled("CandidateRegistrationJob - Deleted");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -1,5 +1,7 @@
 ﻿using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -9,13 +11,15 @@ namespace GetIntoTeachingApiTests.Jobs
     {
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IStore> _mockStore;
+        private readonly Mock<ILogger<CrmSyncJob>> _mockLogger;
         private readonly CrmSyncJob _job;
 
         public CrmSyncJobTests()
         {
             _mockCrm = new Mock<ICrmService>();
+            _mockLogger = new Mock<ILogger<CrmSyncJob>>();
             _mockStore = new Mock<IStore>();
-            _job = new CrmSyncJob(_mockCrm.Object, _mockStore.Object);
+            _job = new CrmSyncJob(_mockCrm.Object, _mockStore.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -24,6 +28,8 @@ namespace GetIntoTeachingApiTests.Jobs
             await _job.RunAsync();
 
             _mockStore.Verify(mock => mock.SyncAsync(_mockCrm.Object), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("CrmSyncJob - Started");
+            _mockLogger.VerifyInformationWasCalled("CrmSyncJob - Succeeded");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -4,6 +4,8 @@ using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Newtonsoft.Json;
@@ -15,10 +17,12 @@ namespace GetIntoTeachingApiTests.Jobs
     public class LocationBatchJobTests : DatabaseTests
     {
         private readonly LocationBatchJob _job;
+        private readonly Mock<ILogger<LocationBatchJob>> _mockLogger;
 
         public LocationBatchJobTests()
         {
-            _job = new LocationBatchJob(DbContext);
+            _mockLogger = new Mock<ILogger<LocationBatchJob>>();
+            _job = new LocationBatchJob(DbContext, _mockLogger.Object);
         }
 
         [Fact]
@@ -39,6 +43,9 @@ namespace GetIntoTeachingApiTests.Jobs
             DbContext.Locations.Count().Should().Be(batch.Count());
             DbContext.Locations.ToList().All(l => 
                 batch.Any(b => BatchLocationMatchesExistingLocation(b, l))).Should().BeTrue();
+
+            _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Started");
+            _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Succeeded");
         }
 
         private static bool BatchLocationMatchesExistingLocation(dynamic batchLocation, Location existingLocation)

--- a/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
@@ -76,7 +76,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockCrm.Verify(mock => mock.Save(It.IsAny<TeachingEventRegistration>()), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_attendee.Email,
-                NotifyService.TeachingEventRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+                NotifyService.TeachingEventRegistrationFailedEmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
             _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Deleted");
         }

--- a/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using Castle.Core.Logging;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -14,6 +17,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<IPerformContextAdapter> _mockContext;
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly Mock<ILogger<TeachingEventRegistrationJob>> _mockLogger;
         private readonly ExistingCandidateRequest _attendee;
         private readonly Guid _teachingEventId;
         private readonly TeachingEventRegistrationJob _job;
@@ -24,8 +28,10 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm = new Mock<ICrmService>();
             _mockNotifyService = new Mock<INotifyService>();
             _teachingEventId = Guid.NewGuid();
+            _mockLogger = new Mock<ILogger<TeachingEventRegistrationJob>>();
             _attendee = new ExistingCandidateRequest() { Email = "test@test.com", FirstName = "first", LastName = "last" };
-            _job = new TeachingEventRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, _mockContext.Object);
+            _job = new TeachingEventRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, 
+                _mockContext.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -40,6 +46,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(r =>
                 r.EventId == _teachingEventId &&
                 r.CandidateId == candidate.Id)), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Succeeded");
         }
 
         [Fact]
@@ -55,18 +63,22 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(r => 
                 r.EventId == _teachingEventId && 
                 r.CandidateId == candidateId)), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Succeeded");
         }
 
         [Fact]
         public void Run_OnFailure_EmailsCandidate()
         {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts - 1);
 
             _job.Run(_attendee, _teachingEventId, null);
 
             _mockCrm.Verify(mock => mock.Save(It.IsAny<TeachingEventRegistration>()), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_attendee.Email,
                 NotifyService.TeachingEventRegistrationFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Started (24/24)");
+            _mockLogger.VerifyInformationWasCalled("TeachingEventRegistrationJob - Deleted");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/NotifyServiceTests.cs
@@ -40,6 +40,8 @@ namespace GetIntoTeachingApiTests.Services
                     _personalisation
                 )
             );
+
+            _mockLogger.VerifyInformationWasCalled("NotifyService - Sending Email (NewPinCodeEmail)");
         }
 
         [Fact]


### PR DESCRIPTION
- Remove `ILogger` from controllers 

The controllers are very thin so there's no need to log anything; any bad request/validation errors etc will be findable by the route and HTTP status codes.

- Log warnings for authentication failures
- Log delayed job events
- Log when sending emails via GOV.UK Notify service