### PR TITLE
Updates for schema changes/validation corrections

### DIFF
--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -10,9 +10,17 @@ namespace GetIntoTeachingApi.Models
     {
         public enum DegreeStatus
         {
-            HasDegreeEquivilent = 222750005,
-            IsStudying = 222750001,
             HasDegree = 222750000,
+            FinalYear = 222750001,
+            SecondYear = 222750002,
+            FirstYear = 222750003,
+            NoDegree = 222750004,
+        }
+
+        public enum DegreeType
+        {
+            Degree = 222750000,
+            DegreeEquivalent = 222750007,
         }
 
         [EntityField("dfe_type", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Models
         }
 
         public enum Destination
-        { 
+        {
             Uk = 222750000,
             International = 222750001,
         }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -14,8 +14,17 @@ namespace GetIntoTeachingApi.Models
             CallbackRequest = 222750000,
         }
 
+        public enum Destination
+        { 
+            Uk = 222750000,
+            International = 222750001,
+        }
+
         [EntityField("dfe_channelcreation", typeof(OptionSetValue))]
         public int? ChannelId { get; set; }
+        [JsonIgnore]
+        [EntityField("dfe_destination", typeof(OptionSetValue))]
+        public int? DestinationId { get; set; }
         [EntityField("scheduledstart")]
         public DateTime ScheduledAt { get; set; }
         [JsonIgnore]

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -157,6 +157,7 @@ namespace GetIntoTeachingApi.Models
                 candidate.PhoneCall = new PhoneCall()
                 {
                     Telephone = Telephone,
+                    DestinationId = DestinationForTelephone(Telephone),
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.CallbackRequest,
                 };
@@ -187,6 +188,23 @@ namespace GetIntoTeachingApi.Models
             candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.TeacherTrainingAdviser });
 
             return candidate;
+        }
+
+        private int? DestinationForTelephone(string telephone)
+        {
+            if (telephone == null)
+            {
+                return null;
+            }
+
+            var sanitizedTelephone = telephone.Replace(" ", string.Empty);
+
+            if (sanitizedTelephone.StartsWith("+") && !sanitizedTelephone.StartsWith("+44"))
+            {
+                return (int)PhoneCall.Destination.International;
+            }
+
+            return (int)PhoneCall.Destination.Uk;
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
@@ -183,6 +184,8 @@ namespace GetIntoTeachingApi.Models
                     SubjectTaughtId = SubjectTaughtId,
                     EducationPhaseId = (int)CandidatePastTeachingPosition.EducationPhase.Secondary,
                 });
+
+                candidate.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
             }
 
             candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.TeacherTrainingAdviser });

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -22,7 +22,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => DateTime.Now);
-            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(@"^\+?[\d\s]+$");
+            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -33,8 +33,8 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be set to schedule a callback.");
 
             RuleFor(request => request.PhoneCallScheduledAt).NotNull()
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegreeEquivilent)
-                .WithMessage("Must be set for candidate with UK equivilent degree.");
+                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .WithMessage("Must be set for candidate with UK equivalent degree.");
 
             RuleFor(request => request.InitialTeacherTrainingYearId).NotNull()
                 .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
@@ -44,18 +44,57 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
                 .WithMessage("Must be set unless candidate has past teaching positions.");
 
