### PR TITLE
Mark candidates with eligibility state

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -180,13 +180,13 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
-        [Route("candidate/status")]
+        [Route("candidate/assignment_status")]
         [SwaggerOperation(
-            Summary = "Retrieves the list of candidate status.",
-            OperationId = "GetCandidateStatus",
+            Summary = "Retrieves the list of candidate assignment status.",
+            OperationId = "GetCandidateAssignmentStatus",
             Tags = new[] { "Types" })]
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
-        public async Task<IActionResult> GetCandidateStatus()
+        public async Task<IActionResult> GetCandidateAssignmentStatus()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_candidatestatus").ToListAsync());
         }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -32,6 +32,12 @@ namespace GetIntoTeachingApi.Models
             WaitingToBeAssigned = 222750001,
         }
 
+        public enum Type
+        {
+            InterestedInTeacherTraining = 222750000,
+            ReturningToTeacherTraining = 222750001,
+        }
+
         public enum GdprConsent
         {
             Consent = 587030001,

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -17,6 +17,16 @@ namespace GetIntoTeachingApi.Models
             Inactive,
         }
 
+        public enum AdviserEligibility
+        {
+            Yes = 222750000,
+        }
+
+        public enum AdviserRequirement
+        {
+            Yes = 222750000,
+        }
+
         public enum AssignmentStatus
         {
             WaitingToBeAssigned = 222750001,
@@ -86,7 +96,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_typeofcandidate", typeof(OptionSetValue))]
         public int? TypeId { get; set; }
         [EntityField("dfe_candidatestatus", typeof(OptionSetValue))]
-        public int? StatusId { get; set; }
+        public int? AssignmentStatusId { get; set; }
         [EntityField("dfe_iscandidateeligibleforadviser", typeof(OptionSetValue))]
         public int? AdviserEligibilityId { get; set; }
         [EntityField("dfe_isadvisorrequiredos", typeof(OptionSetValue))]
@@ -175,11 +185,16 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
+        public bool IsReturningToTeaching()
+        {
+            return PastTeachingPositions.Count > 0;
+        }
+
         protected override bool ShouldMap(ICrmService crm)
         {
             IsNewRegistrant = Id == null;
 
-            if (StatusId == (int)AssignmentStatus.WaitingToBeAssigned)
+            if (AssignmentStatusId == (int)AssignmentStatus.WaitingToBeAssigned)
             {
                 StatusIsWaitingToBeAssignedAt = DateTime.Now;
             }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
@@ -139,7 +138,7 @@ namespace GetIntoTeachingApi.Models
                 EligibilityRulesPassed = "false",
                 AdviserRequirementId = null,
                 AdviserEligibilityId = null,
-                StatusId = null,
+                AssignmentStatusId = null,
                 OptOutOfSms = false,
                 DoNotBulkEmail = false,
                 DoNotEmail = false,
@@ -155,6 +154,7 @@ namespace GetIntoTeachingApi.Models
 
             if (PhoneCallScheduledAt != null)
             {
+                candidate.EligibilityRulesPassed = "true";
                 candidate.PhoneCall = new PhoneCall()
                 {
                     Telephone = Telephone,
@@ -186,6 +186,14 @@ namespace GetIntoTeachingApi.Models
                 });
 
                 candidate.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
+            }
+
+            var eligibleForAnAdviser = DegreeTypeId == (int)CandidateQualification.DegreeType.Degree || candidate.IsReturningToTeaching();
+            if (eligibleForAnAdviser)
+            {
+                candidate.AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned;
+                candidate.AdviserEligibilityId = (int)Candidate.AdviserEligibility.Yes;
+                candidate.AdviserRequirementId = (int)Candidate.AdviserRequirement.Yes;
             }
 
             candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.TeacherTrainingAdviser });

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -196,6 +196,15 @@ namespace GetIntoTeachingApi.Models
                 candidate.AdviserRequirementId = (int)Candidate.AdviserRequirement.Yes;
             }
 
+            if (candidate.IsReturningToTeaching())
+            {
+                candidate.TypeId = (int)Candidate.Type.ReturningToTeacherTraining;
+            }
+            else
+            {
+                candidate.TypeId = (int)Candidate.Type.InterestedInTeacherTraining;
+            }
+
             candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.TeacherTrainingAdviser });
 
             return candidate;

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -107,10 +107,10 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Must(id => TypeIds().Contains(id.ToString()))
                 .Unless(candidate => candidate.TypeId == null)
                 .WithMessage("Must be a valid candidate type.");
