### PR TITLE
Collect metrics and expose to Prometheus

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -20,15 +20,15 @@ namespace GetIntoTeachingApi.Database
             _dbContext = dbContext;
         }
 
-        public static string DatabaseConnectionString() => 
-            GenerateConnectionString(Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME"));
+        public static string DatabaseConnectionString(IEnv env) => 
+            GenerateConnectionString(env, env.DatabaseInstanceName);
 
-        public static string HangfireConnectionString() => 
-            GenerateConnectionString(Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME"));
+        public static string HangfireConnectionString(IEnv env) => 
+            GenerateConnectionString(env, env.HangfireInstanceName);
 
-        public static void ConfigPostgres(DbContextOptionsBuilder builder)
+        public static void ConfigPostgres(IEnv env, DbContextOptionsBuilder builder)
         {
-            builder.UseNpgsql(DbConfiguration.DatabaseConnectionString(), x => x.UseNetTopologySuite());
+            builder.UseNpgsql(DbConfiguration.DatabaseConnectionString(env), x => x.UseNetTopologySuite());
         }
 
         public static void ConfigSqLite(DbContextOptionsBuilder builder, SqliteConnection keepAliveConnection)
@@ -47,9 +47,9 @@ namespace GetIntoTeachingApi.Database
                 _dbContext.Database.EnsureCreated();
         }
 
-        private static string GenerateConnectionString(string instanceName)
+        private static string GenerateConnectionString(IEnv env, string instanceName)
         {
-            var vcap = JsonConvert.DeserializeObject<VcapServices>(new Env().VcapServices);
+            var vcap = JsonConvert.DeserializeObject<VcapServices>(env.VcapServices);
             var postgres = vcap.Postgres.First(p => p.InstanceName == instanceName);
 
             var builder = new NpgsqlConnectionStringBuilder

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
@@ -1,15 +1,23 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using GetIntoTeachingApi.Utils;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
 namespace GetIntoTeachingApi.Database
 {
     public class GetIntoTeachingDbContextFactory : IDesignTimeDbContextFactory<GetIntoTeachingDbContext>
     {
+        private readonly IEnv _env;
+
+        public GetIntoTeachingDbContextFactory(IEnv env)
+        {
+            _env = env;
+        }
+
         public GetIntoTeachingDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
 
-            DbConfiguration.ConfigPostgres(optionsBuilder);
+            DbConfiguration.ConfigPostgres(_env, optionsBuilder);
 
             return new GetIntoTeachingDbContext(optionsBuilder.Options);
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -31,6 +31,7 @@
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="3.1.4" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="3.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />

--- a/GetIntoTeachingApi/Jobs/BaseJob.cs
+++ b/GetIntoTeachingApi/Jobs/BaseJob.cs
@@ -1,14 +1,22 @@
 ﻿using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Utils;
 using Hangfire.Server;
 
 namespace GetIntoTeachingApi.Jobs
 {
     public abstract class BaseJob
     {
+        protected readonly IEnv Env;
+
+        protected BaseJob(IEnv env)
+        {
+            Env = env;
+        }
+
         protected bool IsLastAttempt(PerformContext context, IPerformContextAdapter adapter)
         {
             var currentAttempt = CurrentAttempt(context, adapter);
-            return currentAttempt >= JobConfiguration.Attempts;
+            return currentAttempt >= JobConfiguration.Attempts(Env);
         }
 
         protected int CurrentAttempt(PerformContext context, IPerformContextAdapter adapter)
@@ -18,7 +26,7 @@ namespace GetIntoTeachingApi.Jobs
 
         protected string AttemptInfo(PerformContext context, IPerformContextAdapter adapter)
         {
-            return $"{CurrentAttempt(context, adapter)}/{JobConfiguration.Attempts}";
+            return $"{CurrentAttempt(context, adapter)}/{JobConfiguration.Attempts(Env)}";
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -2,6 +2,7 @@
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire.Server;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +15,8 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IPerformContextAdapter _contextAdapter;
         private readonly ILogger<CandidateRegistrationJob> _logger;
 
-        public CandidateRegistrationJob(ICrmService crm, INotifyService notifyService,
-            IPerformContextAdapter contextAdapter, ILogger<CandidateRegistrationJob> logger)
+        public CandidateRegistrationJob(IEnv env, ICrmService crm, INotifyService notifyService,
+            IPerformContextAdapter contextAdapter, ILogger<CandidateRegistrationJob> logger) : base(env)
         {
             _crm = crm;
             _notifyService = notifyService;

--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Microsoft.Extensions.Logging;
 using Prometheus;
 
@@ -12,7 +13,8 @@ namespace GetIntoTeachingApi.Jobs
         private readonly ILogger<CrmSyncJob> _logger;
         private readonly IMetricService _metrics;
 
-        public CrmSyncJob(ICrmService crm, IStore store, ILogger<CrmSyncJob> logger, IMetricService metrics)
+        public CrmSyncJob(IEnv env, ICrmService crm, IStore store, 
+            ILogger<CrmSyncJob> logger, IMetricService metrics) : base(env)
         {
             _crm = crm;
             _store = store;

--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using GetIntoTeachingApi.Services;
 using Microsoft.Extensions.Logging;
+using Prometheus;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -9,19 +10,24 @@ namespace GetIntoTeachingApi.Jobs
         private readonly ICrmService _crm;
         private readonly IStore _store;
         private readonly ILogger<CrmSyncJob> _logger;
+        private readonly IMetricService _metrics;
 
-        public CrmSyncJob(ICrmService crm, IStore store, ILogger<CrmSyncJob> logger)
+        public CrmSyncJob(ICrmService crm, IStore store, ILogger<CrmSyncJob> logger, IMetricService metrics)
         {
             _crm = crm;
             _store = store;
             _logger = logger;
+            _metrics = metrics;
         }
 
         public async Task RunAsync()
         {
-            _logger.LogInformation("CrmSyncJob - Started");
-            await _store.SyncAsync(_crm);
-            _logger.LogInformation("CrmSyncJob - Succeeded");
+            using (_metrics.CrmSyncDuration.NewTimer())
+            {
+                _logger.LogInformation("CrmSyncJob - Started");
+                await _store.SyncAsync(_crm);
+                _logger.LogInformation("CrmSyncJob - Succeeded");
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -5,8 +5,8 @@ namespace GetIntoTeachingApi.Jobs
 {
     public static class JobConfiguration
     {
-        public static int Attempts => Env.IsDevelopment ? 5 : 24;
-        public static int RetryIntervalInSeconds => Env.IsDevelopment ? 60 : 3600;
+        public static int Attempts => new Env().IsDevelopment ? 5 : 24;
+        public static int RetryIntervalInSeconds => new Env().IsDevelopment ? 60 : 3600;
         public static TimeSpan ExpirationTimeout => TimeSpan.FromHours(24);
     }
 }

--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -5,8 +5,8 @@ namespace GetIntoTeachingApi.Jobs
 {
     public static class JobConfiguration
     {
-        public static int Attempts => new Env().IsDevelopment ? 5 : 24;
-        public static int RetryIntervalInSeconds => new Env().IsDevelopment ? 60 : 3600;
+        public static int Attempts(IEnv env) => env.IsDevelopment ? 5 : 24;
+        public static int RetryIntervalInSeconds(IEnv env) => env.IsDevelopment ? 60 : 3600;
         public static TimeSpan ExpirationTimeout => TimeSpan.FromHours(24);
     }
 }

--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NetTopologySuite;
@@ -21,8 +22,8 @@ namespace GetIntoTeachingApi.Jobs
         private readonly ILogger<LocationBatchJob> _logger;
         private readonly IMetricService _metrics;
 
-        public LocationBatchJob(GetIntoTeachingDbContext dbContext, ILogger<LocationBatchJob> logger,
-            IMetricService metrics)
+        public LocationBatchJob(IEnv env, GetIntoTeachingDbContext dbContext, 
+            ILogger<LocationBatchJob> logger, IMetricService metrics) : base(env)
         {
             _dbContext = dbContext;
             _logger = logger;

--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -3,12 +3,14 @@ using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Prometheus;
 using Location = GetIntoTeachingApi.Models.Location;
 
 namespace GetIntoTeachingApi.Jobs
@@ -17,30 +19,36 @@ namespace GetIntoTeachingApi.Jobs
     {
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly ILogger<LocationBatchJob> _logger;
+        private readonly IMetricService _metrics;
 
-        public LocationBatchJob(GetIntoTeachingDbContext dbContext, ILogger<LocationBatchJob> logger)
+        public LocationBatchJob(GetIntoTeachingDbContext dbContext, ILogger<LocationBatchJob> logger,
+            IMetricService metrics)
         {
             _dbContext = dbContext;
             _logger = logger;
+            _metrics = metrics;
         }
 
         public async Task RunAsync(string batchJson)
         {
-            _logger.LogInformation($"LocationBatchJob - Started");
+            using (_metrics.LocationBatchDuration.NewTimer())
+            {
+                _logger.LogInformation($"LocationBatchJob - Started");
 
-            var batchLocations = JsonConvert.DeserializeObject<List<ExpandoObject>>(
+                var batchLocations = JsonConvert.DeserializeObject<List<ExpandoObject>>(
                     batchJson, new ExpandoObjectConverter()).Select(l => (dynamic) l).ToList();
-            var batchPostcodes = batchLocations.Select(l => l.Postcode);
-            var existingPostcodes = await _dbContext.Locations
-                .Where(l => batchPostcodes.Contains(l.Postcode))
-                .Select(l => l.Postcode)
-                .ToListAsync();
-            var newBatchLocations = batchLocations.Where(l => !existingPostcodes.Contains(l.Postcode));
+                var batchPostcodes = batchLocations.Select(l => l.Postcode);
+                var existingPostcodes = await _dbContext.Locations
+                    .Where(l => batchPostcodes.Contains(l.Postcode))
+                    .Select(l => l.Postcode)
+                    .ToListAsync();
+                var newBatchLocations = batchLocations.Where(l => !existingPostcodes.Contains(l.Postcode));
 
-            await _dbContext.Locations.AddRangeAsync(newBatchLocations.Select(CreateLocation));
-            await _dbContext.SaveChangesAsync();
+                await _dbContext.Locations.AddRangeAsync(newBatchLocations.Select(CreateLocation));
+                await _dbContext.SaveChangesAsync();
 
-            _logger.LogInformation($"LocationBatchJob - Succeeded");
+                _logger.LogInformation($"LocationBatchJob - Succeeded");
+            }
         }
 
         private static Location CreateLocation(dynamic location)

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -23,13 +23,15 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<LocationSyncJob> _logger;
         private readonly IMetricService _metrics;
+        private readonly IEnv _env;
 
         public LocationSyncJob(IBackgroundJobClient jobClient, ILogger<LocationSyncJob> logger,
-            IMetricService metrics)
+            IMetricService metrics, IEnv env)
         {
             _logger = logger;
             _jobClient = jobClient;
             _metrics = metrics;
+            _env = env;
         }
 
         public async Task RunAsync(string ukPostcodeCsvUrl)
@@ -106,7 +108,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private async Task<string> RetrieveCsv(string ukPostcodeCsvUrl)
         {
-            if (Env.IsDevelopment)
+            if (_env.IsDevelopment)
                 return "./Fixtures/ukpostcodes.dev.csv";
 
             var zipPath = GetTempPath();
@@ -130,9 +132,9 @@ namespace GetIntoTeachingApi.Jobs
             return Path.Combine(csvPath, UkPostcodeCsvFilename);
         }
 
-        private static void DeleteCsv(string csvPath)
+        private void DeleteCsv(string csvPath)
         {
-            if (!Env.IsDevelopment)
+            if (!_env.IsDevelopment)
             {
                 File.Delete(csvPath);
             }

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -23,15 +23,13 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<LocationSyncJob> _logger;
         private readonly IMetricService _metrics;
-        private readonly IEnv _env;
 
-        public LocationSyncJob(IBackgroundJobClient jobClient, ILogger<LocationSyncJob> logger,
-            IMetricService metrics, IEnv env)
+        public LocationSyncJob(IEnv env, IBackgroundJobClient jobClient, 
+            ILogger<LocationSyncJob> logger, IMetricService metrics) : base(env)
         {
             _logger = logger;
             _jobClient = jobClient;
             _metrics = metrics;
-            _env = env;
         }
 
         public async Task RunAsync(string ukPostcodeCsvUrl)
@@ -108,7 +106,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private async Task<string> RetrieveCsv(string ukPostcodeCsvUrl)
         {
-            if (_env.IsDevelopment)
+            if (Env.IsDevelopment)
                 return "./Fixtures/ukpostcodes.dev.csv";
 
             var zipPath = GetTempPath();
@@ -134,7 +132,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private void DeleteCsv(string csvPath)
         {
-            if (!_env.IsDevelopment)
+            if (!Env.IsDevelopment)
             {
                 File.Delete(csvPath);
             }

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -7,10 +7,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using CsvHelper;
 using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Prometheus;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -20,30 +22,36 @@ namespace GetIntoTeachingApi.Jobs
         private const int BatchInterval = 100;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<LocationSyncJob> _logger;
+        private readonly IMetricService _metrics;
 
-        public LocationSyncJob(IBackgroundJobClient jobClient, ILogger<LocationSyncJob> logger)
+        public LocationSyncJob(IBackgroundJobClient jobClient, ILogger<LocationSyncJob> logger,
+            IMetricService metrics)
         {
             _logger = logger;
             _jobClient = jobClient;
+            _metrics = metrics;
         }
 
         public async Task RunAsync(string ukPostcodeCsvUrl)
         {
-            _logger.LogInformation($"LocationSyncJob - Started");
-
-            var csvPath = await RetrieveCsv(ukPostcodeCsvUrl);
-
-            try
+            using (_metrics.LocationSyncDuration.NewTimer())
             {
-                await SyncLocations(csvPath);
-            }
-            finally
-            {
-                DeleteCsv(csvPath);
-                _logger.LogInformation($"LocationSyncJob - CSV Deleted");
-            }
+                _logger.LogInformation($"LocationSyncJob - Started");
 
-            _logger.LogInformation($"LocationSyncJob - Succeeded");
+                var csvPath = await RetrieveCsv(ukPostcodeCsvUrl);
+
+                try
+                {
+                    await SyncLocations(csvPath);
+                }
+                finally
+                {
+                    DeleteCsv(csvPath);
+                    _logger.LogInformation($"LocationSyncJob - CSV Deleted");
+                }
+
+                _logger.LogInformation($"LocationSyncJob - Succeeded");
+            }
         }
 
         private async Task SyncLocations(string csvPath)

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire.Server;
 using Microsoft.Extensions.Logging;
 
@@ -15,8 +16,8 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IPerformContextAdapter _contextAdapter;
         private readonly ILogger<TeachingEventRegistrationJob> _logger;
 
-        public TeachingEventRegistrationJob(ICrmService crm, INotifyService notifyService,
-            IPerformContextAdapter contextAdapter, ILogger<TeachingEventRegistrationJob> logger)
+        public TeachingEventRegistrationJob(IEnv env, ICrmService crm, INotifyService notifyService,
+            IPerformContextAdapter contextAdapter, ILogger<TeachingEventRegistrationJob> logger) : base(env)
         {
             _crm = crm;
             _logger = logger;

--- a/GetIntoTeachingApi/Services/HangfirePrometheusExporter.cs
+++ b/GetIntoTeachingApi/Services/HangfirePrometheusExporter.cs
@@ -1,0 +1,68 @@
+﻿using Prometheus;
+using System;
+using Hangfire;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class HangfirePrometheusExporter : IHangfirePrometheusExporter
+    {
+        private readonly JobStorage _hangfireJobStorage;
+        private readonly IMetricService _metrics;
+        private const string RetrySetName = "retries";
+
+        public HangfirePrometheusExporter(JobStorage hangfireJobStorage, IMetricService metrics)
+        {
+            _hangfireJobStorage = hangfireJobStorage;
+            _metrics = metrics;
+        }
+
+        public void ExportHangfireStatistics()
+        {
+            try
+            {
+                var metric = _metrics.HangfireJobs;
+                var jobStatistics = GetJobStatistics();
+
+                metric.WithLabels("deleted").Set(jobStatistics.Deleted);
+                metric.WithLabels("failed").Set(jobStatistics.Failed);
+                metric.WithLabels("scheduled").Set(jobStatistics.Scheduled);
+                metric.WithLabels("processing").Set(jobStatistics.Processing);
+                metric.WithLabels("enqueued").Set(jobStatistics.Enqueued);
+                metric.WithLabels("succeeded").Set(jobStatistics.Succeeded);
+                metric.WithLabels("retry").Set(jobStatistics.Retry);
+            }
+            catch (Exception exception)
+            {
+                throw new ScrapeFailedException("HangfirePrometheusExporter - Scrape failed, inner exception:", exception);
+            }
+        }
+
+        private HangfireJobStatistics GetJobStatistics()
+        {
+            var hangfireStats = _hangfireJobStorage.GetMonitoringApi().GetStatistics();
+            long retryJobs = _hangfireJobStorage.GetConnection().GetAllItemsFromSet(RetrySetName).Count;
+
+            return new HangfireJobStatistics
+            {
+                Deleted = hangfireStats.Deleted,
+                Failed = hangfireStats.Failed,
+                Enqueued = hangfireStats.Enqueued,
+                Scheduled = hangfireStats.Scheduled,
+                Processing = hangfireStats.Processing,
+                Succeeded = hangfireStats.Succeeded,
+                Retry = retryJobs
+            };
+        }
+
+        internal class HangfireJobStatistics
+        {
+            public long Deleted { get; set; }
+            public long Enqueued { get; set; }
+            public long Scheduled { get; set; }
+            public long Processing { get; set; }
+            public long Succeeded { get; set; }
+            public long Failed { get; set; }
+            public long Retry { get; set; }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/IHangfirePrometheusExporter.cs
+++ b/GetIntoTeachingApi/Services/IHangfirePrometheusExporter.cs
@@ -1,0 +1,7 @@
+﻿namespace GetIntoTeachingApi.Services
+{
+    public interface IHangfirePrometheusExporter
+    {
+        void ExportHangfireStatistics();
+    }
+}

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -6,6 +6,7 @@ namespace GetIntoTeachingApi.Services
     {
         Histogram CrmSyncDuration { get; }
         Histogram LocationSyncDuration { get; }
+        Histogram LocationBatchDuration { get; }
         Gauge HangfireJobs { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -5,6 +5,7 @@ namespace GetIntoTeachingApi.Services
     public interface IMetricService
     {
         Histogram CrmSyncDuration { get; }
+        Histogram LocationSyncDuration { get; }
         Gauge HangfireJobs { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -3,7 +3,8 @@
 namespace GetIntoTeachingApi.Services
 {
     public interface IMetricService
-    { 
+    {
         Histogram CrmSyncDuration { get; }
+        Gauge HangfireJobs { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -1,0 +1,9 @@
+﻿using Prometheus;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface IMetricService
+    { 
+        Histogram CrmSyncDuration { get; }
+    }
+}

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -1,0 +1,12 @@
+﻿using Prometheus;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class MetricService : IMetricService
+    {
+        private static readonly Histogram _crmSyncDuration = Metrics
+            .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
+
+        public Histogram CrmSyncDuration => _crmSyncDuration;
+    }
+}

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -6,10 +6,13 @@ namespace GetIntoTeachingApi.Services
     {
         private static readonly Histogram _crmSyncDuration = Metrics
             .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
+        private static readonly Histogram _locationSyncDuration = Metrics
+            .CreateHistogram("api_location_sync_duration_seconds", "Histogram of location sync durations.");
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
+        public Histogram LocationSyncDuration => _locationSyncDuration;
         public Gauge HangfireJobs => _hangfireJobs;
     }
 }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -8,11 +8,14 @@ namespace GetIntoTeachingApi.Services
             .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
         private static readonly Histogram _locationSyncDuration = Metrics
             .CreateHistogram("api_location_sync_duration_seconds", "Histogram of location sync durations.");
+        private static readonly Histogram _locationBatchDuration = Metrics
+            .CreateHistogram("api_location_batch_duration_seconds", "Histogram of location batch processing durations.");
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
+        public Histogram LocationBatchDuration => _locationBatchDuration;
         public Gauge HangfireJobs => _hangfireJobs;
     }
 }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -6,7 +6,10 @@ namespace GetIntoTeachingApi.Services
     {
         private static readonly Histogram _crmSyncDuration = Metrics
             .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
+        private static readonly Gauge _hangfireJobs = Metrics
+            .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
+        public Gauge HangfireJobs => _hangfireJobs;
     }
 }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -156,7 +156,9 @@ The GIT API aims to provide:
             });
 
             app.UseRouting();
-            
+
+            app.UsePrometheusHangfireExporter();
+
             app.UseHttpMetrics();
 
             app.UseAuthorization();

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -16,6 +16,7 @@ using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.Data.Sqlite;
 using Microsoft.Xrm.Sdk;
@@ -43,6 +44,7 @@ namespace GetIntoTeachingApi
             services.AddScoped<IStore, Store>();
             services.AddScoped<DbConfiguration, DbConfiguration>();
 
+            services.AddSingleton<IMetricService, MetricService>();
             services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
             services.AddSingleton<INotifyService, NotifyService>();
@@ -121,7 +123,7 @@ The GIT API aims to provide:
                     .UseFilter(automaticRetry);
                 
                 if (Env.IsDevelopment)
-                    config.UsePostgreSqlStorage("User ID=postgres;Password=password;Host=localhost;Port=5432;Database=dev;");
+                    config.UseMemoryStorage().WithJobExpirationTimeout(JobConfiguration.ExpirationTimeout);
                 else
                     config.UsePostgreSqlStorage(DbConfiguration.HangfireConnectionString());
             });

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -19,6 +19,7 @@ using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.Data.Sqlite;
 using Microsoft.Xrm.Sdk;
+using Prometheus;
 
 namespace GetIntoTeachingApi
 {
@@ -140,8 +141,6 @@ The GIT API aims to provide:
 
             app.UseHttpsRedirection();
 
-            app.UseRouting();
-
             app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
                 Authorization = new[] { new HangfireDashboardAuthorizationFilter(new Env()) }
@@ -153,6 +152,10 @@ The GIT API aims to provide:
             {
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "Get into Teaching API V1");
             });
+
+            app.UseRouting();
+            
+            app.UseHttpMetrics();
 
             app.UseAuthorization();
 
@@ -177,6 +180,7 @@ The GIT API aims to provide:
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapMetrics(); 
                 endpoints.MapControllers();
             });
         }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -4,10 +4,12 @@ namespace GetIntoTeachingApi.Utils
 {
     public class Env : IEnv
     {
-        public bool IsDevelopment => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
-        public bool IsProduction => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Production";
-        public bool IsStaging => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Staging";
+        public bool IsDevelopment => EnvironmentName == "Development";
+        public bool IsProduction => EnvironmentName  == "Production";
+        public bool IsStaging => EnvironmentName == "Staging";
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
+        public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
+        public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
         public string EnvironmentName => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -4,10 +4,10 @@ namespace GetIntoTeachingApi.Utils
 {
     public class Env : IEnv
     {
-        public static bool IsDevelopment => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
-        public static bool IsProduction => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Production";
-        public static bool IsStaging => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Staging";
-
+        public bool IsDevelopment => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
+        public bool IsProduction => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Production";
+        public bool IsStaging => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Staging";
+        public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string EnvironmentName => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");

--- a/GetIntoTeachingApi/Utils/Extensions.cs
+++ b/GetIntoTeachingApi/Utils/Extensions.cs
@@ -1,0 +1,21 @@
+﻿using GetIntoTeachingApi.Services;
+using Hangfire;
+using Microsoft.AspNetCore.Builder;
+using Prometheus;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class Extensions
+    {
+        public static IApplicationBuilder UsePrometheusHangfireExporter(this IApplicationBuilder app)
+        {
+            var jobStorage = (JobStorage) app.ApplicationServices.GetService(typeof(JobStorage));
+            var metrics = (IMetricService) app.ApplicationServices.GetService(typeof(IMetricService));
+            var exporter = new HangfirePrometheusExporter(jobStorage, metrics);
+
+            Metrics.DefaultRegistry.AddBeforeCollectCallback(() => exporter.ExportHangfireStatistics());
+
+            return app;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -6,6 +6,8 @@
         bool IsStaging { get; }
         bool IsProduction { get; }
         bool ExportHangireToPrometheus { get; }
+        string DatabaseInstanceName { get; }
+        string HangfireInstanceName { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -2,6 +2,10 @@
 {
     public interface IEnv
     {
+        bool IsDevelopment { get; }
+        bool IsStaging { get; }
+        bool IsProduction { get; }
+        bool ExportHangireToPrometheus { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CandidateRegistrationJobTests.cs
@@ -3,6 +3,7 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -26,7 +27,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockNotifyService = new Mock<INotifyService>();
             _mockLogger = new Mock<ILogger<CandidateRegistrationJob>>();
             _candidate = new Candidate() { Email = "test@test.com" };
-            _job = new CandidateRegistrationJob(_mockCrm.Object, _mockNotifyService.Object,
+            _job = new CandidateRegistrationJob(new Env(), _mockCrm.Object, _mockNotifyService.Object,
                 _mockContext.Object, _mockLogger.Object);
         }
 
@@ -45,7 +46,7 @@ namespace GetIntoTeachingApiTests.Jobs
         [Fact]
         public void Run_OnFailure_EmailsCandidate()
         {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts - 1);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
 
             _job.Run(_candidate, null);
 

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -1,10 +1,10 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Prometheus;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Jobs
@@ -23,7 +23,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger = new Mock<ILogger<CrmSyncJob>>();
             _mockStore = new Mock<IStore>();
             _metrics = new MetricService();
-            _job = new CrmSyncJob(_mockCrm.Object, _mockStore.Object, _mockLogger.Object, _metrics);
+            _job = new CrmSyncJob(new Env(), _mockCrm.Object, _mockStore.Object, _mockLogger.Object, _metrics);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -1,8 +1,10 @@
-﻿using GetIntoTeachingApi.Jobs;
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Prometheus;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Jobs
@@ -12,6 +14,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IStore> _mockStore;
         private readonly Mock<ILogger<CrmSyncJob>> _mockLogger;
+        private readonly IMetricService _metrics;
         private readonly CrmSyncJob _job;
 
         public CrmSyncJobTests()
@@ -19,7 +22,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm = new Mock<ICrmService>();
             _mockLogger = new Mock<ILogger<CrmSyncJob>>();
             _mockStore = new Mock<IStore>();
-            _job = new CrmSyncJob(_mockCrm.Object, _mockStore.Object, _mockLogger.Object);
+            _metrics = new MetricService();
+            _job = new CrmSyncJob(_mockCrm.Object, _mockStore.Object, _mockLogger.Object, _metrics);
         }
 
         [Fact]
@@ -30,6 +34,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockStore.Verify(mock => mock.SyncAsync(_mockCrm.Object), Times.Once);
             _mockLogger.VerifyInformationWasCalled("CrmSyncJob - Started");
             _mockLogger.VerifyInformationWasCalled("CrmSyncJob - Succeeded");
+            _metrics.CrmSyncDuration.Count.Should().Be(1);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -25,7 +26,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockLogger = new Mock<ILogger<LocationBatchJob>>();
             _metrics = new MetricService();
-            _job = new LocationBatchJob(DbContext, _mockLogger.Object, _metrics);
+            _job = new LocationBatchJob(new Env(), DbContext, _mockLogger.Object, _metrics);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Services;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -17,12 +18,14 @@ namespace GetIntoTeachingApiTests.Jobs
     public class LocationBatchJobTests : DatabaseTests
     {
         private readonly LocationBatchJob _job;
+        private readonly IMetricService _metrics;
         private readonly Mock<ILogger<LocationBatchJob>> _mockLogger;
 
         public LocationBatchJobTests()
         {
             _mockLogger = new Mock<ILogger<LocationBatchJob>>();
-            _job = new LocationBatchJob(DbContext, _mockLogger.Object);
+            _metrics = new MetricService();
+            _job = new LocationBatchJob(DbContext, _mockLogger.Object, _metrics);
         }
 
         [Fact]
@@ -46,6 +49,8 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Started");
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Succeeded");
+
+            _metrics.LocationBatchDuration.Count.Should().Be(2);
         }
 
         private static bool BatchLocationMatchesExistingLocation(dynamic batchLocation, Location existingLocation)

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -31,8 +31,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockLogger = new Mock<ILogger<LocationSyncJob>>();
             _metrics = new MetricService();
-            _job = new LocationSyncJob(_mockJobClient.Object,
-                _mockLogger.Object, _metrics, mockEnv.Object);
+            _job = new LocationSyncJob(mockEnv.Object, _mockJobClient.Object,
+                _mockLogger.Object, _metrics);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
-using Castle.Core.Logging;
+using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Services;
 using GetIntoTeachingApiTests.Helpers;
 using Hangfire;
 using Hangfire.Common;
@@ -12,7 +13,6 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
 using Xunit;
-using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace GetIntoTeachingApiTests.Jobs
 {
@@ -21,12 +21,14 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly LocationSyncJob _job;
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<ILogger<LocationSyncJob>> _mockLogger;
+        private readonly IMetricService _metrics;
 
         public LocationSyncJobTests()
         {
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockLogger = new Mock<ILogger<LocationSyncJob>>();
-            _job = new LocationSyncJob(_mockJobClient.Object, _mockLogger.Object);
+            _metrics = new MetricService();
+            _job = new LocationSyncJob(_mockJobClient.Object, _mockLogger.Object, _metrics);
         }
 
         [Fact]
@@ -64,6 +66,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger.VerifyInformationWasCalled("LocationSyncJob - Queueing 5 Locations (1 Jobs)");
             _mockLogger.VerifyInformationWasCalled("LocationSyncJob - CSV Deleted");
             _mockLogger.VerifyInformationWasCalled("LocationSyncJob - Succeeded");
+
+            _metrics.LocationSyncDuration.Count.Should().Be(1);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Hangfire;
 using Hangfire.Common;
@@ -25,10 +26,13 @@ namespace GetIntoTeachingApiTests.Jobs
 
         public LocationSyncJobTests()
         {
+            var mockEnv = new Mock<IEnv>();
+            mockEnv.Setup(m => m.IsDevelopment).Returns(false);
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockLogger = new Mock<ILogger<LocationSyncJob>>();
             _metrics = new MetricService();
-            _job = new LocationSyncJob(_mockJobClient.Object, _mockLogger.Object, _metrics);
+            _job = new LocationSyncJob(_mockJobClient.Object,
+                _mockLogger.Object, _metrics, mockEnv.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/TeachingEventRegistrationJobTests.cs
@@ -5,6 +5,7 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -30,7 +31,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _teachingEventId = Guid.NewGuid();
             _mockLogger = new Mock<ILogger<TeachingEventRegistrationJob>>();
             _attendee = new ExistingCandidateRequest() { Email = "test@test.com", FirstName = "first", LastName = "last" };
-            _job = new TeachingEventRegistrationJob(_mockCrm.Object, _mockNotifyService.Object, 
+            _job = new TeachingEventRegistrationJob(new Env(), _mockCrm.Object, _mockNotifyService.Object, 
                 _mockContext.Object, _mockLogger.Object);
         }
 
@@ -70,7 +71,7 @@ namespace GetIntoTeachingApiTests.Jobs
         [Fact]
         public void Run_OnFailure_EmailsCandidate()
         {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(JobConfiguration.Attempts - 1);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
 
             _job.Run(_attendee, _teachingEventId, null);
 

--- a/GetIntoTeachingApiTests/Services/HangfirePrometheusExporterTests.cs
+++ b/GetIntoTeachingApiTests/Services/HangfirePrometheusExporterTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using GetIntoTeachingApi.Services;
+using Hangfire;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Moq;
+using Prometheus;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class HangfirePrometheusExporterTests
+    {
+        private readonly Mock<IStorageConnection> _mockStorageConnection;
+        private readonly Mock<IMonitoringApi> _mockMonitoringApi;
+        private readonly HangfirePrometheusExporter _exporter;
+
+        public HangfirePrometheusExporterTests()
+        {
+            _mockStorageConnection = new Mock<IStorageConnection>();
+            _mockMonitoringApi = new Mock<IMonitoringApi>();
+
+            var mockStorage = new Mock<JobStorage>();
+            mockStorage.Setup(x => x.GetConnection()).Returns(_mockStorageConnection.Object);
+            mockStorage.Setup(x => x.GetMonitoringApi()).Returns(_mockMonitoringApi.Object);
+
+            _exporter = new HangfirePrometheusExporter(mockStorage.Object, new MetricService());
+        }
+
+        [Fact]
+        public void ExportHangfireStatistics_PublishesToPrometheus()
+        {
+            var expectedStatistics = new StatisticsDto()
+            {
+                Failed = 1, 
+                Deleted = 2, 
+                Enqueued = 3, 
+                Processing = 4, 
+                Recurring = 5, 
+                Scheduled = 6, 
+                Succeeded = 7
+            };
+            var expectedRetrySet = new HashSet<string> { "job1", "job2", "job3" };
+
+            _mockMonitoringApi.Setup(x => x.GetStatistics()).Returns(expectedStatistics);
+            _mockStorageConnection.Setup(x => x.GetAllItemsFromSet("retries")).Returns(expectedRetrySet);
+
+            _exporter.ExportHangfireStatistics();
+
+            var prometheusContent = GetPrometheusContent();
+
+            ExpectedMetricStrings(expectedStatistics, expectedRetrySet)
+                .ForEach(ms => prometheusContent.Should().Contain(ms));
+        }
+        private static List<string> ExpectedMetricStrings(StatisticsDto statistics, ICollection<string> retrySet)
+        {
+            return new List<string>
+            {
+                "# HELP api_hangfire_jobs Gauge number of Hangifre jobs.\n# TYPE api_hangfire_jobs gauge",
+                MetricString("failed", statistics.Failed),
+                MetricString("deleted", statistics.Deleted),
+                MetricString("enqueued", statistics.Enqueued),
+                MetricString("scheduled", statistics.Scheduled),
+                MetricString("processing", statistics.Processing),
+                MetricString("succeeded", statistics.Succeeded),
+                MetricString("retry", retrySet.Count)
+            };
+        }
+
+        private static string MetricString(string labelValue, double metricValue)
+        {
+            return $"api_hangfire_jobs{{state=\"{labelValue}\"}} {metricValue}";
+        }
+
+        private static string GetPrometheusContent()
+        {
+            using var memoryStream = new MemoryStream();
+            Metrics.DefaultRegistry.CollectAndExportAsTextAsync(memoryStream).Wait();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            using var reader = new StreamReader(memoryStream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -11,17 +11,20 @@ namespace GetIntoTeachingApiTests.Utils
     public class EnvTests : IDisposable
     {
         private readonly string _previousEnvironment;
+        private readonly string _previousCfInstanceIndex;
         private readonly IEnv _env;
 
         public EnvTests()
         {
             _env = new Env();
             _previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            _previousCfInstanceIndex = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
         }
 
         public void Dispose()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", _previousEnvironment);
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", _previousCfInstanceIndex);
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -11,14 +11,28 @@ namespace GetIntoTeachingApiTests.Utils
     public class EnvTests : IDisposable
     {
         private readonly string _previousEnvironment;
+        private readonly IEnv _env;
 
         public EnvTests()
         {
+            _env = new Env();
             _previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         }
+
         public void Dispose()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", _previousEnvironment);
+        }
+
+        [Theory]
+        [InlineData("0", true)]
+        [InlineData("1", false)]
+        [InlineData("10", false)]
+        public void ExportHangfireToPrometheus_TrueOnlyForFirstInstance(string instance, bool expected)
+        {
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", instance);
+
+            _env.ExportHangireToPrometheus.Should().Be(expected);
         }
 
         [Theory]
@@ -29,7 +43,7 @@ namespace GetIntoTeachingApiTests.Utils
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
 
-            Env.IsDevelopment.Should().Be(expected);
+            _env.IsDevelopment.Should().Be(expected);
         }
 
         [Theory]
@@ -40,7 +54,7 @@ namespace GetIntoTeachingApiTests.Utils
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
 
-            Env.IsProduction.Should().Be(expected);
+            _env.IsProduction.Should().Be(expected);
         }
 
         [Theory]
@@ -51,7 +65,7 @@ namespace GetIntoTeachingApiTests.Utils
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
 
-            Env.IsStaging.Should().Be(expected);
+            _env.IsStaging.Should().Be(expected);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -110,5 +110,10 @@ Migrations are applied from code when the application starts (see `DbConfigurati
 
 Deployment is via Terraform and the key will be stored in Azure.
 
+### Logs
 
+Logs are available by loggging into [logit.io](https://logit.io).
 
+### Metrics
+
+Metrics are exposed to Prometheus on the `/metrics` endpoint; [prometheus-net](https://github.com/prometheus-net/prometheus-net) is used for collecting and exposing the metrics.


### PR DESCRIPTION
- Add prometheus-net package

Add the prometheus-net package for collecting and exposing metrics to Prometheus on the `/metrics` endpoint. Gathers .NET Core HTTP request metrics by default.

- Track job duration for CRM and location sync operations

- Expose Hangfire job status to Prometheus on a single instance

Each application instance runs a number of Hangfire workers against the same shared job storage. If we expose the Hangfire statistics to Prometheus for scraping on each instance it will aggregate the results, which would be incorrect. This PR uses the `CF_INSTANCE_INDEX` environment variable to ensure only one instance is exposing the Hangfire job stats.

- Clean up use of `Env` throughout