+            RuleFor(request => request.DegreeTypeId).NotEmpty()
+                .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
+                .WithMessage("Must be set unless candidate has past teaching positions.");
+
+            RuleFor(request => request.DegreeTypeId)
+                .Must(type =>
+                    new List<int?>
+                    {
+                        (int)CandidateQualification.DegreeType.Degree,
+                        (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                    }.Contains(type))
+                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree)
+                .WithMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
+
+            RuleFor(request => request.DegreeTypeId)
+                .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
+                .When(request =>
+                    new List<int?>
+                    {
+                        (int)CandidateQualification.DegreeStatus.FinalYear,
+                        (int)CandidateQualification.DegreeStatus.SecondYear,
+                        (int)CandidateQualification.DegreeStatus.FirstYear,
+                    }.Contains(request.DegreeStatusId))
+                .WithMessage("Must be set to degree when status is studying for a degree.");
+
+            RuleFor(request => request.DegreeTypeId)
+                .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
+                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.NoDegree)
+                .WithMessage("Must be set to degree when the degree status is no degree.");
+
             RuleFor(request => request.DegreeSubject).NotEmpty()
                 .When(request =>
                     new List<int?>
                     {
                         (int)CandidateQualification.DegreeStatus.HasDegree,
-                        (int)CandidateQualification.DegreeStatus.IsStudying,
+                        (int)CandidateQualification.DegreeStatus.FinalYear,
+                        (int)CandidateQualification.DegreeStatus.SecondYear,
+                        (int)CandidateQualification.DegreeStatus.FirstYear,
                     }.Contains(request.DegreeStatusId))
                 .WithMessage("Must be set when candidate has a degree or is studying for a degree.");
 
             RuleFor(request => request.UkDegreeGradeId).NotEmpty()
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree)
-                .WithMessage("Must be set when candidate has a degree.");
+                .When(request =>
+                    new List<int?>
+                    {
+                        (int)CandidateQualification.DegreeStatus.HasDegree,
+                        (int)CandidateQualification.DegreeStatus.FinalYear,
+                        (int)CandidateQualification.DegreeStatus.SecondYear,
+                        (int)CandidateQualification.DegreeStatus.FirstYear,
+                    }.Contains(request.DegreeStatusId))
+                .WithMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
 
             RuleFor(request => request.PreferredTeachingSubjectId).NotEmpty()
                 .When(request => request.Candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -17,6 +17,8 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("DestinationId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_destination" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("ScheduledAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "scheduledstart");
             type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "phonenumber");

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -309,5 +309,13 @@ namespace GetIntoTeachingApiTests.Models
 
             request.Candidate.PhoneCall.DestinationId.Should().BeNull();
         }
+
+        [Fact]
+        public void Candidate_SubjectTaughtIdIsNotNull_PreferredEducationPhaseIdDefaultsToSecondary()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+
+            request.Candidate.PreferredEducationPhaseId.Should().Be((int)Candidate.PreferredEducationPhase.Secondary);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -194,6 +194,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
             candidate.PhoneCall.Telephone.Should().Be(request.Telephone);
             candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
+            candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
 
             candidate.PastTeachingPositions.First().Id.Should().Be(request.PastTeachingPositionId);
             candidate.PastTeachingPositions.First().SubjectTaughtId.Should().Be(request.SubjectTaughtId);
@@ -278,6 +279,35 @@ namespace GetIntoTeachingApiTests.Models
             var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = "Maths", DegreeTypeId = null };
 
             request.Candidate.Qualifications.Count.Should().Be(1);
+        }
+
+        [Theory]
+        [InlineData("07584627385")]
+        [InlineData("+44 7564 375 482")]
+        [InlineData("+447564 375 482")]
+        public void Candidate_UkTelephone_PhoneCallDestinationIsCorrect(string telephone)
+        {
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.Now };
+
+            request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
+        }
+
+        [Theory]
+        [InlineData("+55 7584627385")]
+        [InlineData("+57564 375 482")]
+        public void Candidate_InternationalTelephone_PhoneCallDestinationIsCorrect(string telephone)
+        {
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.Now };
+
+            request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.International);
+        }
+
+        [Fact]
+        public void Candidate_NullTelephone_PhoneCallDestinationIsCorrect()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = null, PhoneCallScheduledAt = DateTime.Now };
+
+            request.Candidate.PhoneCall.DestinationId.Should().BeNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -324,10 +324,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("123 4567", false)]
         [InlineData("  123 456 7", false)]
         [InlineData("+44 7503 483524", false)]
+        [InlineData("+44 7503.483524", false)]
+        [InlineData("+44 (7503) 483524", false)]
         [InlineData("abcgewgewgh", true)]
         [InlineData("abc2451215", true)]
         [InlineData("42154h53151", true)]
