### PR TITLE
Reduce max pool size to 50

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -60,7 +60,8 @@ namespace GetIntoTeachingApi.Database
                 Password = postgres.Credentials.Password,
                 Port = postgres.Credentials.Port,
                 SslMode = SslMode.Require,
-                TrustServerCertificate = true
+                TrustServerCertificate = true,
+                MaxPoolSize = 50
             };
 
             return builder.ConnectionString;


### PR DESCRIPTION
Our Postgres instance is configured to accept 100 connections; each application instance is configured to pool up to 100 connections as well, which means we could exhaust the Postgres instance. This PR reduces the pooling to a max of 50 connections.