### PR TITLE
Scan API with OWASP

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: ${GITHUB_WORKSPACE}/out/zap_run.html
+          path: /home/runner/work/get-into-teaching-api/get-into-teaching-api/out/zap_run.html
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -146,9 +146,9 @@ jobs:
 
       - name: ZAP Scan
         run: |
-          mkdir out
+          mkdir ./out
           chmod 777 out
-          docker run -t -v $(PWD)/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v $(PWD)/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
+          docker run -t -v ./zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ./out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \
               -r zap_run.html  \
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: out/
+          path: ./out/
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -151,15 +151,14 @@ jobs:
           docker run -t -v ${GITHUB_WORKSPACE}/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ${GITHUB_WORKSPACE}/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \
-              -r zap_run.html  \
-              -w zap_run.md    \
-              -J zap_run.json
+              -r zap_run.html 
+          ls -ail ${GITHUB_WORKSPACE}/out
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: ${GITHUB_WORKSPACE}/out
+          path: ${GITHUB_WORKSPACE}/out/zap_run.html
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -149,7 +149,7 @@ jobs:
           mkdir ${GITHUB_WORKSPACE}/out
           chmod 777 ${GITHUB_WORKSPACE}/out
           docker run -t -v ${GITHUB_WORKSPACE}/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ${GITHUB_WORKSPACE}/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
-              -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
+              -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}} \
               -f openapi \
               -r zap_run.html 
           ls -ail ${GITHUB_WORKSPACE}/out

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: ZAP Scan
         run: |
-          docker run -t owasp/zap2docker-stable zap-api-scan.py \
+          docker run -t -v $(PWD)/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v $(PWD):/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \
               -r zap_run.html  \

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -8,8 +8,10 @@ on:
       - master
 
 env:
-  DOCKERHUB_REPOSITORY:     dfedigital/get-into-teaching-api
-  CF_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  DOCKERHUB_REPOSITORY: dfedigital/get-into-teaching-api
+  CF_PROVIDER_DIR:      $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  CONTAINER:            get-into-teaching-api
+  DOMAIN:               london.cloudapps.digital
   
 jobs:
   build_docker:
@@ -61,7 +63,7 @@ jobs:
         env:
             SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
 
-  deploy_qa:
+  deploy:
     name: 'Deploy to Development'
     runs-on: ubuntu-latest
 
@@ -133,4 +135,30 @@ jobs:
              ENVIRON: "Development Test"
          env:
             SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+  owasp:
+    name: OWASP Test
+    runs-on: ubuntu-latest
+    if: always()
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: ZAP Scan
+        run: |
+          docker run -t owasp/zap2docker-stable zap-api-scan.py \
+              -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
+              -f openapi \
+              -r zap_run.html  \
+              -w zap_run.md    \
+              -J zap_run.json
+
+      - name:  Send Message to Sentry.io
+        if: always()
+        uses: sfawcett123/sentry-event@v1
+        with:
+             MESSAGE: "OWASP Application - get-into-teaching-api"
+             STATE:  ${{job.status}}
+             ENVIRON: "Development"
+        env:
+            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -147,6 +147,7 @@ jobs:
       - name: ZAP Scan
         run: |
           mkdir out
+          chmod 777 out
           docker run -t -v $(PWD)/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v $(PWD)/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -146,12 +146,19 @@ jobs:
 
       - name: ZAP Scan
         run: |
-          docker run -t -v $(PWD)/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v $(PWD):/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
+          mkdir out
+          docker run -t -v $(PWD)/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v $(PWD)/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \
               -r zap_run.html  \
               -w zap_run.md    \
               -J zap_run.json
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: zap_run
+          path: out/
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -146,9 +146,9 @@ jobs:
 
       - name: ZAP Scan
         run: |
-          mkdir ./out
-          chmod 777 out
-          docker run -t -v ./zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ./out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
+          mkdir ${GITHUB_WORKSPACE}/out
+          chmod 777 ${GITHUB_WORKSPACE}/out
+          docker run -t -v ${GITHUB_WORKSPACE}/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ${GITHUB_WORKSPACE}/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
               -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger.json \
               -f openapi \
               -r zap_run.html  \
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: ./out/
+          path: ${GITHUB_WORKSPACE}/out
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -146,14 +146,11 @@ jobs:
 
       - name: ZAP Scan
         run: |
-          mkdir ${GITHUB_WORKSPACE}/out
-          chmod 777 ${GITHUB_WORKSPACE}/out
+          mkdir -m a=rwx ${GITHUB_WORKSPACE}/out
           docker run -t -v ${GITHUB_WORKSPACE}/zap_rules.tsv:/zap/wrk/zap_rules.tsv  -v ${GITHUB_WORKSPACE}/out:/zap/wrk/:rw owasp/zap2docker-stable zap-api-scan.py \
-              -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}} \
+              -t  https://${{env.CONTAINER}}-dev.${{env.DOMAIN}}/swagger/v1/swagger.json \
               -f openapi \
               -r zap_run.html 
-          ls -ail ${GITHUB_WORKSPACE}/out
-          echo ${GITHUB_WORKSPACE}/out
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -153,12 +153,13 @@ jobs:
               -f openapi \
               -r zap_run.html 
           ls -ail ${GITHUB_WORKSPACE}/out
+          echo ${GITHUB_WORKSPACE}/out
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: ${{GITHUB_WORKSPACE}}/out/zap_run.html
+          path: ${GITHUB_WORKSPACE}/out/zap_run.html
 
       - name:  Send Message to Sentry.io
         if: always()

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -158,7 +158,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zap_run
-          path: ${GITHUB_WORKSPACE}/out/zap_run.html
+          path: ${{GITHUB_WORKSPACE}}/out/zap_run.html
 
       - name:  Send Message to Sentry.io
         if: always()


### PR DESCRIPTION
### Purpose
Trial of using the ZAP OWASP Scanner against the API

### Findings

1.  The scanner does not have an action out of the box for github
2. The scanner when configured seems to take too long to run, and maybe actually trying to execute the API, which could be problematic

### Conclusion
Do not run the ZAP OWASP Scanner on the API