### PR TITLE
Add endpoint to retrieve callback booking quotas

### DIFF
--- a/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
+++ b/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/callback_booking_quotas")]
+    [ApiController]
+    [Authorize]
+    public class CallbackBookingQuotasController : ControllerBase
+    {
+        private readonly ICrmService _crm;
+
+        public CallbackBookingQuotasController(ICrmService crm)
+        {
+            _crm = crm;
+        }
+
+        [HttpGet]
+        [Route("")]
+        [SwaggerOperation(
+            Summary = "Retrieves all callback booking quotas.",
+            OperationId = "GetCallbackBookingQuotas",
+            Tags = new[] { "Callback Booking Quotas" })]
+        [ProducesResponseType(typeof(CallbackBookingQuota), 200)]
+        public IActionResult GetAll()
+        {
+            var quotas = _crm.GetCallbackBookingQuotas();
+            return Ok(quotas);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -3,7 +3,6 @@ using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -5,7 +5,6 @@ using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers

--- a/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
+++ b/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    [Entity(LogicalName = "dfe_callbackbookingquota")]
+    public class CallbackBookingQuota : BaseModel
+    {
+        [EntityField(Name = "dfe_name")]
+        public string TimeSlot { get; set; }
+        [EntityField(Name = "dfe_workingdayname")]
+        public string Day { get; set; }
+        [EntityField(Name = "dfe_starttime")]
+        public DateTime StartAt { get; set; }
+        [EntityField(Name = "dfe_endtime")]
+        public DateTime EndAt { get; set; }
+        [EntityField(Name = "dfe_numberofbookings")]
+        public int NumberOfBookings { get; set; }
+        [EntityField(Name = "dfe_quota")]
+        public int Quota { get; set; }
+
+        public bool IsAvailable => NumberOfBookings < Quota;
+
+        public CallbackBookingQuota()
+            : base()
+        {
+        }
+
+        public CallbackBookingQuota(Entity entity, ICrmService crm)
+            : base(entity, crm)
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApi.Services
 
         private const int MaximumNumberOfCandidatesToMatch = 20;
         private const int MaximumNumberOfPrivacyPolicies = 3;
+        private const int MaximumCallbackBookingQuotaDaysInAdvance = 14;
         private readonly IOrganizationServiceAdapter _service;
 
         public CrmService(IOrganizationServiceAdapter service)
@@ -34,6 +35,16 @@ namespace GetIntoTeachingApi.Services
         {
             return _service.GetPickListItemsForAttribute(entityName, attributeName)
                 .Select((pickListItem) => new TypeEntity(pickListItem, entityName, attributeName));
+        }
+
+        public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
+        {
+            return _service.CreateQuery("dfe_callbackbookingquota", Context())
+                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") > DateTime.Now &&
+                                   entity.GetAttributeValue<DateTime>("dfe_starttime") <
+                                   DateTime.UtcNow.AddDays(MaximumCallbackBookingQuotaDaysInAdvance))
+                .OrderBy((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime"))
+                .Select((entity) => new CallbackBookingQuota(entity, this));
         }
 
         public IEnumerable<PrivacyPolicy> GetPrivacyPolicies()

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate GetCandidate(ExistingCandidateRequest request);
         IEnumerable<TeachingEvent> GetTeachingEvents();
+        IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);

--- a/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
@@ -1,0 +1,47 @@
+﻿using GetIntoTeachingApi.Controllers;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Controllers
+{
+    public class CallbackBookingQuotasControllerTests
+    {
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly CallbackBookingQuotasController _controller;
+
+        public CallbackBookingQuotasControllerTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _controller = new CallbackBookingQuotasController(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Authorize_IsPresent()
+        {
+            typeof(CallbackBookingQuotasController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void GetAll_ReturnsAllQuotas()
+        {
+            var mockQuotas = new[] { MockQuota(), MockQuota() };
+            _mockCrm.Setup(mock => mock.GetCallbackBookingQuotas()).Returns(mockQuotas);
+
+            var response = _controller.GetAll();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockQuotas);
+        }
+
+        private static CallbackBookingQuota MockQuota()
+        {
+            return new CallbackBookingQuota() { Id = Guid.NewGuid(), StartAt = DateTime.Now, NumberOfBookings = 4 };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var mappings = ok.Value.Should().BeOfType<List<MappingInfo>>().Subject;
-            mappings.Count().Should().Be(9);
+            mappings.Count().Should().Be(10);
             mappings.Any(m => m.LogicalName == "contact" &&
                               m.Class == "GetIntoTeachingApi.Models.Candidate"
                               ).Should().BeTrue();

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 using System;
 using Microsoft.AspNetCore.Authorization;

--- a/GetIntoTeachingApiTests/Models/CallbackBookingQuotaTests.cs
+++ b/GetIntoTeachingApiTests/Models/CallbackBookingQuotaTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class CallbackBookingQuotaTests
+    {
+        [Fact]
+        public void EntityAttributes()
+        {
+            var type = typeof(CallbackBookingQuota);
+
+            type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_callbackbookingquota");
+
+            type.GetProperty("TimeSlot").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_name");
+            type.GetProperty("Day").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_workingdayname");
+            type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_starttime");
+            type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_endtime");
+            type.GetProperty("Quota").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_quota");
+            type.GetProperty("NumberOfBookings").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_numberofbookings");
+        }
+
+        [Theory]
+        [InlineData(1, 2, true)]
+        [InlineData(0, 0, false)]
+        [InlineData(2, 2, false)]
+        [InlineData(3, 2, false)]
+        public void IsAvailable_ReturnsCorrectly(int numberOfBookings, int quota, bool expected)
+        {
+            var callbackBookingQuota = new CallbackBookingQuota() { NumberOfBookings = numberOfBookings, Quota = quota };
+
+            callbackBookingQuota.IsAvailable.Should().Be(expected);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -72,6 +72,20 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void GetCallbackBookingQuotas_ReturnsFutureQuotasUpTo14DaysInAdvance()
+        {
+            var queryableQuotas = MockCallbackBookingQuotas();
+            _mockService.Setup(mock => mock.CreateQuery("dfe_callbackbookingquota", _context))
+                .Returns(queryableQuotas);
+
+            var result = _crm.GetCallbackBookingQuotas().ToList();
+
+            result.Select(quota => quota.NumberOfBookings).Should().BeEquivalentTo(
+                new object[] { 4, 3, 2 },
+                options => options.WithStrictOrdering());
+        }
+
+        [Fact]
         public void GetPrivacyPolicies_Returns3MostRecentActiveWebPrivacyPolicies()
         {
             var queryablePrivacyPolicies = MockPrivacyPolicies();
@@ -297,6 +311,31 @@ namespace GetIntoTeachingApiTests.Services
             candidate3["createdon"] = DateTime.Now.AddDays(-5);
 
             return new[] { candidate1, candidate2, candidate3 }.AsQueryable();
+        }
+
+        private static IQueryable<Entity> MockCallbackBookingQuotas()
+        {
+            var quota1 = new Entity("dfe_callbackbookingquota");
+            quota1["dfe_starttime"] = DateTime.Now.AddDays(-1);
+            quota1["dfe_numberofbookings"] = 1;
+
+            var quota2 = new Entity("dfe_callbackbookingquota");
+            quota2["dfe_starttime"] = DateTime.Now.AddDays(10);
+            quota2["dfe_numberofbookings"] = 2;
+
+            var quota3 = new Entity("dfe_callbackbookingquota");
+            quota3["dfe_starttime"] = DateTime.Now.AddDays(1);
+            quota3["dfe_numberofbookings"] = 3;
+
+            var quota4 = new Entity("dfe_callbackbookingquota");
+            quota4["dfe_starttime"] = DateTime.Now.AddMinutes(20);
+            quota4["dfe_numberofbookings"] = 4;
+
+            var quota5 = new Entity("dfe_callbackbookingquota");
+            quota5["dfe_starttime"] = DateTime.Now.AddDays(15);
+            quota5["dfe_numberofbookings"] = 5;
+
+            return new[] { quota1, quota2, quota3, quota4, quota5 }.AsQueryable();
         }
 
         private static IQueryable<Entity> MockPrivacyPolicies()


### PR DESCRIPTION
Retrieve the callback booking quotas from Dynamics. Returns the booking quotas for the next 14 days, in alignment with the existing TTA process (matches the Azure function the CRM team provided). They also allow filtering to a specific number of weekdays, but I'm not sure if this is a requirement of the new process so I've left that out for now.

```
GET api/callback_booking_quotas

[{
    "timeSlot": "9am - 9:30am",
    "day": "Friday 19 June",
    "startAt": "2020-06-19T08:00:00Z",
    "endAt": "2020-06-19T08:30:00Z",
    "numberOfBookings": 0,
    "quota": 12,
    "isAvailable": true,
    "id": "6325803b-1c83-ea11-a811-000d3a44a94a"
}]
```