### PR TITLE
Update event registration to use manual matchback

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -8,7 +8,6 @@ using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -94,6 +93,8 @@ maximum of 50 using the `limit` query parameter.",
         [Route("{id}/attendees")]
         [SwaggerOperation(
             Summary = "Adds an attendee to a teaching event.",
+            Description = "If the `CandidateId` is specified then the existing candidate will be " +
+                          "registered for the event, otherwise a new candidate will be created.",
             OperationId = "AddTeachingEventAttendee",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(204)]
@@ -101,7 +102,7 @@ maximum of 50 using the `limit` query parameter.",
         [ProducesResponseType(404)]
         public async Task<IActionResult> AddAttendee(
             [FromRoute, SwaggerParameter("The `id` of the `TeachingEvent`.", Required = true)] Guid id,
-            [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] ExistingCandidateRequest attendee)
+            [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] TeachingEventRegistrationRequest request)
         {
             if (!ModelState.IsValid)
             {
@@ -115,7 +116,7 @@ maximum of 50 using the `limit` query parameter.",
                 return NotFound();
             }
 
-            _jobClient.Enqueue<TeachingEventRegistrationJob>((x) => x.Run(attendee, id, null));
+            _jobClient.Enqueue<TeachingEventRegistrationJob>((x) => x.Run(request, id, null));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -6,7 +6,7 @@ namespace GetIntoTeachingApi.Models
 {
     public class ExistingCandidateRequest
     {
-        private static readonly int MinimumAdditionalAttributeMatches = 2;
+        private const int MinimumAdditionalAttributeMatches = 2;
 
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistrationRequest.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistrationRequest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class TeachingEventRegistrationRequest
+    {
+        [SwaggerSchema("Set to register an existing candidate for a teaching event.")]
+        public Guid? CandidateId { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Telephone { get; set; }
+        public string AddressPostcode { get; set; }
+        public CandidatePrivacyPolicy PrivacyPolicy { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationRequestValidator.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class TeachingEventRegistrationRequestValidator : AbstractValidator<TeachingEventRegistrationRequest>
+    {
+        public TeachingEventRegistrationRequestValidator(IStore store)
+        {
+            RuleFor(request => request.FirstName).NotEmpty().MaximumLength(256);
+            RuleFor(request => request.LastName).NotEmpty().MaximumLength(256);
+            RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+            RuleFor(request => request.Telephone).MaximumLength(50);
+            RuleFor(request => request.AddressPostcode).NotEmpty().MaximumLength(40);
+
+            RuleFor(request => request.PrivacyPolicy).NotEmpty().SetValidator(new CandidatePrivacyPolicyValidator(store));
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -80,6 +80,14 @@ namespace GetIntoTeachingApi.Services
             return new Candidate(entity, this);
         }
 
+        public Candidate GetCandidate(Guid id)
+        {
+            var entity = _service.CreateQuery("contact", Context())
+                .FirstOrDefault(c => c.GetAttributeValue<EntityReference>("contactid").Id == id);
+
+            return entity == null ? null : new Candidate(entity, this);
+        }
+
         public bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId)
         {
             return _service.CreateQuery("dfe_candidateprivacypolicy", Context()).FirstOrDefault(entity =>

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate GetCandidate(ExistingCandidateRequest request);
+        Candidate GetCandidate(Guid id);
         IEnumerable<TeachingEvent> GetTeachingEvents();
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationRequestTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class TeachingEventRegistrationRequestTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventRegistrationRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventRegistrationRequestValidatorTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class TeachingEventRegistrationRequestValidatorTests
+    {
+        private readonly TeachingEventRegistrationRequestValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public TeachingEventRegistrationRequestValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new TeachingEventRegistrationRequestValidator(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+
+            _mockStore
+                .Setup(mock => mock.GetPrivacyPolicies())
+                .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
+
+            var request = new TeachingEventRegistrationRequest()
+            {
+                FirstName = "first",
+                LastName = "last",
+                Email = "email@address.com",
+                Telephone = "07584 734 576",
+                AddressPostcode = "postcode",
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_PrivacyPolicyIsInvalid_HasError()
+        {
+            var request = new TeachingEventRegistrationRequest
+            {
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
+            };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(r => r.PrivacyPolicy.AcceptedPolicyId);
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Email, "valid@email.com");
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, "");
+        }
+
+        [Fact]
+        public void Validate_FirstNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_LastNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, "");
+        }
+
+        [Fact]
+        public void Validate_LastNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_TelephoneIsEmpty_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Telephone, "");
+        }
+
+        [Fact]
+        public void Validate_TelephoneTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Telephone, new string('a', 51));
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, "");
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, new string('a', 41));
+        }
+
+        [Fact]
+        public void Validate_PrivacyPolicyIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PrivacyPolicy, null as CandidatePrivacyPolicy);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -171,12 +171,31 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().BeTrue();
         }
 
+        [Fact]
+        public void GetCandidate_WithId_ReturnsCorrectly()
+        {
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates);
+
+            var result = _crm.GetCandidate(JaneDoeGuid);
+
+            result.Id.Should().Be(JaneDoeGuid);
+        }
+
+        [Fact]
+        public void GetCandidate_WithNonExistentId_ReturnsNull()
+        {
+            var result = _crm.GetCandidate(Guid.NewGuid());
+
+            result.Should().BeNull();
+        }
+
         [Theory]
         [InlineData("john@doe.com", "New John", "Doe", "New John")]
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
         [InlineData("jane@doe.com", "Jane", "Doe", "Jane")]
         [InlineData("bob@doe.com", "Bob", "Doe", null)]
-        public void GetCandidate_MatchesOnNewestCandidateWithEmail(
+        public void GetCandidate_WithExistingCandidateRequest_MatchesOnNewestCandidateWithEmail(
             string email,
             string firstName,
             string lastName,
@@ -293,6 +312,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate1 = new Entity("contact");
             candidate1.Id = JaneDoeGuid;
+            candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";


### PR DESCRIPTION
Instead of matching the candidate automatically on event registration we want to manually make the user verify their email address first. The event registration endpoint now accepts a `candidateId` that can be used to add an existing candidate to an event (the id should be obtained from a matchback request and only used once a user has verified the email).

Also adds additional fields to the candidate entity to match the updated event registration process. 