### PR TITLE
Add basic integration test

### DIFF
--- a/GetIntoTeachingApi/Models/MappingInfo.cs
+++ b/GetIntoTeachingApi/Models/MappingInfo.cs
@@ -13,6 +13,10 @@ namespace GetIntoTeachingApi.Models
         public IDictionary<string, IDictionary<string, string>> Relationships { get; set; } =
             new Dictionary<string, IDictionary<string, string>>();
 
+        public MappingInfo()
+        {
+        }
+
         public MappingInfo(Type type)
         {
             _type = type;

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -53,7 +53,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<IEnv>(env);
 
-            if (env.IsDevelopment)
+            if (env.IsDevelopment || env.IsTest)
             {
                 var keepAliveConnection = new SqliteConnection("DataSource=:memory:");
                 services.AddDbContext<GetIntoTeachingDbContext>(builder => DbConfiguration.ConfigSqLite(builder, keepAliveConnection));
@@ -124,7 +124,7 @@ The GIT API aims to provide:
                     .UseRecommendedSerializerSettings()
                     .UseFilter(automaticRetry);
 
-                if (env.IsDevelopment)
+                if (env.IsDevelopment || env.IsTest)
                 {
                     config.UseMemoryStorage().WithJobExpirationTimeout(JobConfiguration.ExpirationTimeout);
                 }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -7,6 +7,7 @@ namespace GetIntoTeachingApi.Utils
         public bool IsDevelopment => EnvironmentName == "Development";
         public bool IsProduction => EnvironmentName == "Production";
         public bool IsStaging => EnvironmentName == "Staging";
+        public bool IsTest => EnvironmentName == null;
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -5,6 +5,7 @@
         bool IsDevelopment { get; }
         bool IsStaging { get; }
         bool IsProduction { get; }
+        bool IsTest { get; }
         bool ExportHangireToPrometheus { get; }
         string DatabaseInstanceName { get; }
         string HangfireInstanceName { get; }

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -16,6 +16,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="5.10.3" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 	<PackageReference Include="Moq" Version="4.14.1" />

--- a/GetIntoTeachingApiTests/Integration/OperationsControllerIntegrationTests.cs
+++ b/GetIntoTeachingApiTests/Integration/OperationsControllerIntegrationTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using FluentAssertions;
+using GetIntoTeachingApi;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.AspNetCore.Mvc.Testing;
+using WireMock;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Integration
+{
+    public class OperationsControllerIntegrationTests : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly HttpClient _client;
+
+        public OperationsControllerIntegrationTests(WebApplicationFactory<Startup> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async void GenerateMappingInfo_ReturnsCorrectly()
+        {
+            var httpResponse = await _client.GetAsync("/api/operations/generate_mapping_info");
+
+            httpResponse.EnsureSuccessStatusCode();
+
+            var json = await httpResponse.Content.ReadAsStringAsync();
+            var mappingInfo = JsonSerializer.Deserialize<IEnumerable<MappingInfo>>(json);
+
+            mappingInfo.Count().Should().Be(10);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -42,6 +42,7 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("Development", true)]
         [InlineData("Staging", false)]
         [InlineData("Production", false)]
+        [InlineData(null, false)]
         public void IsDevelopment_TrueOnlyForDevelopment(string environment, bool expected)
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
@@ -53,6 +54,7 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("Development", false)]
         [InlineData("Staging", false)]
         [InlineData("Production", true)]
+        [InlineData(null, false)]
         public void IsProduction_TrueOnlyForProduction(string environment, bool expected)
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
@@ -64,11 +66,24 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("Development", false)]
         [InlineData("Staging", true)]
         [InlineData("Production", false)]
+        [InlineData(null, false)]
         public void IsStaging_TrueOnlyForStaging(string environment, bool expected)
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
 
             _env.IsStaging.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("Development", false)]
+        [InlineData("Staging", false)]
+        [InlineData("Production", false)]
+        public void IsTest_TrueOnlyForNull(string environment, bool expected)
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+
+            _env.IsTest.Should().Be(expected);
         }
 
         [Fact]


### PR DESCRIPTION
We will be end-to-end testing separately to ensure the integration with Dynamics is functioning correctly, however we won't run these tests as often as the unit/integration tests. This PR adds a basic integration test that will test the full request/response stack.