### PR TITLE
Increase worker count to 20

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -150,7 +150,7 @@ The GIT API aims to provide:
 
             app.UseHttpsRedirection();
 
-            var hangfireOptions = new BackgroundJobServerOptions() { WorkerCount = 1 };
+            var hangfireOptions = new BackgroundJobServerOptions() { WorkerCount = 20 };
             app.UseHangfireServer(hangfireOptions);
 
             app.UseHangfireDashboard("/hangfire", new DashboardOptions


### PR DESCRIPTION
We had lowered this to debug a connection leak issue in test; switching the Postgres provider for Hangfire appears to have fixed the leak, so we can increase the workers without exhausting the pool.