### PR TITLE
Candidate privacy policy schema changes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -10,6 +10,12 @@ namespace GetIntoTeachingApi.Models
     [Entity(LogicalName = "contact")]
     public class Candidate : BaseModel
     {
+        public enum Status
+        {
+            Active,
+            Inactive,
+        }
+
         [EntityField(Name = "dfe_preferredteachingsubject01", Type = typeof(EntityReference), Reference = "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
         [EntityField(Name = "dfe_preferrededucationphase01", Type = typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -8,8 +9,22 @@ namespace GetIntoTeachingApi.Models
     [Entity(LogicalName = "dfe_candidateprivacypolicy")]
     public class CandidatePrivacyPolicy : BaseModel
     {
+        public const int Consent = 222750001;
+
         [EntityField(Name = "dfe_privacypolicynumber", Type = typeof(EntityReference), Reference = "dfe_privacypolicy")]
         public Guid AcceptedPolicyId { get; set; }
+        [JsonIgnore]
+        [EntityField(Name = "dfe_consentreceivedby", Type = typeof(OptionSetValue))]
+        public int ConsentReceivedById { get; set; } = Consent;
+        [JsonIgnore]
+        [EntityField(Name = "dfe_meanofconsent", Type = typeof(OptionSetValue))]
+        public int MeanOfConsentId { get; set; } = Consent;
+        [JsonIgnore]
+        [EntityField(Name = "dfe_name")]
+        public string Description { get; set; } = "Online consent as part of web registration";
+        [JsonIgnore]
+        [EntityField(Name = "dfe_timeofconsent")]
+        public DateTime AcceptedAt { get; set; } = DateTime.Now;
 
         public CandidatePrivacyPolicy()
             : base()

--- a/GetIntoTeachingApi/Models/PrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/PrivacyPolicy.cs
@@ -8,6 +8,11 @@ namespace GetIntoTeachingApi.Models
     [Entity(LogicalName = "dfe_privacypolicy")]
     public class PrivacyPolicy : BaseModel
     {
+        public enum Type
+        {
+            Web = 222750001,
+        }
+
         [EntityField(Name = "dfe_details")]
         public string Text { get; set; }
         [EntityField(Name = "createdon")]

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -28,7 +28,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressPostcode).NotEmpty().MaximumLength(40);
 
             RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator(store)).Unless(candidate => candidate.PhoneCall == null);
-            RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(store)).Unless(candidate => candidate.PrivacyPolicy == null);
+            RuleFor(candidate => candidate.PrivacyPolicy).NotNull().SetValidator(new CandidatePrivacyPolicyValidator(store));
             RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(store));
             RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(store));
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -11,17 +11,6 @@ namespace GetIntoTeachingApi.Services
 {
     public class CrmService : ICrmService
     {
-        public enum PrivacyPolicyType
-        {
-            Web = 222750001,
-        }
-
-        public enum CandidateStatus
-        {
-            Active,
-            Inactive,
-        }
-
         private const int MaximumNumberOfCandidatesToMatch = 20;
         private const int MaximumNumberOfPrivacyPolicies = 3;
         private const int MaximumCallbackBookingQuotaDaysInAdvance = 14;
@@ -62,7 +51,7 @@ namespace GetIntoTeachingApi.Services
         {
             return _service.CreateQuery("dfe_privacypolicy", Context())
                 .Where((entity) =>
-                    entity.GetAttributeValue<OptionSetValue>("dfe_policytype").Value == (int)PrivacyPolicyType.Web &&
+                    entity.GetAttributeValue<OptionSetValue>("dfe_policytype").Value == (int)PrivacyPolicy.Type.Web &&
                     entity.GetAttributeValue<bool>("dfe_active"))
                 .OrderByDescending((policy) => policy.GetAttributeValue<DateTime>("createdon"))
                 .Select((entity) => new PrivacyPolicy(entity, this))
@@ -74,7 +63,7 @@ namespace GetIntoTeachingApi.Services
             var context = Context();
             var entity = _service.CreateQuery("contact", context)
                 .Where(e =>
-                    e.GetAttributeValue<int>("statecode") == (int)CandidateStatus.Active &&
+                    e.GetAttributeValue<int>("statecode") == (int)Candidate.Status.Active &&
                     e.GetAttributeValue<string>("emailaddress1") == request.Email) // Will perform a case-insensitive comparison
                 .OrderByDescending(e => e.GetAttributeValue<double>("dfe_duplicatescorecalculated"))
                 .ThenByDescending(e => e.GetAttributeValue<DateTime>("modifiedon"))

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -161,7 +161,8 @@ The GIT API aims to provide:
 
             app.UseSwagger(c =>
             {
-                c.SerializeAsV2 = true;
+                // The UI generated for V2 is buggy, so use V3 in development.
+                c.SerializeAsV2 = !env.IsDevelopment;
             });
 
             app.UseSwaggerUI(c =>

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 using System;
 using Microsoft.AspNetCore.Authorization;

--- a/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using Microsoft.Xrm.Sdk;
@@ -17,6 +18,36 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("AcceptedPolicyId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_privacypolicynumber" && a.Type == typeof(EntityReference) && a.Reference == "dfe_privacypolicy");
+
+            type.GetProperty("ConsentReceivedById").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_consentreceivedby");
+            type.GetProperty("MeanOfConsentId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_meanofconsent");
+
+            type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_name");
+            type.GetProperty("AcceptedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_timeofconsent");
+        }
+
+        [Fact]
+        public void ConsentReceivedById_DefaultValue_IsCorrect()
+        {
+            new CandidatePrivacyPolicy().ConsentReceivedById.Should().Be(CandidatePrivacyPolicy.Consent);
+        }
+
+        [Fact]
+        public void MeanOfConsentId_DefaultValue_IsCorrect()
+        {
+            new CandidatePrivacyPolicy().MeanOfConsentId.Should().Be(CandidatePrivacyPolicy.Consent);
+        }
+
+        [Fact]
+        public void Description_DefaultValue_IsCorrect()
+        {
+            new CandidatePrivacyPolicy().Description.Should().Be("Online consent as part of web registration");
+        }
+
+        [Fact]
+        public void AcceptedAt_DefaultValue_IsNow()
+        {
+            new CandidatePrivacyPolicy().AcceptedAt.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -30,6 +30,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var mockLocation = NewMock(222);
             var mockInitialTeacherTrainingYear = NewMock(333);
             var mockChannel = NewMock(444);
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
 
             _mockStore
                 .Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist"))
@@ -46,6 +47,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
             _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
                 .Returns(new[] { mockChannel }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetPrivacyPolicies())
+                .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
 
             var candidate = new Candidate()
             {
@@ -65,6 +69,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 LocationId = int.Parse(mockLocation.Id),
                 InitialTeacherTrainingYearId = int.Parse(mockInitialTeacherTrainingYear.Id),
                 ChannelId = int.Parse(mockChannel.Id),
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
             };
 
             var result = _validator.TestValidate(candidate);
@@ -125,6 +130,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.PrivacyPolicy.AcceptedPolicyId);
+        }
+
+        [Fact]
+        public void Validate_PrivacyPolicyIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PrivacyPolicy, null as CandidatePrivacyPolicy);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -350,7 +350,7 @@ namespace GetIntoTeachingApiTests.Services
             var candidate1 = new Entity("contact");
             candidate1.Id = JaneDoeGuid;
             candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
-            candidate1["statecode"] = CrmService.CandidateStatus.Active;
+            candidate1["statecode"] = Candidate.Status.Active;
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";
@@ -358,7 +358,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate1["dfe_duplicatescorecalculated"] = 10.0;
 
             var candidate2 = new Entity("contact");
-            candidate2["statecode"] = CrmService.CandidateStatus.Active;
+            candidate2["statecode"] = Candidate.Status.Active;
             candidate2["emailaddress1"] = "john@doe.com";
             candidate2["firstname"] = "New John";
             candidate2["lastname"] = "Doe";
@@ -366,7 +366,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate2["dfe_duplicatescorecalculated"] = 9.5;
 
             var candidate3 = new Entity("contact");
-            candidate3["statecode"] = CrmService.CandidateStatus.Active;
+            candidate3["statecode"] = Candidate.Status.Active;
             candidate3["emailaddress1"] = "john@doe.com";
             candidate3["firstname"] = "Old John";
             candidate3["lastname"] = "Doe";
@@ -374,7 +374,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate3["dfe_duplicatescorecalculated"] = 8.3;
 
             var candidate4 = new Entity("contact");
-            candidate4["statecode"] = CrmService.CandidateStatus.Inactive;
+            candidate4["statecode"] = Candidate.Status.Inactive;
             candidate4["emailaddress1"] = "inactive@doe.com";
             candidate4["firstname"] = "Inactive";
             candidate4["lastname"] = "Doe";
@@ -382,7 +382,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate4["dfe_duplicatescorecalculated"] = 7.1;
 
             var candidate5 = new Entity("contact");
-            candidate5["statecode"] = CrmService.CandidateStatus.Active;
+            candidate5["statecode"] = Candidate.Status.Inactive;
             candidate5["emailaddress1"] = "master@record.com";
             candidate5["firstname"] = "Child";
             candidate5["lastname"] = "Record";
@@ -391,7 +391,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate5["dfe_duplicatescorecalculated"] = 2.4;
 
             var candidate6 = new Entity("contact");
-            candidate6["statecode"] = CrmService.CandidateStatus.Active;
+            candidate6["statecode"] = Candidate.Status.Inactive;
             candidate6["emailaddress1"] = "master@record.com";
             candidate6["firstname"] = "Child1";
             candidate6["lastname"] = "Record";
@@ -400,7 +400,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate6["dfe_duplicatescorecalculated"] = null;
 
             var candidate7 = new Entity("contact");
-            candidate7["statecode"] = CrmService.CandidateStatus.Active;
+            candidate7["statecode"] = Candidate.Status.Inactive;
             candidate7["emailaddress1"] = "master@record.com";
             candidate7["firstname"] = "Master";
             candidate7["lastname"] = "Record";
@@ -449,7 +449,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var policy1 = new Entity("dfe_privacypolicy");
             policy1["dfe_details"] = "Latest Active Web";
-            policy1["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy1["dfe_policytype"] = new OptionSetValue { Value = (int)PrivacyPolicy.Type.Web };
             policy1["createdon"] = DateTime.UtcNow.AddDays(-10);
             policy1["dfe_active"] = true;
 
@@ -460,26 +460,26 @@ namespace GetIntoTeachingApiTests.Services
             policy2["dfe_active"] = true;
 
             var policy3 = new Entity("dfe_privacypolicy");
-            policy3["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy3["dfe_policytype"] = new OptionSetValue { Value = (int)PrivacyPolicy.Type.Web };
             policy3["dfe_details"] = "Not Active";
             policy3["createdon"] = DateTime.UtcNow.AddDays(-3);
             policy3["dfe_active"] = false;
 
             var policy4 = new Entity("dfe_privacypolicy");
             policy4["dfe_details"] = "Not Latest 1";
-            policy4["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy4["dfe_policytype"] = new OptionSetValue { Value = (int)PrivacyPolicy.Type.Web };
             policy4["createdon"] = DateTime.UtcNow.AddDays(-15);
             policy4["dfe_active"] = true;
 
             var policy5 = new Entity("dfe_privacypolicy");
             policy5["dfe_details"] = "Not Latest 2";
-            policy5["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy5["dfe_policytype"] = new OptionSetValue { Value = (int)PrivacyPolicy.Type.Web };
             policy5["createdon"] = DateTime.UtcNow.AddDays(-20);
             policy5["dfe_active"] = true;
 
             var policy6 = new Entity("dfe_privacypolicy");
             policy6["dfe_details"] = "Not Latest 3";
-            policy6["dfe_policytype"] = new OptionSetValue { Value = (int)CrmService.PrivacyPolicyType.Web };
+            policy6["dfe_policytype"] = new OptionSetValue { Value = (int)PrivacyPolicy.Type.Web };
             policy6["createdon"] = DateTime.UtcNow.AddDays(-25);
             policy6["dfe_active"] = true;
 


### PR DESCRIPTION
- Encapsulate enums in appropriate model

Enum types are currently in the `CrmService` - this was to keep the models unaware of the CRM, however the models are now coupled to the CRM anyway (since the mappings are now data attributes) so it makes more sense for the enum types
to be in the models as well.

- Add additional fields to CandidatePrivacyPolicy

Update the `CandidatePrivacyPolicy` model to include additional, hidden attributes that are required by the CRM.

- Generate v3 OpenAPI docs in development

The UI created by Swashbuckle for V2 Swagger docs is buggy (if you paste in JSON as a request body it doesn't always let you submit the form, but it doesn't give you an error either). This commit updates the Swashbuckle config to generate the more reliable V3 UI when in development, but creates V2 in other environments as this is needed to use the Swagger codegen tool for Ruby.