### PR TITLE
Exclude un-testable files from coverage reports

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,6 +24,22 @@ jobs:
         run: |
           sudo dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
           dotnet build-server shutdown
-          dotnet sonarscanner begin /k:"DFE-Digital_get-into-teaching-api" /o:"dfe-digital" /n:"get-into-teaching-api" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="GetIntoTeachingApiTests/coverage.opencover.xml" /d:sonar.coverage.exclusions="GetIntoTeachingApiTests/**/*" /d:sonar.verbose=true /d:sonar.log.level="DEBUG"
+          dotnet sonarscanner begin \
+            /k:"DFE-Digital_get-into-teaching-api" \
+            /o:"dfe-digital" \
+            /n:"get-into-teaching-api" \
+            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.opencover.reportsPaths="GetIntoTeachingApiTests/coverage.opencover.xml" \
+            /d:sonar.coverage.exclusions="\
+                GetIntoTeachingApiTests/**/*,\
+                GetIntoTeachingApi/Migrations/*.cs,\
+                GetIntoTeachingApi/Adapters/*.cs,\
+                GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs\
+                GetIntoTeachingApi/Startup.cs\
+                GetIntoTeachingApi/Program.cs\
+            " \
+            /d:sonar.verbose=true \
+            /d:sonar.log.level="DEBUG"
           sudo dotnet build
           dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Omits files that cannot be unit tested from coverage reports:

- Migrations
- Adapters (abstracting untestable dependencies)
- Database Factory (used for migrations only)
- Startup.cs
- Program.cs