### PR TITLE
Accept QualificationId on MailingListAddMemberRequest

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMemberRequest.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMemberRequest.cs
@@ -6,6 +6,7 @@ namespace GetIntoTeachingApi.Models
     public class MailingListAddMemberRequest
     {
         public Guid? CandidateId { get; set; }
+        public Guid? QualificationId { get; set; }
         public Guid PreferredTeachingSubjectId { get; set; }
         public Guid AcceptedPolicyId { get; set; }
 
@@ -49,7 +50,7 @@ namespace GetIntoTeachingApi.Models
                 DoNotSendMm = false,
             };
 
-            candidate.Qualifications.Add(new CandidateQualification() { UkDegreeGradeId = UkDegreeGradeId });
+            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, UkDegreeGradeId = UkDegreeGradeId });
             candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
 
             if (SubscribeToEvents)

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberRequestTests.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApiTests.Models
             var request = new MailingListAddMemberRequest()
             {
                 CandidateId = Guid.NewGuid(),
+                QualificationId = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.Parse(mockEntityReference.Id),
                 AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
                 DescribeYourselfOptionId = int.Parse(mockPickListItem.Id),
@@ -58,6 +59,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Qualifications.First().UkDegreeGradeId.Should().Be(request.UkDegreeGradeId);
+            candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
         }
 
         [Theory]


### PR DESCRIPTION
If the `UkDegreeGradeId` is prefilled from an existing qualification, then the `QualificationId` should be sent in the request to add a member to the mailing list in order to update the existing qualification details with whatever the user selects as part of the form submission.