### PR TITLE
Ignore inactive contacts and prioritise master records

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -46,7 +46,7 @@ that can then be used for verification.",
                 return BadRequest(this.ModelState);
             }
 
-            var candidate = _crm.GetCandidate(request);
+            var candidate = _crm.MatchCandidate(request);
             if (candidate == null)
             {
                 return NotFound();

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -70,7 +70,7 @@ exchanged for your token matches the request payload here).",
                 return Unauthorized();
             }
 
-            var candidate = _crm.GetCandidate(request);
+            var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null)
             {

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -71,7 +71,8 @@ namespace GetIntoTeachingApi.Services
                 .Where(e =>
                     e.GetAttributeValue<int>("statecode") == (int)CandidateStatus.Active &&
                     e.GetAttributeValue<string>("emailaddress1") == request.Email) // Will perform a case-insensitive comparison
-                .OrderByDescending(e => e.GetAttributeValue<DateTime>("createdon"))
+                .OrderBy(e => e.GetAttributeValue<bool>("merged"))
+                .ThenByDescending(e => e.GetAttributeValue<DateTime>("modifiedon"))
                 .Take(MaximumNumberOfCandidatesToMatch)
                 .ToList()
                 .FirstOrDefault(request.Match);

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -16,6 +16,12 @@ namespace GetIntoTeachingApi.Services
             Web = 222750001,
         }
 
+        public enum CandidateStatus
+        {
+            Active,
+            Inactive,
+        }
+
         private const int MaximumNumberOfCandidatesToMatch = 20;
         private const int MaximumNumberOfPrivacyPolicies = 3;
         private const int MaximumCallbackBookingQuotaDaysInAdvance = 14;
@@ -63,6 +69,7 @@ namespace GetIntoTeachingApi.Services
             var context = Context();
             var entity = _service.CreateQuery("contact", context)
                 .Where(e =>
+                    e.GetAttributeValue<int>("statecode") == (int)CandidateStatus.Active &&
                     e.GetAttributeValue<string>("emailaddress1") == request.Email) // Will perform a case-insensitive comparison
                 .OrderByDescending(e => e.GetAttributeValue<DateTime>("createdon"))
                 .Take(MaximumNumberOfCandidatesToMatch)

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApi.Services
                 .Take(MaximumNumberOfPrivacyPolicies);
         }
 
