### PR TITLE
Update PhoneCall to reflect schema changes

### DIFF
--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GetIntoTeachingApi.Attributes;
+﻿using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
 

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -12,8 +13,21 @@ namespace GetIntoTeachingApi.Models
         public int? ChannelId { get; set; }
         [EntityField("scheduledstart")]
         public DateTime ScheduledAt { get; set; }
+        [JsonIgnore]
         [EntityField("phonenumber")]
         public string Telephone { get; set; }
+        [JsonIgnore]
+        [EntityField("subject")]
+        public string Subject { get; set; }
+        [JsonIgnore]
+        [EntityField("dfe_appointmentflag")]
+        public bool IsAppointment { get; set; } = false;
+        [JsonIgnore]
+        [EntityField("dfe_appointmentrequired")]
+        public bool AppointmentRequired { get; set; } = false;
+        [JsonIgnore]
+        [EntityField("directioncode")]
+        public bool IsDirectionCode { get; set; } = true;
 
         public PhoneCall()
             : base()
@@ -23,6 +37,12 @@ namespace GetIntoTeachingApi.Models
         public PhoneCall(Entity entity, ICrmService crm)
             : base(entity, crm)
         {
+        }
+
+        public void PopulateWithCandidate(Candidate candidate)
+        {
+            Telephone = candidate.Telephone;
+            Subject = $"Scheduled phone call requested by {candidate.FullName}";
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
@@ -26,12 +26,12 @@ namespace GetIntoTeachingApi.Models.Validators
 
         private IEnumerable<string> UkDegreeGradeIds()
         {
-            return _store.GetPickListItems("dfe_qualification", "dfe_ukdegreegrade").Select(grade => grade.Id);
+            return _store.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade").Select(grade => grade.Id);
         }
 
         private IEnumerable<string> StatusIds()
         {
-            return _store.GetPickListItems("dfe_qualification", "dfe_degreestatus").Select(status => status.Id);
+            return _store.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus").Select(status => status.Id);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
@@ -15,7 +15,6 @@ namespace GetIntoTeachingApi.Models.Validators
             _store = store;
 
             RuleFor(phoneCall => phoneCall.ScheduledAt).GreaterThan(candidate => DateTime.Now);
-            RuleFor(phoneCall => phoneCall.Telephone).NotEmpty().MaximumLength(50);
 
             RuleFor(candidate => candidate.ChannelId)
                 .Must(id => ChannelIds().Contains(id.ToString()))

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -20,6 +20,40 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("ScheduledAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "scheduledstart");
             type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "phonenumber");
+            type.GetProperty("Subject").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "subject");
+            type.GetProperty("IsAppointment").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_appointmentflag");
+            type.GetProperty("AppointmentRequired").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_appointmentrequired");
+            type.GetProperty("IsDirectionCode").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "directioncode");
+        }
+
+        [Fact]
+        public void PopulateWithCandidate_SetsTelephoneAndSubject()
+        {
+            var phoneCall = new PhoneCall();
+            var candidate = new Candidate() { FirstName = "John", LastName = "Doe", Telephone = "123456789" };
+
+            phoneCall.PopulateWithCandidate(candidate);
+
+            phoneCall.Telephone.Should().Be(candidate.Telephone);
+            phoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
+        }
+
+        [Fact]
+        public void IsAppointment_DefaultValue_IsCorrect()
+        {
+            new PhoneCall().IsAppointment.Should().BeFalse();
+        }
+
+        [Fact]
+        public void AppointmentRequired_DefaultValue_IsCorrect()
+        {
+            new PhoneCall().AppointmentRequired.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsDirectionCode_DefaultValue_IsCorrect()
+        {
+            new PhoneCall().IsDirectionCode.Should().BeTrue();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
@@ -28,10 +27,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var mockDegreeStatus = NewMock(333);
 
             _mockStore
-                .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_ukdegreegrade"))
+                .Setup(mock => mock.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade"))
                 .Returns(new[] { mockGrade }.AsQueryable());
             _mockStore
-                .Setup(mock => mock.GetPickListItems("dfe_qualification", "dfe_degreestatus"))
+                .Setup(mock => mock.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus"))
                 .Returns(new[] { mockDegreeStatus }.AsQueryable());
 
             var qualification = new CandidateQualification()

--- a/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
@@ -32,7 +32,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var phoneCall = new PhoneCall()
             {
                 ScheduledAt = DateTime.Now.AddDays(2),
-                Telephone = "07584 395 284",
                 ChannelId = int.Parse(mockChannel.Id),
             };
 
@@ -45,18 +44,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_ScheduledAtInPast_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ScheduledAt, DateTime.Now.AddDays(-1));
-        }
-
-        [Fact]
-        public void Validate_TelephoneIsEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.Telephone, "");
-        }
-
-        [Fact]
-        public void Validate_TelephoneTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.Telephone, new string('a', 51));
         }
 
         [Fact]


### PR DESCRIPTION
Certain fields of the `PhoneCall` model are populated using the data already collected in the `Candidate` model. This commit hooks into the mapping process to set the values on the `PhoneCall` before mapping it to an `Entity`.

Add a number of hidden fields with default values that the CRM expects.