### PR TITLE
Make Postcode optional unless Radius is provided

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
@@ -14,8 +14,8 @@ namespace GetIntoTeachingApi.Models.Validators
             _store = store;
 
             RuleFor(request => request.Postcode)
-                .NotEmpty()
                 .Must(store.IsValidPostcode)
+                .Unless(request => request.Postcode == null && request.Radius == null)
                 .WithMessage("Must be a valid postcode.");
             RuleFor(request => request.TypeId)
                 .Must(id => TypeIds().Contains(id.ToString()))

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -61,6 +61,20 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_RadiusIsNotNullAndPostcodeIsNull_HasError()
+        {
+            var request = new TeachingEventSearchRequest()
+            {
+                Radius = 10,
+                Postcode = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request.Postcode).WithErrorMessage("Must be a valid postcode.");
+        }
+
+        [Fact]
         public void Validate_TypeIdIsInvalid_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.TypeId, 123);
@@ -76,6 +90,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_PostcodeIsEmpty_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.Postcode, "");
+        }
+
+        [Fact]
+        public void Validate_PostcodeIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(request => request.Postcode, null as string);
         }
 
         [Fact]


### PR DESCRIPTION
It is possible to do a national search in the front-end, so this PR updates the API to support searching without a postcode. If a radius is provided then a postcode must be specified.