### PR TITLE
Run sync operations in series

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -27,14 +27,9 @@ namespace GetIntoTeachingApi.Services
 
         public async Task SyncAsync(ICrmService crm)
         {
-            var tasks = new []
-            {
-                SyncTeachingEvents(crm),
-                SyncPrivacyPolicies(crm), 
-                SyncTypeEntities(crm),
-            };
-
-            await Task.WhenAll(tasks);
+            await SyncTeachingEvents(crm);
+            await SyncPrivacyPolicies(crm);
+            await SyncTypeEntities(crm);
         }
 
         public IQueryable<TypeEntity> GetLookupItems(string entityName)


### PR DESCRIPTION
Previously I updated the sync methods to run in parallel for better performance, however this introduced an issue as the DbContext is shared across each method in the `Store` (multiple threads accessing the same context is not supported).

Change back to running the sync operations in series; it only takes about 10 seconds to do a full sync so performance isn't an issue.