-            RuleFor(candidate => candidate.StatusId)
-                .Must(id => StatusIds().Contains(id.ToString()))
-                .Unless(candidate => candidate.StatusId == null)
-                .WithMessage("Must be a valid candidate status.");
+            RuleFor(candidate => candidate.AssignmentStatusId)
+                .Must(id => AssignmentStatusIds().Contains(id.ToString()))
+                .Unless(candidate => candidate.AssignmentStatusId == null)
+                .WithMessage("Must be a valid candidate assignment status.");
             RuleFor(candidate => candidate.AdviserEligibilityId)
                 .Must(id => AdviserEligibilityIds().Contains(id.ToString()))
                 .Unless(candidate => candidate.AdviserEligibilityId == null)
@@ -171,7 +171,7 @@ namespace GetIntoTeachingApi.Models.Validators
             return _store.GetPickListItems("contact", "dfe_typeofcandidate").Select(type => type.Id);
         }
 
-        private IEnumerable<string> StatusIds()
+        private IEnumerable<string> AssignmentStatusIds()
         {
             return _store.GetPickListItems("contact", "dfe_candidatestatus").Select(type => type.Id);
         }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -37,15 +37,15 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be set for candidate with UK equivalent degree.");
 
             RuleFor(request => request.InitialTeacherTrainingYearId).NotNull()
-                .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
+                .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set unless candidate has past teaching positions.");
 
             RuleFor(request => request.DegreeStatusId).NotEmpty()
-                .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
+                .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set unless candidate has past teaching positions.");
 
             RuleFor(request => request.DegreeTypeId).NotEmpty()
-                .Unless(request => request.Candidate.PastTeachingPositions.Count > 0)
+                .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set unless candidate has past teaching positions.");
 
             RuleFor(request => request.DegreeTypeId)

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -44,6 +44,10 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set unless candidate has past teaching positions.");
 
+            RuleFor(request => request.DegreeStatusId)
+                .Must(status => status != (int)CandidateQualification.DegreeStatus.NoDegree)
+                .WithMessage("Not eligible for service if degree status is no degree.");
+
             RuleFor(request => request.DegreeTypeId).NotEmpty()
                 .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set unless candidate has past teaching positions.");

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -163,12 +163,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public async void GetCandidateStatus_ReturnsAllStatus()
+        public async void GetCandidateAssignmentStatus_ReturnsAllStatus()
         {
             var mockEntities = MockTypeEntities();
             _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_candidatestatus")).Returns(mockEntities.AsAsyncQueryable());
 
-            var response = await _controller.GetCandidateStatus();
+            var response = await _controller.GetCandidateAssignmentStatus();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().BeEquivalentTo(mockEntities);

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -51,7 +51,7 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_websitewhereinconsiderationjourney" && a.Type == typeof(OptionSetValue));
             type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_typeofcandidate" && a.Type == typeof(OptionSetValue));
-            type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+            type.GetProperty("AssignmentStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidatestatus" && a.Type == typeof(OptionSetValue));
             type.GetProperty("AdviserEligibilityId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_iscandidateeligibleforadviser" && a.Type == typeof(OptionSetValue));
@@ -350,7 +350,7 @@ namespace GetIntoTeachingApiTests.Models
             var mockService = new Mock<IOrganizationServiceAdapter>();
             var context = mockService.Object.Context();
             var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { StatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned };
+            var candidate = new Candidate() { AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned };
             var candidateEntity = new Entity("contact");
             mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(candidateEntity);
 
@@ -366,7 +366,7 @@ namespace GetIntoTeachingApiTests.Models
             var mockService = new Mock<IOrganizationServiceAdapter>();
             var context = mockService.Object.Context();
             var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { StatusId = null };
+            var candidate = new Candidate() { AssignmentStatusId = null };
             var candidateEntity = new Entity("contact");
             mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(candidateEntity);
 
@@ -405,6 +405,24 @@ namespace GetIntoTeachingApiTests.Models
         public void OptOutOfGdpr_DefaultValue_IsCorrect()
         {
             new Candidate().OptOutOfGdpr.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsReturningToTeaching_WhenHasPastTeachingPositions_ReturnsTrue()
+        {
+            var candidate = new Candidate();
+            candidate.PastTeachingPositions.Add(new CandidatePastTeachingPosition());
+
+            candidate.IsReturningToTeaching().Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsReturningToTeaching_WhenHasPastTeachingPositions_ReturnsFalse()
+        {
+            var candidate = new Candidate();
+            candidate.PastTeachingPositions = new List<CandidatePastTeachingPosition>();
+
+            candidate.IsReturningToTeaching().Should().BeFalse();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -164,9 +164,9 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseEnglishId);
             candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsId);
             candidate.PlanningToRetakeCgseScienceId.Should().Equals(request.PlanningToRetakeCgseScienceId);
-            candidate.AdviserRequirementId.Should().BeNull();
-            candidate.AdviserEligibilityId.Should().BeNull();
-            candidate.StatusId.Should().BeNull();
+            candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
+            candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
+            candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
@@ -181,7 +181,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.AddressState.Should().Be(request.AddressState);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.ChannelId.Should().BeNull();
-            candidate.EligibilityRulesPassed.Should().Be("false");
+            candidate.EligibilityRulesPassed.Should().Be("true");
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();
@@ -316,6 +316,56 @@ namespace GetIntoTeachingApiTests.Models
             var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
 
             request.Candidate.PreferredEducationPhaseId.Should().Be((int)Candidate.PreferredEducationPhase.Secondary);
+        }
+
+        [Fact]
+        public void Candidate_PhoneCallScheduledAtIsNull_EligibilityRulesPassedIsFalse()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { PhoneCallScheduledAt = null };
+
+            request.Candidate.EligibilityRulesPassed.Should().Be("false");
+        }
+
+        [Fact]
+        public void Candidate_DegreeTypeDegree_IsEligibleForAdviser()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { DegreeTypeId = (int)CandidateQualification.DegreeType.Degree };
+
+            request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
+            request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
+            request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
+        }
+
+        [Fact]
+        public void Candidate_DegreeTypeDegreeEquivalent_IsNotEligibleForAdviser()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent };
+
+            request.Candidate.AssignmentStatusId.Should().BeNull();
+            request.Candidate.AdviserEligibilityId.Should().BeNull();
+            request.Candidate.AdviserRequirementId.Should().BeNull();
+        }
+
+        [Fact]
+        public void Candidate_ReturningToTeaching_IsEligibleForAdviser()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+
+            request.Candidate.IsReturningToTeaching().Should().BeTrue();
+            request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
+            request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
+            request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
+        }
+
+        [Fact]
+        public void Candidate_HasNoPastTeachingPositions_IsNotEligibleForAdviser()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
+
+            request.Candidate.IsReturningToTeaching().Should().BeFalse();
+            request.Candidate.AssignmentStatusId.Should().BeNull();
+            request.Candidate.AdviserEligibilityId.Should().BeNull();
+            request.Candidate.AdviserRequirementId.Should().BeNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -367,5 +367,23 @@ namespace GetIntoTeachingApiTests.Models
             request.Candidate.AdviserEligibilityId.Should().BeNull();
             request.Candidate.AdviserRequirementId.Should().BeNull();
         }
