### PR TITLE
Simplify email validation

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
@@ -16,7 +17,7 @@ namespace GetIntoTeachingApi.Models.Validators
 
             RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
-            RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress().MaximumLength(100);
+            RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).NotNull().LessThan(candidate => DateTime.Now);
             RuleFor(candidate => candidate.Telephone).NotEmpty().MaximumLength(50);
             RuleFor(candidate => candidate.AddressLine1).NotEmpty().MaximumLength(1024);

--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentValidation;
+using FluentValidation.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
@@ -10,7 +11,7 @@ namespace GetIntoTeachingApi.Models.Validators
         {
             RuleFor(request => request.FirstName).MaximumLength(256);
             RuleFor(request => request.LastName).MaximumLength(256);
-            RuleFor(request => request.Email).NotEmpty().EmailAddress().MaximumLength(100);
+            RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.Now);
             RuleFor(request => request)
                 .Must(SpecifyTwoAdditionalRequiredAttributes)


### PR DESCRIPTION
Validate the email contains an `@` that is not at the start or the end; makes it consistent with Dynamics validation and removes the complex regex that is breaking the auto-generated Ruby client.