-        public Candidate GetCandidate(ExistingCandidateRequest request)
+        public Candidate MatchCandidate(ExistingCandidateRequest request)
         {
             var context = Context();
             var entity = _service.CreateQuery("contact", context)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -11,7 +11,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<TypeEntity> GetLookupItems(string entityName);
         IEnumerable<TypeEntity> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
-        Candidate GetCandidate(ExistingCandidateRequest request);
+        Candidate MatchCandidate(ExistingCandidateRequest request);
         Candidate GetCandidate(Guid id);
         IEnumerable<TeachingEvent> GetTeachingEvents();
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -50,7 +50,7 @@ namespace GetIntoTeachingApiTests.Controllers
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             var candidate = new Candidate { Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
             _mockTokenService.Setup(mock => mock.GenerateToken(request)).Returns("123456");
-            _mockCrm.Setup(mock => mock.GetCandidate(request)).Returns(candidate);
+            _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns(candidate);
 
             var response = _controller.CreateAccessToken(request);
 
@@ -68,7 +68,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CreateAccessToken_MismatchedCandidate_ReturnsNotFound()
         {
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
-            _mockCrm.Setup(mock => mock.GetCandidate(request)).Returns<Candidate>(null);
+            _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns<Candidate>(null);
 
             var response = _controller.CreateAccessToken(request);
 

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -52,7 +52,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
-            _mockCrm.Setup(mock => mock.GetCandidate(_request)).Returns(candidate);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
 
             var response = _controller.Get("000000", _request);
 
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         public void Get_MissingCandidate_RespondsWithNotFound()
         {
             _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
-            _mockCrm.Setup(mock => mock.GetCandidate(_request)).Returns<Candidate>(null);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
 
             var response = _controller.Get("000000", _request);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -195,6 +195,7 @@ namespace GetIntoTeachingApiTests.Services
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
         [InlineData("jane@doe.com", "Jane", "Doe", "Jane")]
         [InlineData("bob@doe.com", "Bob", "Doe", null)]
+        [InlineData("inactive@doe.com", "Inactive", "Doe", null)]
         public void MatchCandidate_WithExistingCandidateRequest_MatchesOnNewestCandidateWithEmail(
             string email,
             string firstName,
@@ -313,24 +314,34 @@ namespace GetIntoTeachingApiTests.Services
             var candidate1 = new Entity("contact");
             candidate1.Id = JaneDoeGuid;
             candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
+            candidate1["statecode"] = CrmService.CandidateStatus.Active;
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";
             candidate1["createdon"] = DateTime.Now;
 
             var candidate2 = new Entity("contact");
+            candidate2["statecode"] = CrmService.CandidateStatus.Active;
             candidate2["emailaddress1"] = "john@doe.com";
             candidate2["firstname"] = "New John";
             candidate2["lastname"] = "Doe";
             candidate2["createdon"] = DateTime.Now;
 
             var candidate3 = new Entity("contact");
+            candidate3["statecode"] = CrmService.CandidateStatus.Active;
             candidate3["emailaddress1"] = "john@doe.com";
             candidate3["firstname"] = "Old John";
             candidate3["lastname"] = "Doe";
             candidate3["createdon"] = DateTime.Now.AddDays(-5);
 
-            return new[] { candidate1, candidate2, candidate3 }.AsQueryable();
+            var candidate4 = new Entity("contact");
+            candidate4["statecode"] = CrmService.CandidateStatus.Inactive;
+            candidate4["emailaddress1"] = "inactive@doe.com";
+            candidate4["firstname"] = "Inactive";
+            candidate4["lastname"] = "Doe";
+            candidate4["createdon"] = DateTime.Now;
+
+            return new[] { candidate1, candidate2, candidate3, candidate4 }.AsQueryable();
         }
 
         private static IQueryable<Entity> MockCallbackBookingQuotas()

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -216,6 +216,26 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void MatchCandidate_WithMasterChildRecords_ReturnsMasterRecord()
+        {
+            var request = new ExistingCandidateRequest
+            {
+                Email = "master@record.com", 
+                LastName = "Record", 
+                DateOfBirth = new DateTime(2000, 1, 1)
+            };
+            _mockService.Setup(mock => mock.CreateQuery("contact", _context)).Returns(MockCandidates());
+            _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
+                new Relationship("dfe_contact_dfe_candidatequalification_ContactId"), _context));
+            _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
+                new Relationship("dfe_contact_dfe_candidatepastteachingposition_ContactId"), _context));
+
+            var result = _crm.MatchCandidate(request);
+
+            result?.FirstName.Should().Be("Master");
+        }
+
+        [Fact]
         public void Save_MapsEntityAndSavesContext()
         {
             var entity = new Entity() { Id = Guid.NewGuid() };
@@ -318,30 +338,52 @@ namespace GetIntoTeachingApiTests.Services
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";
-            candidate1["createdon"] = DateTime.Now;
+            candidate1["modifiedon"] = DateTime.Now;
+            candidate1["merged"] = false;
 
             var candidate2 = new Entity("contact");
             candidate2["statecode"] = CrmService.CandidateStatus.Active;
             candidate2["emailaddress1"] = "john@doe.com";
             candidate2["firstname"] = "New John";
             candidate2["lastname"] = "Doe";
-            candidate2["createdon"] = DateTime.Now;
+            candidate2["modifiedon"] = DateTime.Now;
+            candidate2["merged"] = false;
 
             var candidate3 = new Entity("contact");
             candidate3["statecode"] = CrmService.CandidateStatus.Active;
             candidate3["emailaddress1"] = "john@doe.com";
             candidate3["firstname"] = "Old John";
             candidate3["lastname"] = "Doe";
-            candidate3["createdon"] = DateTime.Now.AddDays(-5);
+            candidate3["modifiedon"] = DateTime.Now.AddDays(-5);
+            candidate3["merged"] = false;
 
             var candidate4 = new Entity("contact");
             candidate4["statecode"] = CrmService.CandidateStatus.Inactive;
             candidate4["emailaddress1"] = "inactive@doe.com";
             candidate4["firstname"] = "Inactive";
             candidate4["lastname"] = "Doe";
-            candidate4["createdon"] = DateTime.Now;
+            candidate4["modifiedon"] = DateTime.Now;
+            candidate4["merged"] = false;
 
-            return new[] { candidate1, candidate2, candidate3, candidate4 }.AsQueryable();
+            var candidate5 = new Entity("contact");
+            candidate5["statecode"] = CrmService.CandidateStatus.Active;
+            candidate5["emailaddress1"] = "master@record.com";
+            candidate5["firstname"] = "Child";
+            candidate5["lastname"] = "Record";
+            candidate5["modifiedon"] = DateTime.Now;
+            candidate5["birthdate"] = new DateTime(2000, 1, 1);
+            candidate5["merged"] = true;
+
+            var candidate6 = new Entity("contact");
+            candidate6["statecode"] = CrmService.CandidateStatus.Active;
+            candidate6["emailaddress1"] = "master@record.com";
+            candidate6["firstname"] = "Master";
+            candidate6["lastname"] = "Record";
+            candidate6["modifiedon"] = DateTime.Now.AddDays(-5);
+            candidate6["birthdate"] = new DateTime(2000, 1, 1);
+            candidate6["merged"] = false;
+
+            return new[] { candidate1, candidate2, candidate3, candidate4, candidate5, candidate6 }.AsQueryable();
         }
 
         private static IQueryable<Entity> MockCallbackBookingQuotas()

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -195,7 +195,7 @@ namespace GetIntoTeachingApiTests.Services
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
         [InlineData("jane@doe.com", "Jane", "Doe", "Jane")]
         [InlineData("bob@doe.com", "Bob", "Doe", null)]
-        public void GetCandidate_WithExistingCandidateRequest_MatchesOnNewestCandidateWithEmail(
+        public void MatchCandidate_WithExistingCandidateRequest_MatchesOnNewestCandidateWithEmail(
             string email,
             string firstName,
             string lastName,
@@ -209,7 +209,7 @@ namespace GetIntoTeachingApiTests.Services
             _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
                 new Relationship("dfe_contact_dfe_candidatepastteachingposition_ContactId"), _context));
 
-            var result = _crm.GetCandidate(request);
+            var result = _crm.MatchCandidate(request);
 
             result?.FirstName.Should().Be(expectedFirstName);
         }


### PR DESCRIPTION
- Rename GetCandidate to MatchCandidate

There is another `GetCandidate` method on the `ICrmService` that accepts a candidate ID; renaming this method to avoid confusion -- this is the method that should be used to 'matchback' an existing candidate.

- Ignore candidates with inactive statecode

According to the CRM team any 'merged' contact records will be set as inactive, so we don't need to explicitly check for the master record.

- Prioritise master records over merged children

Master records have a `merged` attribute of `false`; these should be prioritised over child records (that have been merged into a master record).