+
+        [Fact]
+        public void Candidate_ReturningToTeaching_TypeIsCorrect()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+
+            request.Candidate.IsReturningToTeaching().Should().BeTrue();
+            request.Candidate.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
+        }
+
+        [Fact]
+        public void Candidate_NotReturningToTeaching_TypeIsCorrect()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
+
+            request.Candidate.IsReturningToTeaching().Should().BeFalse();
+            request.Candidate.TypeId.Should().Be((int)Candidate.Type.InterestedInTeacherTraining);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -92,7 +92,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 PlanningToRetakeCgseScienceId = int.Parse(mockPickListItem.Id),
                 PlanningToRetakeGcseEnglishId = int.Parse(mockPickListItem.Id),
                 TypeId = int.Parse(mockPickListItem.Id),
-                StatusId = int.Parse(mockPickListItem.Id),
+                AssignmentStatusId = int.Parse(mockPickListItem.Id),
                 DoNotPostalMail = false,
                 EligibilityRulesPassed = "true",
                 DescribeYourselfOptionId = int.Parse(mockPickListItem.Id),
@@ -506,15 +506,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_StatusIdIsInvalid_HasError()
+        public void Validate_AssignmentStatusIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.StatusId, 123);
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AssignmentStatusId, 123);
         }
 
         [Fact]
-        public void Validate_StatusIdIsNull_HasNoError()
+        public void Validate_AssignmentStatusIdIsNull_HasNoError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.StatusId, null as int?);
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AssignmentStatusId, null as int?);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -239,6 +239,19 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_DegreeStatusIsNoDegree_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("DegreeStatusId").WithErrorMessage("Not eligible for service if degree status is no degree.");
+        }
+
+        [Fact]
         public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp


### PR DESCRIPTION
- Set eligibility status for TTA sign up

When signing up to the Teacher Training Service a candidate is eligible to talk to an adviser if:

They have a qualification of type degree.
They are returning to teaching.

- Prevent sign up if candidate does not have a degree

- Set Candidate TypeId based on returner status