### PR TITLE
Flesh out mailing list endpoint

### DIFF
--- a/GetIntoTeachingApi/Jobs/MailingListAddMemberJob.cs
+++ b/GetIntoTeachingApi/Jobs/MailingListAddMemberJob.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class MailingListAddMemberJob : BaseJob
+    {
+        private readonly ICrmService _crm;
+        private readonly INotifyService _notifyService;
+        private readonly IPerformContextAdapter _contextAdapter;
+        private readonly ILogger<MailingListAddMemberJob> _logger;
+
+        public MailingListAddMemberJob(
+            IEnv env,
+            ICrmService crm,
+            INotifyService notifyService,
+            IPerformContextAdapter contextAdapter,
+            ILogger<MailingListAddMemberJob> logger)
+            : base(env)
+        {
+            _crm = crm;
+            _logger = logger;
+            _notifyService = notifyService;
+            _contextAdapter = contextAdapter;
+        }
+
+        public void Run(MailingListAddMemberRequest request, PerformContext context)
+        {
+            _logger.LogInformation($"MailingListAddMemberJob - Started ({AttemptInfo(context, _contextAdapter)})");
+
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                NotifyCandidateOfFailure(request);
+                _logger.LogInformation("MailingListAddMemberJob - Deleted");
+            }
+            else
+            {
+                AddMemberToMailingList(request);
+                _logger.LogInformation("MailingListAddMemberJob - Succeeded");
+            }
+        }
+
+        private void AddMemberToMailingList(MailingListAddMemberRequest request)
+        {
+            var candidate = FindOrCreateCandidate(request.CandidateId);
+
+            candidate.PreferredTeachingSubjectId = request.PreferredTeachingSubjectId;
+            candidate.Email = request.Email;
+            candidate.FirstName = request.FirstName;
+            candidate.LastName = request.LastName;
+            candidate.Telephone = request.Telephone ?? candidate.Telephone;
+            candidate.AddressPostcode = request.AddressPostcode;
+            candidate.PrivacyPolicy = request.PrivacyPolicy;
+
+            _crm.Save(candidate);
+        }
+
+        private void NotifyCandidateOfFailure(MailingListAddMemberRequest request)
+        {
+            // We fire and forget the email, ensuring the job succeeds.
+            _notifyService.SendEmailAsync(
+                request.Email,
+                NotifyService.MailingListAddMemberFailedEmailTemplateId,
+                new Dictionary<string, dynamic>());
+        }
+
+        private Candidate FindOrCreateCandidate(Guid? candidateId)
+        {
+            return candidateId != null ? _crm.GetCandidate((Guid)candidateId) : new Candidate();
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/MailingListAddMemberRequest.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMemberRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class MailingListAddMemberRequest
+    {
+        [SwaggerSchema("Set to add an existing candidate to the mailing list.")]
+        public Guid? CandidateId { get; set; }
+        public Guid PreferredTeachingSubjectId { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Telephone { get; set; }
+        public string AddressPostcode { get; set; }
+        public CandidatePrivacyPolicy PrivacyPolicy { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberRequestValidator.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentValidation;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class MailingListAddMemberRequestValidator : AbstractValidator<MailingListAddMemberRequest>
+    {
+        private readonly IStore _store;
+
+        public MailingListAddMemberRequestValidator(IStore store)
+        {
+            _store = store;
+
+            RuleFor(request => request.FirstName).NotEmpty().MaximumLength(256);
+            RuleFor(request => request.LastName).NotEmpty().MaximumLength(256);
+            RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+            RuleFor(request => request.Telephone).MaximumLength(50);
+            RuleFor(request => request.AddressPostcode).NotEmpty().MaximumLength(40);
+
+            RuleFor(request => request.PrivacyPolicy).NotEmpty().SetValidator(new CandidatePrivacyPolicyValidator(store));
+
+            RuleFor(candidate => candidate.PreferredTeachingSubjectId)
+                .Must(id => PreferredTeachingSubjectIds().Contains(id.ToString()))
+                .WithMessage("Must be a valid teaching subject.");
+        }
+
+        private IEnumerable<string> PreferredTeachingSubjectIds()
+        {
+            return _store.GetLookupItems("dfe_teachingsubjectlist").Select(subject => subject.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -11,6 +11,7 @@ namespace GetIntoTeachingApi.Services
         public const string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
         public const string CandidateRegistrationFailedEmailTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
         public const string TeachingEventRegistrationFailedEmailTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
+        public const string MailingListAddMemberFailedEmailTemplateId = "4b3653b4-e524-42b8-bfed-201cb6bb8a25";
         private readonly ILogger<NotifyService> _logger;
         private readonly INotificationClientAdapter _client;
         private readonly IEnv _env;

--- a/GetIntoTeachingApiTests/Jobs/MailingListAddMemberJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MailingListAddMemberJobTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class MailingListAddMemberJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly Mock<ILogger<MailingListAddMemberJob>> _mockLogger;
+        private readonly MailingListAddMemberRequest _request;
+        private readonly MailingListAddMemberJob _job;
+
+        public MailingListAddMemberJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockNotifyService = new Mock<INotifyService>();
+            _mockLogger = new Mock<ILogger<MailingListAddMemberJob>>();
+            _request = new MailingListAddMemberRequest()
+            {
+                Email = "test@test.com",
+                FirstName = "first",
+                LastName = "last",
+                Telephone = "1234",
+                AddressPostcode = "KY11 9YU",
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
+            };
+            _job = new MailingListAddMemberJob(new Env(), _mockCrm.Object, _mockNotifyService.Object,
+                _mockContext.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void Run_OnSuccessWithExistingCandidate_AddsAsMember()
+        {
+            var candidateId = Guid.NewGuid();
+            var candidate = new Candidate() { Id = candidateId };
+            _request.CandidateId = candidateId;
+            _mockCrm.Setup(m => m.Save(It.Is<Candidate>(c => VerifyUpdatedCandidate(c))));
+            _mockCrm.Setup(m => m.GetCandidate(candidateId)).Returns(candidate);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _job.Run(_request, null);
+
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Succeeded");
+        }
+
+        [Fact]
+        public void Run_OnSuccessWithNewCandidate_AddsAsMember()
+        {
+            var candidateId = Guid.NewGuid();
+            _mockCrm.Setup(m => m.Save(It.Is<Candidate>(c => VerifyUpdatedCandidate(c)))).Callback<BaseModel>(c => c.Id = candidateId);
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _job.Run(_request, null);
+
+            _mockCrm.Verify(m => m.GetCandidate(It.IsAny<Guid>()), Times.Never);
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Succeeded");
+        }
+
+        [Fact]
+        public void Run_OnFailure_EmailsCandidate()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
+
+            _job.Run(_request, null);
+
+            _mockNotifyService.Verify(mock => mock.SendEmailAsync(_request.Email,
+                NotifyService.MailingListAddMemberFailedEmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Started (24/24)");
+            _mockLogger.VerifyInformationWasCalled("MailingListAddMemberJob - Deleted");
+        }
+
+        private bool VerifyUpdatedCandidate(Candidate candidate)
+        {
+            return candidate.FirstName == _request.FirstName &&
+                   candidate.LastName == _request.LastName &&
+                   candidate.Email == _request.Email &&
+                   candidate.Telephone == _request.Telephone &&
+                   candidate.AddressPostcode == _request.AddressPostcode &&
+                   candidate.PreferredTeachingSubjectId == _request.PreferredTeachingSubjectId &&
+                   candidate.PrivacyPolicy == _request.PrivacyPolicy;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberRequestTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class MailingListAddMemberRequestTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestValidatorTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class MailingListAddMemberRequestValidatorTests
+    {
+        private readonly MailingListAddMemberRequestValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public MailingListAddMemberRequestValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new MailingListAddMemberRequestValidator(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+            var mockPreferredTeachingSubject = new TypeEntity { Id = Guid.NewGuid().ToString() };
+
+            _mockStore
+                .Setup(mock => mock.GetPrivacyPolicies())
+                .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
+                .Returns(new[] { mockPreferredTeachingSubject }.AsQueryable());
+
+            var request = new MailingListAddMemberRequest()
+            {
+                FirstName = "first",
+                LastName = "last",
+                Email = "email@address.com",
+                Telephone = "07584 734 576",
+                AddressPostcode = "postcode",
+                PreferredTeachingSubjectId = Guid.Parse(mockPreferredTeachingSubject.Id),
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_PrivacyPolicyIsInvalid_HasError()
+        {
+            var request = new MailingListAddMemberRequest
+            {
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
+            };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(r => r.PrivacyPolicy.AcceptedPolicyId);
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
+        }
+
+        [Fact]
+        public void Validate_EmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Email, "valid@email.com");
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, "");
+        }
+
+        [Fact]
+        public void Validate_FirstNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_LastNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, "");
+        }
+
+        [Fact]
+        public void Validate_LastNameTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, new string('a', 257));
+        }
+
+        [Fact]
+        public void Validate_TelephoneIsEmpty_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Telephone, "");
+        }
+
+        [Fact]
+        public void Validate_TelephoneTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Telephone, new string('a', 51));
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, "");
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, new string('a', 41));
+        }
+
+        [Fact]
+        public void Validate_PrivacyPolicyIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PrivacyPolicy, null as CandidatePrivacyPolicy);
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, Guid.NewGuid());
+        }
+    }
+}


### PR DESCRIPTION
Add a basic mailing list job to insert a candidate record or update an existing record with the latest field values from the mailing list form. The CRM does not yet contain the schema for subscribing to a mailing list, so this will need to be added in as soon as it's available (in addition to a few other candidate fields we will collect but don't yet have a schema for).