### PR TITLE
Convert API payloads to snake_case

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Microsoft.Xrm.Sdk;
+using Newtonsoft.Json.Serialization;
 using Prometheus;
 using Swashbuckle.AspNetCore.Swagger;
 
@@ -69,7 +70,8 @@ namespace GetIntoTeachingApi
             services.AddControllers().AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();
-            });
+            }).AddJsonOptions(options =>
+                options.JsonSerializerOptions.PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance);
 
             services.AddSwaggerGen(c =>
             {

--- a/GetIntoTeachingApi/Utils/SnakeCaseNamingPolicy.cs
+++ b/GetIntoTeachingApi/Utils/SnakeCaseNamingPolicy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Text.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class SnakeCaseNamingPolicy : JsonNamingPolicy
+    {
+        private readonly SnakeCaseNamingStrategy _newtonsoftSnakeCaseNamingStrategy
+            = new SnakeCaseNamingStrategy();
+
+        public static SnakeCaseNamingPolicy Instance { get; } = new SnakeCaseNamingPolicy();
+
+        public override string ConvertName(string name)
+        {
+            return _newtonsoftSnakeCaseNamingStrategy.GetPropertyName(name, false);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/SnakeCaseNamingPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Utils/SnakeCaseNamingPolicyTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class SnakeCaseNamingPolicyTests
+    {
+        [Theory]
+        [InlineData("helloWorld", "hello_world")]
+        [InlineData("HelloWorld", "hello_world")]
+        [InlineData("hello_world", "hello_world")]
+        [InlineData("HELLOWORLD", "helloworld")]
+        public void ConvertName_ConvertsCorrectly(string candidate, string expected)
+        {
+            SnakeCaseNamingPolicy.Instance.ConvertName(candidate).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
The expectation is that Ruby applications will be consuming the API predominantly, so it makes sense to accept snake_case attributes instead of the default camelCase to make the implementation simpler on the service consuming the API.