-        [InlineData("5325.56326.32", true)]
+        [InlineData("5325.56fs326.32", true)]
         public void Validate_TelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
         {
             if (hasError)

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -211,31 +211,129 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_DegreeStatusIsEquivilentAndPhoneCallScheduledAtIsNull_HasError()
+        public void Validate_DegreeTypeIsEquivalentAndPhoneCallScheduledAtIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegreeEquivilent,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 PhoneCallScheduledAt = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Must be set for candidate with UK equivilent degree.");
+            result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Must be set for candidate with UK equivalent degree.");
         }
 
         [Fact]
-        public void Validate_DegreeStatusIsEquivilentAndPhoneCallScheduledAtIsNotNull_HasNoError()
+        public void Validate_DegreeTypeIsEquivalentAndPhoneCallScheduledAtIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegreeEquivilent,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 PhoneCallScheduledAt = DateTime.Now,
             };
 
             var result = _validator.TestValidate(request);
 
             result.ShouldNotHaveValidationErrorFor("PhoneCallScheduledAt");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                DegreeTypeId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsDegree_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsDegreeEquivalent_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsStudyingAndAndDegreeTypeIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.FinalYear,
+                DegreeTypeId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set to degree when status is studying for a degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsStudyingAndAndDegreeTypeIsDegree_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.FinalYear,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsNoDegreeAndAndDegreeTypeIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
+                DegreeTypeId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set to degree when the degree status is no degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsNoDegreeAndAndDegreeTypeIsDegree_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
         }
 
         [Fact]
@@ -281,7 +379,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndDegreeStatusIsNotNull_HasError()
+        public void Validate_NoPastTeachingPositionsAndDegreeStatusIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
@@ -295,11 +393,39 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_NoPastTeachingPositionsAndDegreeTypeIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                SubjectTaughtId = null,
+                DegreeTypeId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set unless candidate has past teaching positions.");
+        }
+
+        [Fact]
+        public void Validate_NoPastTeachingPositionsAndDegreeTypeIsNotNull_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                SubjectTaughtId = null,
+                DegreeTypeId = 1,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
+        }
+
+        [Fact]
         public void Validate_DegreeStatusIsStudyingAndDegreeSubjectIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                DegreeStatusId = (int)CandidateQualification.DegreeStatus.IsStudying,
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
                 DegreeSubject = null,
             };
 
@@ -313,7 +439,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                DegreeStatusId = (int)CandidateQualification.DegreeStatus.IsStudying,
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
                 DegreeSubject = "Maths",
             };
 
@@ -361,11 +487,39 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("UkDegreeGradeId").WithErrorMessage("Must be set when candidate has a degree.");
+            result.ShouldHaveValidationErrorFor("UkDegreeGradeId").WithErrorMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
         }
 
         [Fact]
         public void Validate_DegreeStatusIsHasDegreeAndUkDegreeGradeIsNotNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                UkDegreeGradeId = 1,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("UkDegreeGradeId");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsStudyingAndUkDegreeGradeIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                UkDegreeGradeId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("UkDegreeGradeId").WithErrorMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsStudyingAndUkDegreeGradeIsNotNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {


### PR DESCRIPTION
- Update telephone validation

We want to allow pretty much anything from the client as this will be international numbers.

- Determine PhoneCall DestinationId from Telephone

If the number starts with a `+` and is not `+44` then we mark it as international.

- Correct validation around degree type/subject

Pin down the validation around degree subject and type, which is non-intuitive. Essentially:

> Do you have a degree?

```
Yes - status = 222750000 (has degree), type = 222750000 (degree)

No - status = 222750004 (no degree),type = 222750000 (degree)

Studying - status = 222750001 (final)/222750002(second)/222750003(first) (depends on subsequent question), type = 222750000 (degree)

Equivalent - status = 222750000 (has degree), type = 222750005 (equivalent)
```