### PR TITLE
Individual endpoints to exchange PIN code for candidate information

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         public IActionResult AddMember(
-            [FromBody, SwaggerRequestBody("Member to add to the mailing list.", Required = true)] MailingListAddMemberRequest request)
+            [FromBody, SwaggerRequestBody("Member to add to the mailing list.", Required = true)] MailingListAddMember request)
         {
             if (!ModelState.IsValid)
             {

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -31,11 +31,11 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         [HttpPost]
         [SwaggerOperation(
             Summary = "Sign up a candidate for the Teacher Training Adviser service.",
-            OperationId = "UpsertTeacherTrainingAdviserCandidate",
+            OperationId = "SignUpTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" })]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
-        public IActionResult Upsert(
+        public IActionResult SignUp(
             [FromBody, SwaggerRequestBody("Candidate to sign up for the Teacher Training Adviser service.", Required = true)] TeacherTrainingAdviserSignUp request)
         {
             if (!ModelState.IsValid)
@@ -51,14 +51,14 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         [HttpPost]
         [Route("{accessToken}")]
         [SwaggerOperation(
-            Summary = "Retrieves an existing candidate for the Teacher Training Adviser service.",
+            Summary = "Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate.",
             Description = @"
-Retrieves an existing candidate for the Teacher Training Adviser service. The `accessToken` is obtained from a 
+Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate. The `accessToken` is obtained from a 
 `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
 exchanged for your token matches the request payload here).",
-            OperationId = "GetExistingTeacherTrainingAdviserCandidate",
+            OperationId = "GetPreFilledTeacherTrainingAdviserSignUp",
             Tags = new[] { "Teacher Training Adviser" })]
-        [ProducesResponseType(typeof(Candidate), 200)]
+        [ProducesResponseType(typeof(TeacherTrainingAdviserSignUp), 200)]
         [ProducesResponseType(404)]
         public IActionResult Get(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
@@ -76,7 +76,7 @@ exchanged for your token matches the request payload here).",
                 return NotFound();
             }
 
-            return Ok(candidate);
+            return Ok(new TeacherTrainingAdviserSignUp(candidate));
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -36,7 +36,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         public IActionResult Upsert(
-            [FromBody, SwaggerRequestBody("Candidate to sign up for the Teacher Training Adviser service.", Required = true)] TeacherTrainingAdviserSignUpRequest request)
+            [FromBody, SwaggerRequestBody("Candidate to sign up for the Teacher Training Adviser service.", Required = true)] TeacherTrainingAdviserSignUp request)
         {
             if (!ModelState.IsValid)
             {

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -19,13 +19,21 @@ namespace GetIntoTeachingApi.Controllers
     public class TeachingEventsController : ControllerBase
     {
         private const int MaximumUpcomingRequests = 50;
+        private readonly ICandidateAccessTokenService _tokenService;
+        private readonly ICrmService _crm;
         private readonly IStore _store;
         private readonly IBackgroundJobClient _jobClient;
 
-        public TeachingEventsController(IStore store, IBackgroundJobClient jobClient)
+        public TeachingEventsController(
+            IStore store,
+            IBackgroundJobClient jobClient,
+            ICandidateAccessTokenService tokenService,
+            ICrmService crm)
         {
             _store = store;
             _jobClient = jobClient;
+            _crm = crm;
+            _tokenService = tokenService;
         }
 
         [HttpGet]
@@ -115,6 +123,37 @@ maximum of 50 using the `limit` query parameter.",
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(request.Candidate, null));
 
             return NoContent();
+        }
+
+        [HttpPost]
+        [Route("attendees/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated TeachingEventAddAttendee for the candidate.",
+            Description = @"
+Retrieves a pre-populated TeachingEventAddAttendee for the candidate. The `accessToken` is obtained from a 
+`POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+exchanged for your token matches the request payload here).",
+            OperationId = "GetPreFilledTeachingEventAddAttendee",
+            Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(TeachingEventAddAttendee), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetAttendee(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            if (!_tokenService.IsValid(accessToken, request))
+            {
+                return Unauthorized();
+            }
+
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new TeachingEventAddAttendee(candidate));
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -105,7 +105,7 @@ maximum of 50 using the `limit` query parameter.",
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
         [ProducesResponseType(404)]
         public IActionResult AddAttendee(
-            [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] TeachingEventAddAttendeeRequest request)
+            [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] TeachingEventAddAttendee request)
         {
             if (!ModelState.IsValid)
             {

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -3,19 +3,24 @@ using System.Text.Json.Serialization;
 
 namespace GetIntoTeachingApi.Models
 {
-    public class TeachingEventAddAttendeeRequest
+    public class MailingListAddMember
     {
         public Guid? CandidateId { get; set; }
-        public Guid EventId { get; set; }
+        public Guid? QualificationId { get; set; }
+        public Guid PreferredTeachingSubjectId { get; set; }
         public Guid AcceptedPolicyId { get; set; }
+
+        public int DescribeYourselfOptionId { get; set; }
+        public int ConsiderationJourneyStageId { get; set; }
+        public int UkDegreeGradeId { get; set; }
 
         public string Email { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
+        public string CallbackInformation { get; set; }
         public bool SubscribeToEvents { get; set; }
-        public bool SubscribeToMailingList { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -25,36 +30,32 @@ namespace GetIntoTeachingApi.Models
             var candidate = new Candidate()
             {
                 Id = CandidateId,
+                DescribeYourselfOptionId = DescribeYourselfOptionId,
+                ConsiderationJourneyStageId = ConsiderationJourneyStageId,
+                PreferredTeachingSubjectId = PreferredTeachingSubjectId,
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
+                CallbackInformation = CallbackInformation,
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = AcceptedPolicyId },
-                ChannelId = CandidateId == null ? (int?)Candidate.Channel.Event : null,
+                ChannelId = CandidateId == null ? (int?)Candidate.Channel.MailingList : null,
                 EligibilityRulesPassed = "false",
                 OptOutOfSms = false,
-                DoNotBulkEmail = true,
+                DoNotBulkEmail = false,
                 DoNotEmail = false,
                 DoNotBulkPostalMail = true,
                 DoNotPostalMail = true,
-                DoNotSendMm = true,
+                DoNotSendMm = false,
             };
 
-            candidate.TeachingEventRegistrations.Add(new TeachingEventRegistration()
-            {
-                EventId = EventId,
-                ChannelId = (int)TeachingEventRegistration.Channel.Event,
-            });
+            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, UkDegreeGradeId = UkDegreeGradeId });
+            candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
 
             if (SubscribeToEvents)
             {
                 candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
-            }
-
-            if (SubscribeToMailingList)
-            {
-                candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
             }
 
             return candidate;

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Models
         public Guid? PastTeachingPositionId { get; set; }
         public Guid? PreferredTeachingSubjectId { get; set; }
         public Guid? CountryId { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
 
         public int? UkDegreeGradeId { get; set; }
@@ -39,7 +40,10 @@ namespace GetIntoTeachingApi.Models
         public string AddressCity { get; set; }
         public string AddressState { get; set; }
         public string AddressPostcode { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
         public DateTime? PhoneCallScheduledAt { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public bool AlreadySubscribedToTeacherTrainingAdviser { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -80,6 +84,8 @@ namespace GetIntoTeachingApi.Models
             AddressCity = candidate.AddressCity;
             AddressState = candidate.AddressState;
             AddressPostcode = candidate.AddressPostcode;
+
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.TeacherTrainingAdviser);
 
             var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
 

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Text.Json.Serialization;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -11,7 +13,7 @@ namespace GetIntoTeachingApi.Models
         public Guid? PastTeachingPositionId { get; set; }
         public Guid? PreferredTeachingSubjectId { get; set; }
         public Guid? CountryId { get; set; }
-        public Guid AcceptedPolicyId { get; set; }
+        public Guid? AcceptedPolicyId { get; set; }
 
         public int? UkDegreeGradeId { get; set; }
         public int? DegreeStatusId { get; set; }
@@ -42,6 +44,62 @@ namespace GetIntoTeachingApi.Models
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
 
+        public TeacherTrainingAdviserSignUp()
+        {
+        }
+
+        public TeacherTrainingAdviserSignUp(Candidate candidate)
+        {
+            PopulateWithCandidate(candidate);
+        }
+
+        private void PopulateWithCandidate(Candidate candidate)
+        {
+            CandidateId = candidate.Id;
+            PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
+            CountryId = candidate.CountryId;
+
+            InitialTeacherTrainingYearId = candidate.InitialTeacherTrainingYearId;
+            PreferredEducationPhaseId = candidate.PreferredEducationPhaseId;
+            HasGcseEnglishId = candidate.HasGcseEnglishId;
+            HasGcseMathsId = candidate.HasGcseMathsId;
+            HasGcseScienceId = candidate.HasGcseScienceId;
+            PlanningToRetakeCgseScienceId = candidate.PlanningToRetakeCgseScienceId;
+            PlanningToRetakeGcseEnglishId = candidate.PlanningToRetakeGcseEnglishId;
+            PlanningToRetakeGcseMathsId = candidate.PlanningToRetakeGcseMathsId;
+
+            Email = candidate.Email;
+            FirstName = candidate.FirstName;
+            LastName = candidate.LastName;
+            DateOfBirth = candidate.DateOfBirth;
+            TeacherId = candidate.TeacherId;
+            Telephone = candidate.Telephone;
+            AddressLine1 = candidate.AddressLine1;
+            AddressLine2 = candidate.AddressLine2;
+            AddressLine3 = candidate.AddressLine3;
+            AddressCity = candidate.AddressCity;
+            AddressState = candidate.AddressState;
+            AddressPostcode = candidate.AddressPostcode;
+
+            var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
+
+            if (latestQualification != null)
+            {
+                QualificationId = latestQualification.Id;
+                DegreeSubject = latestQualification.Subject;
+                UkDegreeGradeId = latestQualification.UkDegreeGradeId;
+                DegreeStatusId = latestQualification.DegreeStatusId;
+            }
+
+            var latestPastTeachingPosition = candidate.PastTeachingPositions.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
+
+            if (latestPastTeachingPosition != null)
+            {
+                PastTeachingPositionId = latestPastTeachingPosition.Id;
+                SubjectTaughtId = latestPastTeachingPosition.SubjectTaughtId;
+            }
+        }
+
         private Candidate CreateCandidate()
         {
             var candidate = new Candidate()
@@ -49,7 +107,6 @@ namespace GetIntoTeachingApi.Models
                 Id = CandidateId,
                 PreferredTeachingSubjectId = PreferredTeachingSubjectId,
                 CountryId = CountryId,
-                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = AcceptedPolicyId },
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
@@ -82,6 +139,11 @@ namespace GetIntoTeachingApi.Models
                 DoNotPostalMail = false,
                 DoNotSendMm = false,
             };
+
+            if (AcceptedPolicyId != null)
+            {
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+            }
 
             if (PhoneCallScheduledAt != null)
             {

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace GetIntoTeachingApi.Models
 {
-    public class TeacherTrainingAdviserSignUpRequest
+    public class TeacherTrainingAdviserSignUp
     {
         public Guid? CandidateId { get; set; }
         public Guid? QualificationId { get; set; }

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -3,24 +3,19 @@ using System.Text.Json.Serialization;
 
 namespace GetIntoTeachingApi.Models
 {
-    public class MailingListAddMemberRequest
+    public class TeachingEventAddAttendee
     {
         public Guid? CandidateId { get; set; }
-        public Guid? QualificationId { get; set; }
-        public Guid PreferredTeachingSubjectId { get; set; }
+        public Guid EventId { get; set; }
         public Guid AcceptedPolicyId { get; set; }
-
-        public int DescribeYourselfOptionId { get; set; }
-        public int ConsiderationJourneyStageId { get; set; }
-        public int UkDegreeGradeId { get; set; }
 
         public string Email { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
-        public string CallbackInformation { get; set; }
         public bool SubscribeToEvents { get; set; }
+        public bool SubscribeToMailingList { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -30,32 +25,36 @@ namespace GetIntoTeachingApi.Models
             var candidate = new Candidate()
             {
                 Id = CandidateId,
-                DescribeYourselfOptionId = DescribeYourselfOptionId,
-                ConsiderationJourneyStageId = ConsiderationJourneyStageId,
-                PreferredTeachingSubjectId = PreferredTeachingSubjectId,
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
-                CallbackInformation = CallbackInformation,
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = AcceptedPolicyId },
-                ChannelId = CandidateId == null ? (int?)Candidate.Channel.MailingList : null,
+                ChannelId = CandidateId == null ? (int?)Candidate.Channel.Event : null,
                 EligibilityRulesPassed = "false",
                 OptOutOfSms = false,
-                DoNotBulkEmail = false,
+                DoNotBulkEmail = true,
                 DoNotEmail = false,
                 DoNotBulkPostalMail = true,
                 DoNotPostalMail = true,
-                DoNotSendMm = false,
+                DoNotSendMm = true,
             };
 
-            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, UkDegreeGradeId = UkDegreeGradeId });
-            candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
+            candidate.TeachingEventRegistrations.Add(new TeachingEventRegistration()
+            {
+                EventId = EventId,
+                ChannelId = (int)TeachingEventRegistration.Channel.Event,
+            });
 
             if (SubscribeToEvents)
             {
                 candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
+            }
+
+            if (SubscribeToMailingList)
+            {
+                candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
             }
 
             return candidate;

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -8,6 +8,11 @@ namespace GetIntoTeachingApi.Models.Validators
         public MailingListAddMemberValidator(IStore store)
         {
             RuleFor(request => request.AddressPostcode).NotEmpty();
+            RuleFor(request => request.PreferredTeachingSubjectId).NotEmpty();
+            RuleFor(request => request.AcceptedPolicyId).NotEmpty();
+            RuleFor(request => request.DescribeYourselfOptionId).NotEmpty();
+            RuleFor(request => request.ConsiderationJourneyStageId).NotEmpty();
+            RuleFor(request => request.UkDegreeGradeId).NotEmpty();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -3,9 +3,9 @@ using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class MailingListAddMemberRequestValidator : AbstractValidator<MailingListAddMemberRequest>
+    public class MailingListAddMemberValidator : AbstractValidator<MailingListAddMember>
     {
-        public MailingListAddMemberRequestValidator(IStore store)
+        public MailingListAddMemberValidator(IStore store)
         {
             RuleFor(request => request.AddressPostcode).NotEmpty();
 

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class TeacherTrainingAdviserSignUpRequestValidator : AbstractValidator<TeacherTrainingAdviserSignUpRequest>
+    {
+        public TeacherTrainingAdviserSignUpRequestValidator(IStore store)
+        {
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -3,9 +3,9 @@ using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class TeachingEventAddAttendeeRequestValidator : AbstractValidator<TeachingEventAddAttendeeRequest>
+    public class TeacherTrainingAdviserSignUpValidator : AbstractValidator<TeacherTrainingAdviserSignUp>
     {
-        public TeachingEventAddAttendeeRequestValidator(IStore store)
+        public TeacherTrainingAdviserSignUpValidator(IStore store)
         {
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -7,6 +7,8 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public TeacherTrainingAdviserSignUpValidator(IStore store)
         {
+            RuleFor(request => request.AcceptedPolicyId).NotNull();
+
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }
     }

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
@@ -3,9 +3,9 @@ using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class TeacherTrainingAdviserSignUpRequestValidator : AbstractValidator<TeacherTrainingAdviserSignUpRequest>
+    public class TeachingEventAddAttendeeValidator : AbstractValidator<TeachingEventAddAttendee>
     {
-        public TeacherTrainingAdviserSignUpRequestValidator(IStore store)
+        public TeachingEventAddAttendeeValidator(IStore store)
         {
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
@@ -7,6 +7,9 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public TeachingEventAddAttendeeValidator(IStore store)
         {
+            RuleFor(request => request.EventId).NotEmpty();
+            RuleFor(request => request.AcceptedPolicyId).NotEmpty();
+
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }
     }

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -10,24 +10,66 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class MailingListControllerTests
     {
+        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly MailingListController _controller;
+        private readonly ExistingCandidateRequest _request;
 
         public MailingListControllerTests()
         {
+            _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockCrm = new Mock<ICrmService>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
-            _controller = new MailingListController(_mockJobClient.Object);
+            _controller = new MailingListController(_mockTokenService.Object, _mockCrm.Object, _mockJobClient.Object);
         }
 
         [Fact]
         public void Authorize_IsPresent()
         {
             typeof(MailingListController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void GetMember_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request)).Returns(false);
+
+            var response = _controller.GetMember("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void GetMember_ValidToken_RespondsWithMailingListAddMember()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.GetMember("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as MailingListAddMember;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void GetMember_MissingCandidate_RespondsWithNotFound()
+        {
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.GetMember("000000", _request);
+
+            response.Should().BeOfType<NotFoundResult>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -33,7 +33,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void AddMember_InvalidRequest_RespondsWithValidationErrors()
         {
-            var request = new MailingListAddMemberRequest() { FirstName = null };
+            var request = new MailingListAddMember() { FirstName = null };
             _controller.ModelState.AddModelError("FirstName", "First name must be specified.");
 
             var response = _controller.AddMember(request);
@@ -46,7 +46,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void AddMember_ValidRequest_EnqueuesJobRespondsWithNoContent()
         {
-            var request = new MailingListAddMemberRequest() { Email = "test@test.com", FirstName = "John", LastName = "Doe" };
+            var request = new MailingListAddMember() { Email = "test@test.com", FirstName = "John", LastName = "Doe" };
 
             var response = _controller.AddMember(request);
 

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -75,7 +75,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Upsert_InvalidRequest_RespondsWithValidationErrors()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest { Email = "invalid-email@" };
+            var request = new TeacherTrainingAdviserSignUp { Email = "invalid-email@" };
             _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
             var response = _controller.Upsert(request);
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Upsert_ValidRequest_EnqueuesJobAndRespondsWithSuccess()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest { FirstName = "first" };
+            var request = new TeacherTrainingAdviserSignUp { FirstName = "first" };
 
             var response = _controller.Upsert(request);
 

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -48,7 +48,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Get_ValidToken_RespondsWithCandidate()
+        public void Get_ValidToken_RespondsWithTeacherTrainingAdviserSignUp()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
@@ -57,8 +57,8 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
             var response = _controller.Get("000000", _request);
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var candidateResponse = ok.Value as Candidate;
-            candidateResponse.Should().Be(candidate);
+            var responseModel = ok.Value as TeacherTrainingAdviserSignUp;
+            responseModel.CandidateId.Should().Be(candidate.Id);
         }
 
         [Fact]
@@ -73,12 +73,12 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Upsert_InvalidRequest_RespondsWithValidationErrors()
+        public void SignUp_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new TeacherTrainingAdviserSignUp { Email = "invalid-email@" };
             _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
-            var response = _controller.Upsert(request);
+            var response = _controller.SignUp(request);
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
@@ -86,11 +86,11 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Upsert_ValidRequest_EnqueuesJobAndRespondsWithSuccess()
+        public void SignUp_ValidRequest_EnqueuesJobAndRespondsWithSuccess()
         {
             var request = new TeacherTrainingAdviserSignUp { FirstName = "first" };
 
-            var response = _controller.Upsert(request);
+            var response = _controller.SignUp(request);
 
             response.Should().BeOfType<NoContentResult>();
             _mockJobClient.Verify(x => x.Create(

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -49,7 +49,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void AddAttendee_InvalidRequest_RespondsWithValidationErrors()
         {
-            var request = new TeachingEventAddAttendeeRequest() { EventId = Guid.NewGuid(), FirstName = null };
+            var request = new TeachingEventAddAttendee() { EventId = Guid.NewGuid(), FirstName = null };
             _controller.ModelState.AddModelError("FirstName", "First name must be specified.");
 
             var response = _controller.AddAttendee(request);
@@ -63,7 +63,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void AddAttendee_ValidRequest_EnqueuesJobRespondsWithNoContent()
         {
             var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
-            var request = new TeachingEventAddAttendeeRequest() { EventId = (Guid)teachingEvent.Id, Email = "test@test.com", FirstName = "John", LastName = "Doe" };
+            var request = new TeachingEventAddAttendee() { EventId = (Guid)teachingEvent.Id, Email = "test@test.com", FirstName = "John", LastName = "Doe" };
 
             var response = _controller.AddAttendee(request);
 

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -20,15 +20,21 @@ namespace GetIntoTeachingApiTests.Controllers
 {
     public class TeachingEventsControllerTests
     {
+        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<IStore> _mockStore;
         private readonly TeachingEventsController _controller;
+        private readonly ExistingCandidateRequest _request;
 
         public TeachingEventsControllerTests()
         {
+            _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockCrm = new Mock<ICrmService>();
             _mockStore = new Mock<IStore>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
-            _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object);
+            _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object, _mockTokenService.Object, _mockCrm.Object);
         }
 
         [Fact]
@@ -138,6 +144,41 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockStore.Setup(mock => mock.GetTeachingEventAsync(It.IsAny<Guid>())).ReturnsAsync(null as TeachingEvent);
 
             var response = await _controller.Get(Guid.NewGuid());
+
+            response.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public void GetAttendee_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request)).Returns(false);
+
+            var response = _controller.GetAttendee("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void GetAttendee_ValidToken_RespondsWithTeachingEventAddAttendee()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.GetAttendee("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as TeachingEventAddAttendee;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void GetAttendee_MissingCandidate_RespondsWithNotFound()
+        {
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.GetAttendee("000000", _request);
 
             response.Should().BeOfType<NotFoundResult>();
         }

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -6,79 +6,81 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
 {
-    public class TeachingEventAddAttendeeRequestTests
+    public class MailingListAddMemberTests
     {
         [Fact]
         public void Candidate_MapsCorrectly()
         {
-            var request = new TeachingEventAddAttendeeRequest()
+            var request = new MailingListAddMember()
             {
-                EventId = Guid.NewGuid(),
                 CandidateId = Guid.NewGuid(),
+                QualificationId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
+                DescribeYourselfOptionId = 1,
+                ConsiderationJourneyStageId = 2,
+                UkDegreeGradeId = 3,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
+                CallbackInformation = "Test information",
                 SubscribeToEvents = true,
-                SubscribeToMailingList = true,
             };
 
             var candidate = request.Candidate;
 
             candidate.Id.Should().Equals(request.CandidateId);
+            candidate.DescribeYourselfOptionId.Should().Be(request.DescribeYourselfOptionId);
+            candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.Telephone.Should().Be(request.Telephone);
+            candidate.CallbackInformation.Should().Be(request.CallbackInformation);
             candidate.ChannelId.Should().BeNull();
             candidate.EligibilityRulesPassed.Should().Be("false");
             candidate.OptOutOfSms.Should().BeFalse();
-            candidate.DoNotBulkEmail.Should().BeTrue();
+            candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();
             candidate.DoNotBulkPostalMail.Should().BeTrue();
             candidate.DoNotPostalMail.Should().BeTrue();
-            candidate.DoNotSendMm.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be(request.AcceptedPolicyId);
-            candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.Event);
-            candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
-            candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
+            candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
+            candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
+            candidate.Qualifications.First().UkDegreeGradeId.Should().Be(request.UkDegreeGradeId);
+            candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
         }
 
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNull_IsMailingList()
         {
-            var request = new TeachingEventAddAttendeeRequest() { CandidateId = null };
+            var request = new MailingListAddMember() { CandidateId = null };
 
-            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.Event);
+            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.MailingList);
         }
 
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNotNull_IsNull()
         {
-            var request = new TeachingEventAddAttendeeRequest() { CandidateId = Guid.NewGuid() };
+            var request = new MailingListAddMember() { CandidateId = Guid.NewGuid() };
 
             request.Candidate.ChannelId.Should().BeNull();
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsFalse_DoesNotCreateSubscription()
-        {
-            var request = new TeachingEventAddAttendeeRequest() { SubscribeToMailingList = false };
-
-            request.Candidate.Subscriptions.Count.Should().Be(0);
-        }
-
-        [Fact]
         public void Candidate_SubscribeToEventsIsFalse_DoesNotCreateSubscription()
         {
-            var request = new TeachingEventAddAttendeeRequest() { SubscribeToEvents = false };
+            var request = new MailingListAddMember() { SubscribeToEvents = false };
 
-            request.Candidate.Subscriptions.Count.Should().Be(0);
+            request.Candidate.Subscriptions.Count.Should().Be(1);
+            request.Candidate.Subscriptions.Where(s => s.TypeId == (int)Subscription.ServiceType.Event).Count().Should().Be(0);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -8,6 +9,61 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class MailingListAddMemberTests
     {
+        [Fact]
+        public void Constructor_WithCandidate_MapsCorrectly()
+        {
+            var latestQualification = new CandidateQualification()
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.Now.AddDays(10),
+                UkDegreeGradeId = 1,
+            };
+
+            var qualifications = new List<CandidateQualification>()
+            {
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                latestQualification,
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+            };
+
+            var subscriptions = new List<Subscription>() { new Subscription() { TypeId = (int)Subscription.ServiceType.Event } };
+
+            var candidate = new Candidate()
+            {
+                Id = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                DescribeYourselfOptionId = 2,
+                ConsiderationJourneyStageId = 3,
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                Telephone = "1234567",
+                AddressPostcode = "KY11 9YU",
+                CallbackInformation = "Callback info",
+                Qualifications = qualifications,
+                Subscriptions = subscriptions,
+            };
+
+            var response = new MailingListAddMember(candidate);
+
+            response.CandidateId.Should().Be(candidate.Id);
+            response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
+            response.DescribeYourselfOptionId.Should().Be(candidate.DescribeYourselfOptionId);
+            response.ConsiderationJourneyStageId.Should().Be(candidate.ConsiderationJourneyStageId);
+            response.Email.Should().Be(candidate.Email);
+            response.FirstName.Should().Be(candidate.FirstName);
+            response.LastName.Should().Be(candidate.LastName);
+            response.Telephone.Should().Be(candidate.Telephone);
+            response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+            response.CallbackInformation.Should().Be(candidate.CallbackInformation);
+
+            response.QualificationId.Should().Be(latestQualification.Id);
+            response.UkDegreeGradeId.Should().Be(latestQualification.UkDegreeGradeId);
+
+            response.AlreadySubscribedToEvents.Should().BeTrue();
+            response.AlreadySubscribedToMailingList.Should().BeFalse();
+        }
+
         [Fact]
         public void Candidate_MapsCorrectly()
         {
@@ -51,7 +107,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
 
-            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be(request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Qualifications.First().UkDegreeGradeId.Should().Be(request.UkDegreeGradeId);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -8,6 +9,104 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TeacherTrainingAdviserSignUpTests
     {
+        [Fact]
+        public void Constructor_WithCandidate_MapsCorrectly()
+        {
+            var latestQualification = new CandidateQualification()
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.Now.AddDays(10),
+                DegreeStatusId = 1,
+                UkDegreeGradeId = 2,
+                Subject = "English"
+            };
+
+            var qualifications = new List<CandidateQualification>()
+            {
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                latestQualification,
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+            };
+
+            var latestPastTeachingPosition = new CandidatePastTeachingPosition()
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.Now.AddDays(10),
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var pastTeachingPositions = new List<CandidatePastTeachingPosition>()
+            {
+                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                latestPastTeachingPosition,
+                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+            };
+
+            var candidate = new Candidate()
+            {
+                Id = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                CountryId = Guid.NewGuid(),
+                InitialTeacherTrainingYearId = 1,
+                PreferredEducationPhaseId = 2,
+                HasGcseEnglishId = 3,
+                HasGcseMathsId = 4,
+                HasGcseScienceId = 5,
+                PlanningToRetakeGcseEnglishId = 6,
+                PlanningToRetakeGcseMathsId = 7,
+                PlanningToRetakeCgseScienceId = 8,
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                DateOfBirth = DateTime.Now,
+                Telephone = "1234567",
+                TeacherId = "abc123",
+                AddressLine1 = "Address 1",
+                AddressLine2 = "Address 2",
+                AddressLine3 = "Address 3",
+                AddressCity = "City",
+                AddressState = "State",
+                AddressPostcode = "KY11 9YU",
+                Qualifications = qualifications,
+                PastTeachingPositions = pastTeachingPositions,
+            };
+
+            var response = new TeacherTrainingAdviserSignUp(candidate);
+
+            response.CandidateId.Should().Be(candidate.Id);
+            response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
+            response.CountryId.Should().Be(candidate.CountryId);
+            response.InitialTeacherTrainingYearId.Should().Be(candidate.InitialTeacherTrainingYearId);
+            response.PreferredEducationPhaseId.Should().Be(candidate.PreferredEducationPhaseId);
+            response.HasGcseEnglishId.Should().Be(candidate.HasGcseEnglishId);
+            response.HasGcseMathsId.Should().Be(candidate.HasGcseMathsId);
+            response.HasGcseScienceId.Should().Be(candidate.HasGcseScienceId);
+            response.PlanningToRetakeCgseScienceId.Should().Be(candidate.PlanningToRetakeCgseScienceId);
+            response.PlanningToRetakeGcseEnglishId.Should().Be(candidate.PlanningToRetakeGcseEnglishId);
+            response.PlanningToRetakeGcseMathsId.Should().Be(candidate.PlanningToRetakeGcseMathsId);
+            response.Email.Should().Be(candidate.Email);
+            response.FirstName.Should().Be(candidate.FirstName);
+            response.LastName.Should().Be(candidate.LastName);
+            response.TeacherId.Should().Be(candidate.TeacherId);
+            response.Telephone.Should().Be(candidate.Telephone);
+            response.AddressLine1.Should().Be(candidate.AddressLine1);
+            response.AddressLine2.Should().Be(candidate.AddressLine2);
+            response.AddressLine3.Should().Be(candidate.AddressLine3);
+            response.AddressCity.Should().Be(candidate.AddressCity);
+            response.AddressState.Should().Be(candidate.AddressState);
+            response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+
+            response.QualificationId.Should().Be(latestQualification.Id);
+            response.DegreeStatusId.Should().Be(latestQualification.DegreeStatusId);
+            response.UkDegreeGradeId.Should().Be(latestQualification.UkDegreeGradeId);
+            response.DegreeSubject.Should().Be(latestQualification.Subject);
+
+            response.PastTeachingPositionId.Should().Be(latestPastTeachingPosition.Id);
+            response.SubjectTaughtId.Should().Be(latestPastTeachingPosition.SubjectTaughtId);
+
+            response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
+        }
+
         [Fact]
         public void Candidate_MapsCorrectly()
         {
@@ -84,7 +183,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotPostalMail.Should().BeFalse();
             candidate.DoNotSendMm.Should().BeFalse();
 
-            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be(request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
             candidate.PhoneCall.Telephone.Should().Be(request.Telephone);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithCandidate_MapsCorrectly()
         {
+            var subscriptions = new List<Subscription>() { new Subscription() { TypeId = (int)Subscription.ServiceType.TeacherTrainingAdviser } };
+
             var latestQualification = new CandidateQualification()
             {
                 Id = Guid.NewGuid(),
@@ -69,6 +71,7 @@ namespace GetIntoTeachingApiTests.Models
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 PastTeachingPositions = pastTeachingPositions,
+                Subscriptions = subscriptions,
             };
 
             var response = new TeacherTrainingAdviserSignUp(candidate);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
 {
-    public class TeacherTrainingAdviserSignUpRequestTests
+    public class TeacherTrainingAdviserSignUpTests
     {
         [Fact]
         public void Candidate_MapsCorrectly()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest()
+            var request = new TeacherTrainingAdviserSignUp()
             {
                 CandidateId = Guid.NewGuid(),
                 QualificationId = Guid.NewGuid(),
@@ -105,7 +105,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNull_IsTeacherTrainingAdviser()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { CandidateId = null };
+            var request = new TeacherTrainingAdviserSignUp() { CandidateId = null };
 
             request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.TeacherTrainingAdviser);
         }
@@ -113,7 +113,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNotNull_IsNull()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { CandidateId = Guid.NewGuid() };
+            var request = new TeacherTrainingAdviserSignUp() { CandidateId = Guid.NewGuid() };
 
             request.Candidate.ChannelId.Should().BeNull();
         }
@@ -121,7 +121,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_PhoneCallScheduledAtIsNull_NoPhoneCallIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { PhoneCallScheduledAt = null };
+            var request = new TeacherTrainingAdviserSignUp() { PhoneCallScheduledAt = null };
 
             request.Candidate.PhoneCall.Should().BeNull();
         }
@@ -129,7 +129,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_SubjectTaughtIdIsNull_NoPastTeachingPositionIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { SubjectTaughtId = null };
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
 
             request.Candidate.PastTeachingPositions.Should().BeEmpty();
         }
@@ -137,7 +137,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_QualificationFieldsAreNull_NoQualificationIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = null };
+            var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = null };
 
             request.Candidate.Qualifications.Should().BeEmpty();
         }
@@ -145,7 +145,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_UkDegreeGradeIdIsPresent_QualificationIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { UkDegreeGradeId = 1, DegreeStatusId = null, DegreeSubject = null };
+            var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = 1, DegreeStatusId = null, DegreeSubject = null };
 
             request.Candidate.Qualifications.Count.Should().Be(1);
         }
@@ -153,7 +153,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_DegreeStatusIdIsPresent_QualificationIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { UkDegreeGradeId = null, DegreeStatusId = 1, DegreeSubject = null };
+            var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = null, DegreeStatusId = 1, DegreeSubject = null };
 
             request.Candidate.Qualifications.Count.Should().Be(1);
         }
@@ -161,7 +161,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_DegreeSubjectIdIsPresent_QualificationIsCreated()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = "Maths" };
+            var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = "Maths" };
 
             request.Candidate.Qualifications.Count.Should().Be(1);
         }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -8,6 +9,35 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TeachingEventAddAttendeeTests
     {
+        [Fact]
+        public void Constructor_WithCandidate_MapsCorrectly()
+        {
+            var subscriptions = new List<Subscription>() { new Subscription() { TypeId = (int)Subscription.ServiceType.Event } };
+
+            var candidate = new Candidate()
+            {
+                Id = Guid.NewGuid(),
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                Telephone = "1234567",
+                AddressPostcode = "KY11 9YU",
+                Subscriptions = subscriptions,
+            };
+
+            var response = new TeachingEventAddAttendee(candidate);
+
+            response.CandidateId.Should().Be(candidate.Id);
+            response.Email.Should().Be(candidate.Email);
+            response.FirstName.Should().Be(candidate.FirstName);
+            response.LastName.Should().Be(candidate.LastName);
+            response.Telephone.Should().Be(candidate.Telephone);
+            response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+
+            response.AlreadySubscribedToEvents.Should().BeTrue();
+            response.AlreadySubscribedToMailingList.Should().BeFalse();
+        }
+
         [Fact]
         public void Candidate_MapsCorrectly()
         {
@@ -43,7 +73,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeTrue();
 
-            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be(request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -6,81 +6,79 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
 {
-    public class MailingListAddMemberRequestTests
+    public class TeachingEventAddAttendeeTests
     {
         [Fact]
         public void Candidate_MapsCorrectly()
         {
-            var request = new MailingListAddMemberRequest()
+            var request = new TeachingEventAddAttendee()
             {
+                EventId = Guid.NewGuid(),
                 CandidateId = Guid.NewGuid(),
-                QualificationId = Guid.NewGuid(),
-                PreferredTeachingSubjectId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
-                DescribeYourselfOptionId = 1,
-                ConsiderationJourneyStageId = 2,
-                UkDegreeGradeId = 3,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                CallbackInformation = "Test information",
                 SubscribeToEvents = true,
+                SubscribeToMailingList = true,
             };
 
             var candidate = request.Candidate;
 
             candidate.Id.Should().Equals(request.CandidateId);
-            candidate.DescribeYourselfOptionId.Should().Be(request.DescribeYourselfOptionId);
-            candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
-            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.Telephone.Should().Be(request.Telephone);
-            candidate.CallbackInformation.Should().Be(request.CallbackInformation);
             candidate.ChannelId.Should().BeNull();
             candidate.EligibilityRulesPassed.Should().Be("false");
             candidate.OptOutOfSms.Should().BeFalse();
-            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeTrue();
             candidate.DoNotEmail.Should().BeFalse();
             candidate.DoNotBulkPostalMail.Should().BeTrue();
             candidate.DoNotPostalMail.Should().BeTrue();
-            candidate.DoNotSendMm.Should().BeFalse();
+            candidate.DoNotSendMm.Should().BeTrue();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be(request.AcceptedPolicyId);
-            candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
-            candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
-            candidate.Qualifications.First().UkDegreeGradeId.Should().Be(request.UkDegreeGradeId);
-            candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
+            candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.Event);
+            candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
+            candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
         }
 
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNull_IsMailingList()
         {
-            var request = new MailingListAddMemberRequest() { CandidateId = null };
+            var request = new TeachingEventAddAttendee() { CandidateId = null };
 
-            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.MailingList);
+            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.Event);
         }
 
         [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNotNull_IsNull()
         {
-            var request = new MailingListAddMemberRequest() { CandidateId = Guid.NewGuid() };
+            var request = new TeachingEventAddAttendee() { CandidateId = Guid.NewGuid() };
 
             request.Candidate.ChannelId.Should().BeNull();
         }
 
         [Fact]
+        public void Candidate_SubscribeToMailingListIsFalse_DoesNotCreateSubscription()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false };
+
+            request.Candidate.Subscriptions.Count.Should().Be(0);
+        }
+
+        [Fact]
         public void Candidate_SubscribeToEventsIsFalse_DoesNotCreateSubscription()
         {
-            var request = new MailingListAddMemberRequest() { SubscribeToEvents = false };
+            var request = new TeachingEventAddAttendee() { SubscribeToEvents = false };
 
-            request.Candidate.Subscriptions.Count.Should().Be(1);
-            request.Candidate.Subscriptions.Where(s => s.TypeId == (int)Subscription.ServiceType.Event).Count().Should().Be(0);
+            request.Candidate.Subscriptions.Count.Should().Be(0);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestTests.cs
@@ -70,5 +70,35 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
         }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_AcceptedPolicyIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_DescribeYourselfOptionIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.DescribeYourselfOptionId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_ConsiderationJourneyStageIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.ConsiderationJourneyStageId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_UkDegreeGradeIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.UkDegreeGradeId, null as int?);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberRequestTests.cs
@@ -1,41 +1,47 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Linq;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Validators;
 using GetIntoTeachingApi.Services;
 using Moq;
-using System;
-using System.Linq;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.Validators
 {
-    public class TeachingEventAddAttendeeRequestValidatorTests
+    public class MailingListAddMemberRequestTests
     {
-        private readonly TeachingEventAddAttendeeRequestValidator _validator;
+        private readonly MailingListAddMemberValidator _validator;
         private readonly Mock<IStore> _mockStore;
 
-        public TeachingEventAddAttendeeRequestValidatorTests()
+        public MailingListAddMemberRequestTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new TeachingEventAddAttendeeRequestValidator(_mockStore.Object);
+            _validator = new MailingListAddMemberValidator(_mockStore.Object);
         }
 
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
+            var mockPickListItem = new TypeEntity { Id = "123" };
+            var mockEntityReference = new TypeEntity { Id = Guid.NewGuid().ToString() };
             var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
 
-            var request = new TeachingEventAddAttendeeRequest()
+            var request = new MailingListAddMember()
             {
                 CandidateId = null,
-                EventId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.Parse(mockEntityReference.Id),
                 AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
+                DescribeYourselfOptionId = int.Parse(mockPickListItem.Id),
+                ConsiderationJourneyStageId = int.Parse(mockPickListItem.Id),
+                UkDegreeGradeId = int.Parse(mockPickListItem.Id),
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
+                CallbackInformation = "Test information",
             };
 
             var result = _validator.TestValidate(request);
@@ -49,14 +55,20 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_CandidateIsInvalid_HasError()
         {
-            var request = new TeachingEventAddAttendeeRequest
+            var request = new MailingListAddMember
             {
-                FirstName = null,
+                PreferredTeachingSubjectId = Guid.NewGuid(),
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("Candidate.FirstName");
+            result.ShouldHaveValidationErrorFor("Candidate.PreferredTeachingSubjectId");
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpRequestValidatorTests.cs
@@ -1,0 +1,83 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class TeacherTrainingAdviserSignUpRequestValidatorTests
+    {
+        private readonly TeacherTrainingAdviserSignUpRequestValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public TeacherTrainingAdviserSignUpRequestValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new TeacherTrainingAdviserSignUpRequestValidator(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var request = new TeacherTrainingAdviserSignUpRequest()
+            {
+                CandidateId = Guid.NewGuid(),
+                AcceptedPolicyId = Guid.NewGuid(),
+                QualificationId = Guid.NewGuid(),
+                SubjectTaughtId = Guid.NewGuid(),
+                PastTeachingPositionId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                CountryId = Guid.NewGuid(),
+                UkDegreeGradeId = 1,
+                DegreeStatusId = 2,
+                InitialTeacherTrainingYearId = 3,
+                PreferredEducationPhaseId = 4,
+                HasGcseEnglishId = 5,
+                HasGcseMathsId = 6,
+                HasGcseScienceId = 7,
+                PlanningToRetakeCgseScienceId = 8,
+                PlanningToRetakeGcseEnglishId = 9,
+                PlanningToRetakeGcseMathsId = 10,
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                DateOfBirth = DateTime.Now,
+                TeacherId = "abc123",
+                DegreeSubject = "Maths",
+                Telephone = "1234567",
+                AddressLine1 = "Line 1",
+                AddressLine2 = "Line 2",
+                AddressLine3 = "Line 3",
+                AddressCity = "City",
+                AddressState = "State",
+                AddressPostcode = "KY11 9YU",
+                PhoneCallScheduledAt = DateTime.Now,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            // Ensure no validation errors on root object (we expect errors on the Candidate
+            // properties as we can't mock them).
+            var propertiesWithErrors = result.Errors.Select(e => e.PropertyName);
+            propertiesWithErrors.All(p => p.StartsWith("Candidate.")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_CandidateIsInvalid_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUpRequest
+            {
+                FirstName = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("Candidate.FirstName");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -79,5 +79,11 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             result.ShouldHaveValidationErrorFor("Candidate.FirstName");
         }
+
+        [Fact]
+        public void Validate_AcceptedPrivacyPolicyIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -10,21 +10,21 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.Validators
 {
-    public class TeacherTrainingAdviserSignUpRequestValidatorTests
+    public class TeacherTrainingAdviserSignUpValidatorTests
     {
-        private readonly TeacherTrainingAdviserSignUpRequestValidator _validator;
+        private readonly TeacherTrainingAdviserSignUpValidator _validator;
         private readonly Mock<IStore> _mockStore;
 
-        public TeacherTrainingAdviserSignUpRequestValidatorTests()
+        public TeacherTrainingAdviserSignUpValidatorTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new TeacherTrainingAdviserSignUpRequestValidator(_mockStore.Object);
+            _validator = new TeacherTrainingAdviserSignUpValidator(_mockStore.Object);
         }
 
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest()
+            var request = new TeacherTrainingAdviserSignUp()
             {
                 CandidateId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
@@ -70,7 +70,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_CandidateIsInvalid_HasError()
         {
-            var request = new TeacherTrainingAdviserSignUpRequest
+            var request = new TeacherTrainingAdviserSignUp
             {
                 FirstName = null,
             };

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -58,5 +58,17 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             result.ShouldHaveValidationErrorFor("Candidate.FirstName");
         }
+
+        [Fact]
+        public void Validate_AcceptedPolicyIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_EventIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.EventId, null as Guid?);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -1,47 +1,41 @@
-﻿using System;
-using System.Linq;
-using FluentAssertions;
+﻿using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Validators;
 using GetIntoTeachingApi.Services;
 using Moq;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.Validators
 {
-    public class MailingListAddMemberRequestValidatorTests
+    public class TeachingEventAddAttendeeValidatorTests
     {
-        private readonly MailingListAddMemberRequestValidator _validator;
+        private readonly TeachingEventAddAttendeeValidator _validator;
         private readonly Mock<IStore> _mockStore;
 
-        public MailingListAddMemberRequestValidatorTests()
+        public TeachingEventAddAttendeeValidatorTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new MailingListAddMemberRequestValidator(_mockStore.Object);
+            _validator = new TeachingEventAddAttendeeValidator(_mockStore.Object);
         }
 
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var mockPickListItem = new TypeEntity { Id = "123" };
-            var mockEntityReference = new TypeEntity { Id = Guid.NewGuid().ToString() };
             var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
 
-            var request = new MailingListAddMemberRequest()
+            var request = new TeachingEventAddAttendee()
             {
                 CandidateId = null,
-                PreferredTeachingSubjectId = Guid.Parse(mockEntityReference.Id),
+                EventId = Guid.NewGuid(),
                 AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
-                DescribeYourselfOptionId = int.Parse(mockPickListItem.Id),
-                ConsiderationJourneyStageId = int.Parse(mockPickListItem.Id),
-                UkDegreeGradeId = int.Parse(mockPickListItem.Id),
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                CallbackInformation = "Test information",
             };
 
             var result = _validator.TestValidate(request);
@@ -55,20 +49,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_CandidateIsInvalid_HasError()
         {
-            var request = new MailingListAddMemberRequest
+            var request = new TeachingEventAddAttendee
             {
-                PreferredTeachingSubjectId = Guid.NewGuid(),
+                FirstName = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("Candidate.PreferredTeachingSubjectId");
-        }
-
-        [Fact]
-        public void Validate_AddressPostcodeIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
+            result.ShouldHaveValidationErrorFor("Candidate.FirstName");
         }
     }
 }


### PR DESCRIPTION
- Add validator for TeachingAdviserSignUpRequest

Add basic validation to ensure underlying Candidate is valid - still needs fleshed out for more specific validation based on branches.

- Remove Request suffix from models

These models will be used for response models going forward as well, so it makes sense to drop the `Request` suffix from their name.

- Exchange pin code for TeacherTrainingAdviserSignUp

Instead of returning the base `Candidate` model, it makes more sense to return the request model for a TTA sign up already pre-filled so that the client does not have to map to/from the `Candidate` model and the logic around which qualification/past teaching position to use can be encapsulated in the API.

- Exchange pin code for MailingListAddMember

Add new endpoint to exchange PIN code for a pre-filled `MailingListAddMember` in order to enable easily pre-populating the mailing list sign up form.

- Exchange pin code for TeachingEventAddAttendee

Add new endpoint to exchange PIN code for a pre-filled `TeachingEventAddAttendee` in order to enable easily pre-populating the teaching event sign up form.