### PR TITLE
Add ServiceSubscription and subscribe on TTA sign up

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -281,5 +281,18 @@ namespace GetIntoTeachingApi.Controllers
         {
             return Ok(await _store.GetPickListItems("phonecall", "dfe_destination").ToListAsync());
         }
+
+        [HttpGet]
+        [CrmETag]
+        [Route("service_subscription/types")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of subscription types.",
+            OperationId = "GetServiceSubscriptionTypes",
+            Tags = new[] { "Types" })]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public async Task<IActionResult> GetServiceSubscriptionTypes()
+        {
+            return Ok(await _store.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype").ToListAsync());
+        }
     }
 }

--- a/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
+++ b/GetIntoTeachingApi/Jobs/CandidateRegistrationJob.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -46,9 +47,28 @@ namespace GetIntoTeachingApi.Jobs
             }
             else
             {
+                AddServiceSubscription(candidate);
                 _crm.Save(candidate);
                 _logger.LogInformation("CandidateRegistrationJob - Succeeded");
             }
+        }
+
+        private void AddServiceSubscription(Candidate candidate)
+        {
+            var alreadySubscribed = candidate.Id != null && _crm.IsCandidateSubscribedToServiceOfType(
+                (Guid)candidate.Id, (int)ServiceSubscription.ServiceType.TeacherTrainingAdviser);
+
+            if (alreadySubscribed)
+            {
+                return;
+            }
+
+            var subscription = new ServiceSubscription()
+            {
+                TypeId = (int)ServiceSubscription.ServiceType.TeacherTrainingAdviser,
+            };
+
+            candidate.ServiceSubscriptions.Add(subscription);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -132,10 +132,12 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
 
+        [EntityRelationship("dfe_contact_dfe_servicesubscription_contact", typeof(ServiceSubscription))]
+        public List<ServiceSubscription> ServiceSubscriptions { get; set; } = new List<ServiceSubscription>();
         [EntityRelationship("dfe_contact_dfe_candidatequalification_ContactId", typeof(CandidateQualification))]
-        public List<CandidateQualification> Qualifications { get; set; }
+        public List<CandidateQualification> Qualifications { get; set; } = new List<CandidateQualification>();
         [EntityRelationship("dfe_contact_dfe_candidatepastteachingposition_ContactId", typeof(CandidatePastTeachingPosition))]
-        public List<CandidatePastTeachingPosition> PastTeachingPositions { get; set; }
+        public List<CandidatePastTeachingPosition> PastTeachingPositions { get; set; } = new List<CandidatePastTeachingPosition>();
         [SwaggerSchema("Set to schedule a phone call.", WriteOnly = true)]
         [EntityRelationship("dfe_contact_phonecall_contactid", typeof(PhoneCall))]
         public PhoneCall PhoneCall { get; set; }

--- a/GetIntoTeachingApi/Models/ServiceSubscription.cs
+++ b/GetIntoTeachingApi/Models/ServiceSubscription.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models
+{
+    [Entity("dfe_servicesubscription")]
+    public class ServiceSubscription : BaseModel
+    {
+        public enum SubscriptionStatus
+        {
+            Active,
+        }
+
+        public enum ServiceType
+        {
+            Event = 222750000,
+            MailingList = 222750001,
+            TeacherTrainingAdviser = 222750002,
+        }
+
+        [EntityField("dfe_servicesubscriptiontype", typeof(OptionSetValue))]
+        public int? TypeId { get; set; }
+        [JsonIgnore]
+        [EntityField("statecode", typeof(OptionSetValue))]
+        public int StatusId { get; set; } = (int)SubscriptionStatus.Active;
+        [EntityField("dfe_servicesubscriptionstartdate")]
+        public DateTime StartAt { get; set; } = DateTime.Now;
+        [EntityField("dfe_optoutsms")]
+        public bool OptOutOfSms { get; set; }
+        [EntityField("donotbulkemail")]
+        public bool DoNotBulkEmail { get; set; }
+        [EntityField("donotbulkpostalmail")]
+        public bool DoNotBulkPostalMail { get; set; }
+        [EntityField("donotemail")]
+        public bool DoNotEmail { get; set; }
+        [EntityField("donotpostalmail")]
+        public bool DoNotPostalMail { get; set; }
+        [EntityField("donotsendmm")]
+        public bool DoNotSendMm { get; set; }
+
+        public ServiceSubscription()
+            : base()
+        {
+        }
+
+        public ServiceSubscription(Entity entity, ICrmService crm)
+            : base(entity, crm)
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/ServiceSubscriptionValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ServiceSubscriptionValidator.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentValidation;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class ServiceSubscriptionValidator : AbstractValidator<ServiceSubscription>
+    {
+        private readonly IStore _store;
+
+        public ServiceSubscriptionValidator(IStore store)
+        {
+            _store = store;
+
+            RuleFor(subscription => subscription.TypeId)
+                .Must(id => TypeIds().Contains(id.ToString()))
+                .WithMessage("Must be a valid service subscription type.");
+        }
+
+        private IEnumerable<string> TypeIds()
+        {
+            return _store.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype").Select(channel => channel.Id);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -77,6 +77,7 @@ namespace GetIntoTeachingApi.Services
 
             _service.LoadProperty(entity, new Relationship("dfe_contact_dfe_candidatequalification_ContactId"), context);
             _service.LoadProperty(entity, new Relationship("dfe_contact_dfe_candidatepastteachingposition_ContactId"), context);
+            _service.LoadProperty(entity, new Relationship("dfe_contact_dfe_servicesubscription_contact"), context);
 
             return new Candidate(entity, this);
         }
@@ -101,6 +102,13 @@ namespace GetIntoTeachingApi.Services
             return _service.CreateQuery("msevtmgt_eventregistration", Context()).FirstOrDefault(entity =>
                 entity.GetAttributeValue<EntityReference>("msevtmgt_contactid").Id == candidateId &&
                 entity.GetAttributeValue<EntityReference>("msevtmgt_eventid").Id == teachingEventId) == null;
+        }
+
+        public bool IsCandidateSubscribedToServiceOfType(Guid candidateId, int serviceSubscriptionTypeId)
+        {
+            return _service.CreateQuery("dfe_servicesubscription", Context()).FirstOrDefault(entity =>
+                entity.GetAttributeValue<EntityReference>("dfe_contact").Id == candidateId &&
+                entity.GetAttributeValue<OptionSetValue>("dfe_servicesubscriptiontype").Value == serviceSubscriptionTypeId) != null;
         }
 
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
+        bool IsCandidateSubscribedToServiceOfType(Guid candidateId, int serviceSubscriptionTypeId);
         void Save(BaseModel model);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -188,6 +188,7 @@ namespace GetIntoTeachingApi.Services
             await SyncTypes(crm.GetPickListItems("msevtmgt_event", "dfe_event_type"));
             await SyncTypes(crm.GetPickListItems("phonecall", "dfe_channelcreation"));
             await SyncTypes(crm.GetPickListItems("phonecall", "dfe_destination"));
+            await SyncTypes(crm.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"));
         }
 
         private async Task SyncModels<T>(IEnumerable<T> models, IQueryable<T> dbSet)

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -43,7 +43,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var mappings = ok.Value.Should().BeOfType<List<MappingInfo>>().Subject;
-            mappings.Count().Should().Be(10);
+            mappings.Count().Should().Be(11);
             mappings.Any(m => m.LogicalName == "contact" &&
                               m.Class == "GetIntoTeachingApi.Models.Candidate"
             ).Should().BeTrue();

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -283,6 +283,19 @@ namespace GetIntoTeachingApiTests.Controllers
             ok.Value.Should().BeEquivalentTo(mockEntities);
         }
 
+        [Fact]
+        public async void GetServiceSubscriptionTypes_ReturnsAllTypes()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"))
+                .Returns(mockEntities.AsAsyncQueryable());
+
+            var response = await _controller.GetServiceSubscriptionTypes();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
         private static TypeEntity[] MockTypeEntities()
         {
             return new[]

--- a/GetIntoTeachingApiTests/Models/ServiceSubscriptionTests.cs
+++ b/GetIntoTeachingApiTests/Models/ServiceSubscriptionTests.cs
@@ -1,0 +1,89 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models;
+using Microsoft.Xrm.Sdk;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class ServiceSubscriptionTests
+    {
+        [Fact]
+        public void EntityAttributes()
+        {
+            var type = typeof(ServiceSubscription);
+
+            type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_servicesubscription");
+
+            type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_servicesubscriptiontype" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "statecode" && a.Type == typeof(OptionSetValue));
+
+            type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_servicesubscriptionstartdate");
+            type.GetProperty("DoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotbulkemail");
+            type.GetProperty("DoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotbulkpostalmail");
+            type.GetProperty("DoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotemail");
+            type.GetProperty("DoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotpostalmail");
+            type.GetProperty("DoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotsendmm");
+            type.GetProperty("OptOutOfSms").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_optoutsms");
+        }
+
+        [Fact]
+        public void StatusId_DefaultValue_IsActive()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.StatusId.Should().Be((int)ServiceSubscription.SubscriptionStatus.Active);
+        }
+
+        [Fact]
+        public void StartAt_DefaultValue_IsNow()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.StartAt.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact]
+        public void DoNotBulkEmail_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.DoNotBulkEmail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DoNotBulkPostalMail_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.DoNotBulkPostalMail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DoNotEmail_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.DoNotEmail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DoNotPostalMail_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.DoNotPostalMail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DoNotSendMm_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.DoNotSendMm.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OptOutOfSms_DefaultValue_IsFalse()
+        {
+            var subscription = new ServiceSubscription();
+            subscription.OptOutOfSms.Should().BeFalse();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/ServiceSubscriptionValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ServiceSubscriptionValidatorTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class ServiceSubscriptionValidatorTests
+    {
+        private readonly ServiceSubscriptionValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public ServiceSubscriptionValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new ServiceSubscriptionValidator(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPickListItem = new TypeEntity { Id = "123" };
+
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+
+            var subscription = new ServiceSubscription()
+            {
+                TypeId = int.Parse(mockPickListItem.Id),
+                DoNotBulkEmail = false,
+                DoNotBulkPostalMail = true,
+                DoNotEmail = true,
+                DoNotPostalMail = false,
+                DoNotSendMm = true,
+                OptOutOfSms = false,
+            };
+
+            var result = _validator.TestValidate(subscription);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_TypeIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(subscription => subscription.TypeId, 123);
+        }
+
+        [Fact]
+        public void Validate_TypeIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(subscription => subscription.TypeId, null as int?);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -173,6 +173,38 @@ namespace GetIntoTeachingApiTests.Services
         public void CandidateYetToRegisterForTeachingEvent_WhenNotYetRegistered_ReturnsTrue()
         {
             var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var entity = new Entity();
+            entity["dfe_contact"] = new EntityReference("contact", (Guid)candidate.Id);
+            entity["dfe_servicesubscriptiontype"] = new OptionSetValue((int)ServiceSubscription.ServiceType.Event);
+
+            _mockService.Setup(m => m.CreateQuery("dfe_servicesubscription", _context))
+                .Returns(new List<Entity> { entity }.AsQueryable());
+
+            var result = _crm.IsCandidateSubscribedToServiceOfType((Guid)candidate.Id, (int)ServiceSubscription.ServiceType.MailingList);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsCandidateSubscribedToServiceOfType_WhenAlreadySubscribed_ReturnsTrue()
+        {
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var entity = new Entity();
+            entity["dfe_contact"] = new EntityReference("contact", (Guid)candidate.Id);
+            entity["dfe_servicesubscriptiontype"] = new OptionSetValue((int)ServiceSubscription.ServiceType.TeacherTrainingAdviser);
+
+            _mockService.Setup(m => m.CreateQuery("dfe_servicesubscription", _context))
+                .Returns(new List<Entity> { entity }.AsQueryable());
+
+            var result = _crm.IsCandidateSubscribedToServiceOfType((Guid)candidate.Id, (int)ServiceSubscription.ServiceType.TeacherTrainingAdviser);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsCandidateSubscribedToServiceOfType_WhenNotYetSubscribed_ReturnsFalse()
+        {
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
             var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
 
             var entity = new Entity();
@@ -225,6 +257,8 @@ namespace GetIntoTeachingApiTests.Services
                 new Relationship("dfe_contact_dfe_candidatequalification_ContactId"), _context));
             _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
                 new Relationship("dfe_contact_dfe_candidatepastteachingposition_ContactId"), _context));
+            _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
+                new Relationship("dfe_contact_dfe_servicesubscription_contact"), _context));
 
             var result = _crm.MatchCandidate(request);
 
@@ -245,6 +279,8 @@ namespace GetIntoTeachingApiTests.Services
                 new Relationship("dfe_contact_dfe_candidatequalification_ContactId"), _context));
             _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
                 new Relationship("dfe_contact_dfe_candidatepastteachingposition_ContactId"), _context));
+            _mockService.Setup(mock => mock.LoadProperty(It.IsAny<Entity>(),
+                new Relationship("dfe_contact_dfe_servicesubscription_contact"), _context));
 
             var result = _crm.MatchCandidate(request);
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -273,6 +273,7 @@ namespace GetIntoTeachingApiTests.Services
             mockCrm.Verify(m => m.GetPickListItems("msevtmgt_event", "dfe_event_type"));
             mockCrm.Verify(m => m.GetPickListItems("phonecall", "dfe_channelcreation"));
             mockCrm.Verify(m => m.GetPickListItems("phonecall", "dfe_destination"));
+            mockCrm.Verify(m => m.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"));
         }
 
         [Fact]


### PR DESCRIPTION
- Add ServiceSubscription model

- Subscribe candidate on sign up for TTA

Subscribe the candidate to the TTA subscription as part of the background job. If a candidate has already subscribed a duplicate subscription will not be created.

Return the subscriptions associated with a candidate as part of the request to exchange an access token for an existing candidate.