### PR TITLE
Set fixed number of Hangfire workers

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -123,14 +123,14 @@ The GIT API aims to provide:
                     .UseSimpleAssemblyNameTypeSerializer()
                     .UseRecommendedSerializerSettings()
                     .UseFilter(automaticRetry);
-                
+
                 if (env.IsDevelopment)
                     config.UseMemoryStorage().WithJobExpirationTimeout(JobConfiguration.ExpirationTimeout);
                 else
                     config.UsePostgreSqlStorage(DbConfiguration.HangfireConnectionString(env));
             });
 
-            services.AddHangfireServer();
+            services.AddHangfireServer(options => options.WorkerCount = 10);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
The Postgres connection limit (100) is being hit in the test environment shortly after Hangfire starts up. By default the number of workers is a multiple of the number of cores the instance has - we don't know what this is, but assuming 20 cores it would result in `20 * 5 = 100` connections being created and the limit being hit. This PR fixes the number of workers to 10, which should be sufficient for the application.