### PR TITLE
Output Swagger using v2

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -158,7 +158,10 @@ The GIT API aims to provide:
                 Authorization = new[] { new HangfireDashboardAuthorizationFilter(env) },
             });
 
-            app.UseSwagger();
+            app.UseSwagger(c =>
+            {
+                c.SerializeAsV2 = true;
+            });
 
             app.UseSwaggerUI(c =>
             {


### PR DESCRIPTION
There is less support in code generation tools for Swagger v3 with respect to Ruby clients; outputting it as v2 may mean that we can generate a client for the adviser service app.