### PR TITLE
Support HTTP ETag/If-Not-Modified headers for CRM content

### DIFF
--- a/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using GetIntoTeachingApi.Jobs;
+using Hangfire;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace GetIntoTeachingApi.Filters
+{
+    public class CrmETagAttribute : Attribute, IActionFilter
+    {
+        private readonly JobStorage _hangfireJobStorage;
+
+        public CrmETagAttribute()
+        {
+            _hangfireJobStorage = JobStorage.Current;
+        }
+
+        public CrmETagAttribute(JobStorage hangfireJobStorage)
+        {
+            _hangfireJobStorage = hangfireJobStorage;
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var canCacheRequest = context.HttpContext.Request.Method == "GET";
+
+            if (!canCacheRequest)
+            {
+                return;
+            }
+
+            var path = context.HttpContext.Request.Path.ToString();
+            var queryString = context.HttpContext.Request.QueryString.ToString();
+            var eTag = GenerateETag($"{path}{queryString}", CrmSyncNextExecutionAt());
+            var ifNoneMatchHeader = context.HttpContext.Request.Headers["If-None-Match"].ToString();
+
+            if (ifNoneMatchHeader == eTag)
+            {
+                context.Result = new StatusCodeResult((int)HttpStatusCode.NotModified);
+            }
+
+            context.HttpContext.Response.Headers.Add("ETag", new[] { eTag });
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            var canCacheStatusCode = context.HttpContext.Response.StatusCode == (int)HttpStatusCode.OK;
+
+            if (canCacheStatusCode)
+            {
+                return;
+            }
+
+            // Ensure we never cache a bad response.
+            context.HttpContext.Response.Headers.Remove("ETag");
+        }
+
+        private static string GenerateETag(string url, string nextSyncAt)
+        {
+            var text = $"{url}{nextSyncAt}";
+            using var sha256 = new SHA256Managed();
+            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(text));
+
+            return BitConverter.ToString(hash).Replace("-", string.Empty);
+        }
+
+        private string CrmSyncNextExecutionAt()
+        {
+            var connection = _hangfireJobStorage.GetConnection();
+            var recurringJob = connection.GetAllEntriesFromHash(
+                $"recurring-job:{JobConfiguration.CrmSyncJobId}");
+
+            return recurringJob?["NextExecution"];
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -20,6 +21,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("latest")]
         [SwaggerOperation(
             Summary = "Retrieves the latest privacy policy.",

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -28,6 +29,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("upcoming")]
         [SwaggerOperation(
             Summary = "Retrieves the upcoming teaching events.",
@@ -50,6 +52,7 @@ maximum of 50 using the `limit` query parameter.",
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("search")]
         [SwaggerOperation(
             Summary = "Searches for teaching events.",
@@ -70,6 +73,7 @@ maximum of 50 using the `limit` query parameter.",
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("{id}")]
         [SwaggerOperation(
             Summary = "Retrieves an event.",

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -22,6 +23,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("countries")]
         [SwaggerOperation(
             Summary = "Retrieves the list of countries.",
@@ -34,6 +36,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("teaching_subjects")]
         [SwaggerOperation(
             Summary = "Retrieves the list of teaching subjects.",
@@ -46,6 +49,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("candidate/initial_teacher_training_years")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate initial teacher training years.",
@@ -58,6 +62,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("candidate/preferred_education_phases")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate preferred education phases.",
@@ -70,6 +75,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("candidate/locations")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate locations.",
@@ -82,6 +88,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("candidate/channels")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate channels.",
@@ -94,6 +101,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("qualification/degree_status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of qualification degree status.",
@@ -106,6 +114,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("qualification/categories")]
         [SwaggerOperation(
             Summary = "Retrieves the list of qualification categories.",
@@ -118,6 +127,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("qualification/types")]
         [SwaggerOperation(
             Summary = "Retrieves the list of qualification types.",
@@ -130,6 +140,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("past_teaching_position/education_phases")]
         [SwaggerOperation(
             Summary = "Retrieves the list of past teaching position education phases.",
@@ -142,6 +153,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("teaching_event/types")]
         [SwaggerOperation(
             Summary = "Retrieves the list of teaching event types.",
@@ -154,6 +166,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("phone_call/channels")]
         [SwaggerOperation(
             Summary = "Retrieves the list of phone call channels.",

--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -8,5 +8,7 @@ namespace GetIntoTeachingApi.Jobs
         public static int Attempts(IEnv env) => env.IsDevelopment ? 5 : 24;
         public static int RetryIntervalInSeconds(IEnv env) => env.IsDevelopment ? 60 : 3600;
         public static TimeSpan ExpirationTimeout => TimeSpan.FromHours(24);
+        public static string CrmSyncJobId => "crm-sync";
+        public static string LocationSyncJobId => "location-sync";
     }
 }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -181,9 +181,9 @@ The GIT API aims to provide:
             app.UseAuthorization();
 
             // Configure recurring jobs.
-            RecurringJob.AddOrUpdate<CrmSyncJob>("crm-sync", (x) => x.RunAsync(), Cron.Daily());
+            RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), Cron.Daily);
             RecurringJob.AddOrUpdate<LocationSyncJob>(
-                "location-sync",
+                JobConfiguration.LocationSyncJobId,
                 (x) => x.RunAsync("https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip"),
                 Cron.Weekly());
 
@@ -195,13 +195,13 @@ The GIT API aims to provide:
             if (!env.IsTest)
             {
                 // Sync with the CRM.
-                RecurringJob.Trigger("crm-sync");
+                RecurringJob.Trigger(JobConfiguration.CrmSyncJobId);
 
                 // Initial locations sync.
                 var dbContext = serviceScope.ServiceProvider.GetService<GetIntoTeachingDbContext>();
                 if (!dbContext.Locations.Any())
                 {
-                    RecurringJob.Trigger("location-sync");
+                    RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
                 }
             }
 

--- a/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
@@ -1,0 +1,228 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using GetIntoTeachingApi.Filters;
+using GetIntoTeachingApi.Jobs;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Filters
+{
+    public class CrmETagAttributeTests
+    {
+        private readonly CrmETagAttribute _filter;
+        private readonly ActionExecutingContext _actionExecutingContext;
+        private readonly ActionExecutedContext _actionExecutedContext;
+        private readonly StatusCodeResult _originalResult;
+        private readonly Mock<HttpContext> _mockHttpContext;
+        private readonly Mock<IStorageConnection> _mockStorageConnection;
+
+        public CrmETagAttributeTests()
+        {
+            var actionContext = new ActionContext(
+                Mock.Of<HttpContext>(),
+                Mock.Of<RouteData>(),
+                Mock.Of<ActionDescriptor>(),
+                new ModelStateDictionary()
+            );
+
+            _actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                Mock.Of<Controller>()
+            );
+
+            _actionExecutedContext = new ActionExecutedContext(
+                actionContext, 
+                new List<IFilterMetadata>(), 
+                Mock.Of<Controller>()
+            );
+
+            _mockHttpContext = new Mock<HttpContext>();
+            _originalResult = new StatusCodeResult((int)HttpStatusCode.OK);
+            _actionExecutingContext.HttpContext = _mockHttpContext.Object;
+            _actionExecutedContext.HttpContext = _mockHttpContext.Object;
+            _actionExecutingContext.Result = _originalResult;
+
+            _mockStorageConnection = new Mock<IStorageConnection>();
+            var mockStorage = new Mock<JobStorage>();
+            mockStorage.Setup(m => m.GetConnection()).Returns(_mockStorageConnection.Object);
+
+            _filter = new CrmETagAttribute(mockStorage.Object);
+        }
+
+        [Theory]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public void OnActionExecuting_NoneGetRequest_IsIgnored(string method)
+        {
+            _mockHttpContext.Setup(m => m.Request.Method).Returns(method);
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _actionExecutingContext.Result.Should().Be(_originalResult);
+            _mockHttpContext.Verify(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()), Times.Never);
+        }
+
+        [Fact]
+        public void OnActionExecuting_DifferentPaths_RespondsWithUniqueETags()
+        {
+            var eTags = new List<string>();
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.SetupSequence(m => m.Request.Path)
+                .Returns("/path/to/resource1")
+                .Returns("/path/to/resource2");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()))
+                .Callback<string, StringValues>((key, values) => eTags.AddRange(values.ToArray()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            eTags.Distinct().Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void OnActionExecuting_BeforeFirstCrmSyncJobHasRan_RespondsWithAnETag()
+        {
+            const string eTag = "2B75BAF65CCDB4D32112CBEA0D66505CD5EC5A05D699EF8ED79169ED128D2F38";
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockHttpContext.Verify(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+        }
+
+        [Fact]
+        public void OnActionExecuting_AfterCrmSyncJobHasRan_RespondsWithNewETag()
+        {
+            const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
+            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
+                $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockHttpContext.Verify(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithMatchingIfNoneMatch_Responds304NotModified()
+        {
+            const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
+            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
+                $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns(eTag);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _actionExecutingContext.Result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should()
+                .Be((int) HttpStatusCode.NotModified);
+            _mockHttpContext.Verify(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithDifferentIfNoneMatch_RespondsWithResultAndETag()
+        {
+            const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
+            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
+                $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns("wrong-etag");
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _actionExecutingContext.Result.Should().Be(_originalResult);
+            _mockHttpContext.Verify(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+        }
+
+        [Fact]
+        public void OnActionExecuting_SamePathDifferentQueryString_RespondsWithUniqueETag()
+        {
+            var eTags = new List<string>();
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.SetupSequence(m => m.Request.Path)
+                .Returns("/path/to/resource1?test=one")
+                .Returns("/path/to/resource1?test=two");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.IsAny<StringValues>()))
+                .Callback<string, StringValues>((key, values) => eTags.AddRange(values.ToArray()));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            eTags.Distinct().Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void OnActionExecuted_BadResponse_ClearsETag()
+        {
+            const string eTag = "2B75BAF65CCDB4D32112CBEA0D66505CD5EC5A05D699EF8ED79169ED128D2F38";
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockHttpContext.Setup(m => m.Response.StatusCode)
+                .Returns((int)HttpStatusCode.InternalServerError);
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockHttpContext.Verify(m => m.Response.Headers.Remove("ETag"));
+        }
+
+        [Fact]
+        public void OnActionExecuted_OkResponse_RetainsETag()
+        {
+            const string eTag = "2B75BAF65CCDB4D32112CBEA0D66505CD5EC5A05D699EF8ED79169ED128D2F38";
+            _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
+            _mockHttpContext.Setup(m => m.Request.Method).Returns("GET");
+            _mockHttpContext.Setup(m => m.Request.QueryString).Returns(new QueryString());
+            _mockHttpContext.Setup(m => m.Request.Path).Returns("/path/to/resource1");
+            _mockHttpContext.Setup(m => m.Response.Headers.Add("ETag", It.Is<StringValues>(v => v.Contains(eTag))));
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockHttpContext.Setup(m => m.Response.StatusCode)
+                .Returns((int)HttpStatusCode.OK);
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockHttpContext.Verify(m => m.Response.Headers.Remove("ETag"), Times.Never);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -5,6 +5,8 @@ using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using System;
+using GetIntoTeachingApi.Filters;
+using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
 
@@ -25,6 +27,13 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(PrivacyPoliciesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void CrmETag_IsPresent()
+        {
+            JobStorage.Current = new Mock<JobStorage>().Object;
+            typeof(PrivacyPoliciesController).GetMethod("GetLatest").Should().BeDecoratedWith<CrmETagAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using Moq;
@@ -13,6 +14,7 @@ using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
+using MoreLinq;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -33,6 +35,16 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(TeachingEventsController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+
+        [Fact]
+        public void CrmETag_IsPresent()
+        {
+            JobStorage.Current = new Mock<JobStorage>().Object;
+            var methods = new [] { "GetUpcoming", "Get", "Search" };
+
+            methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -4,10 +4,13 @@ using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 using System;
+using System.Reflection;
+using GetIntoTeachingApi.Filters;
+using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using MoreLinq;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Controllers
@@ -27,6 +30,15 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(TypesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void CrmETag_IsPresent()
+        {
+            JobStorage.Current = new Mock<JobStorage>().Object;
+            var methods = typeof(TypesController).GetMethods(BindingFlags.DeclaredOnly);
+
+            methods.ForEach(m => m.Should().BeDecoratedWith<CrmETagAttribute>());
         }
 
         [Fact]


### PR DESCRIPTION
Content is currently synced from the CRM on a weekly basis; any requests made should be cachable up until the moment a new sync has been performed. To achieve this, the PR generates an `ETag` based on the next CRM sync job execution date (which changes after a successful sync) along with the request path. When an `If-Not-Modified` header is sent containing the current `ETag` we immediately respond with a 304 (not modified) header, avoiding the overhead of calling the action and querying the data. If an incorrect/outdated `ETag` is present (or no `If-Not-Modified` header is provided) then the request completes as normal and returns an `ETag`.

Another way to do this would be to compute the `ETag` from the response body, but this has the overhead of actually having to fulfil the response (although it means the `ETag` would not change across syncs, which would mean the cache may be valid for longer).

Any non-200 responses are stripped of their `ETag` in the `OnActionExecuted` callback to ensure bad responses are never cached.

Adds `CrmETag` attribute to cachable actions.