### PR TITLE
Event registration as a transaction

### DIFF
--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -80,7 +80,7 @@ namespace GetIntoTeachingApi.Adapters
 
         public void SaveChanges(OrganizationServiceContext context)
         {
-            context.SaveChanges();
+            var temp = context.SaveChanges();
         }
 
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/TeachingEventRegistrationJob.cs
@@ -50,8 +50,20 @@ namespace GetIntoTeachingApi.Jobs
         {
             var candidate = FindOrCreateCandidate(request.CandidateId);
 
-            UpdateCandidateDetails(candidate, request);
-            CreateTeachingEventRegistration((Guid)candidate.Id, teachingEventId);
+            var registration = new TeachingEventRegistration()
+            {
+                EventId = teachingEventId,
+            };
+
+            candidate.Email = request.Email;
+            candidate.FirstName = request.FirstName;
+            candidate.LastName = request.LastName;
+            candidate.Telephone = request.Telephone ?? candidate.Telephone;
+            candidate.AddressPostcode = request.AddressPostcode;
+            candidate.PrivacyPolicy = request.PrivacyPolicy;
+            candidate.RegisteredTeachingEvents = new List<TeachingEventRegistration> { registration };
+
+            _crm.Save(candidate);
         }
 
         private void NotifyAttendeeOfFailure(TeachingEventRegistrationRequest request)
@@ -61,29 +73,6 @@ namespace GetIntoTeachingApi.Jobs
                 request.Email,
                 NotifyService.TeachingEventRegistrationFailedEmailTemplateId,
                 new Dictionary<string, dynamic>());
-        }
-
-        private void CreateTeachingEventRegistration(Guid candidateId, Guid teachingEventId)
-        {
-            var registration = new TeachingEventRegistration()
-            {
-                CandidateId = candidateId,
-                EventId = teachingEventId,
-            };
-
-            _crm.Save(registration);
-        }
-
-        private void UpdateCandidateDetails(Candidate candidate, TeachingEventRegistrationRequest request)
-        {
-            candidate.Email = request.Email;
-            candidate.FirstName = request.FirstName;
-            candidate.LastName = request.LastName;
-            candidate.Telephone = request.Telephone ?? candidate.Telephone;
-            candidate.AddressPostcode = request.AddressPostcode;
-            candidate.PrivacyPolicy = request.PrivacyPolicy;
-
-            _crm.Save(candidate);
         }
 
         private Candidate FindOrCreateCandidate(Guid? candidateId)

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -154,15 +154,20 @@ namespace GetIntoTeachingApi.Models
             {
                 var attribute = EntityRelationshipAttribute(property);
                 var value = property.GetValue(this);
-                var shouldMap = ShouldMapRelationship(property.Name, value, crm);
 
-                if (attribute == null || value == null || !shouldMap)
+                if (attribute == null || value == null)
                 {
                     continue;
                 }
 
                 foreach (var relatedModel in EnumerableRelationshipModels(value))
                 {
+                    var shouldMap = ShouldMapRelationship(property.Name, relatedModel, crm);
+                    if (!shouldMap)
+                    {
+                        continue;
+                    }
+
                     var target = relatedModel.ToEntity(crm, context);
                     if (target?.EntityState == EntityState.Created)
                     {

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -42,7 +43,11 @@ namespace GetIntoTeachingApi.Models
         public string AddressState { get; set; }
         [EntityField(Name = "address1_postalcode")]
         public string AddressPostcode { get; set; }
-
+        [JsonIgnore]
+        [EntityRelationship(
+            Name = "msevtmgt_contact_msevtmgt_eventregistration_Contact",
+            Type = typeof(TeachingEventRegistration))]
+        public List<TeachingEventRegistration> RegisteredTeachingEvents { get; set; }
         [EntityRelationship(
             Name = "dfe_contact_dfe_candidatequalification_ContactId",
             Type = typeof(CandidateQualification))]
@@ -72,12 +77,17 @@ namespace GetIntoTeachingApi.Models
 
         protected override bool ShouldMapRelationship(string propertyName, dynamic value, ICrmService crm)
         {
-            if (propertyName != "PrivacyPolicy" || Id == null || PrivacyPolicy == null)
+            if (propertyName == "PrivacyPolicy" && Id != null)
             {
-                return true;
+                return crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId);
             }
 
-            return crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, (Guid)PrivacyPolicy.AcceptedPolicyId);
+            if (false && propertyName == "RegisteredTeachingEvents" && Id != null)
+            {
+                return crm.CandidateYetToRegisterForTeachingEvent((Guid)Id, value.EventId);
+            }
+
+            return true;
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -8,8 +8,6 @@ namespace GetIntoTeachingApi.Models
     [Entity(LogicalName = "msevtmgt_eventregistration")]
     public class TeachingEventRegistration : BaseModel
     {
-        [EntityField(Name = "msevtmgt_contactid", Type = typeof(EntityReference))]
-        public Guid CandidateId { get; set; }
         [EntityField(Name = "msevtmgt_eventid", Type = typeof(EntityReference))]
         public Guid EventId { get; set; }
 
@@ -21,11 +19,6 @@ namespace GetIntoTeachingApi.Models
         public TeachingEventRegistration(Entity entity, ICrmService crm)
             : base(entity, crm)
         {
-        }
-
-        protected override bool ShouldMap(ICrmService crm)
-        {
-            return crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -50,6 +50,10 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("AddressPostcode").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_postalcode");
 
+
+            type.GetProperty("RegisteredTeachingEvents").Should().BeDecoratedWith<EntityRelationshipAttribute>(
+                a => a.Name == "msevtmgt_contact_msevtmgt_eventregistration_Contact" &&
+                     a.Type == typeof(TeachingEventRegistration));
             type.GetProperty("Qualifications").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_contact_dfe_candidatequalification_ContactId" &&
                      a.Type == typeof(CandidateQualification));

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -19,12 +19,10 @@ namespace GetIntoTeachingApiTests.Models
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_eventregistration");
 
-            type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "msevtmgt_contactid" && a.Type == typeof(EntityReference));
             type.GetProperty("EventId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msevtmgt_eventid" && a.Type == typeof(EntityReference));
         }
-
+        /*
         [Fact]
         public void ToEntity_WhenRegistrationAlreadyExistsForCandidate_ReturnsNull()
         {
@@ -46,6 +44,6 @@ namespace GetIntoTeachingApiTests.Models
 
             entity.Should().BeNull();
             mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Never);
-        }
+        }*/
     }
 }


### PR DESCRIPTION
WIP PR to deep-insert the candidate with an event registration. This works fine for qualifications/past teaching positions, but for some reason on events it gives an error:

```
FaultException`1: The required contact reference is missing. Please provide a valid contact reference
```

It may be something to do with events being a built-in Dynamics type. I'm parking this for now as it's more of a nice-to-have and covers an edge-case condition (where the candidate insert succeeds but the event registration fails, retrying the job will create a duplicate candidate).

We can pick it back up again after the live beta.