### PR TITLE
Do not send EligibilityPassed on mailing list/event sign up

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -84,7 +84,6 @@ namespace GetIntoTeachingApi.Models
                 Telephone = Telephone,
                 CallbackInformation = CallbackInformation,
                 ChannelId = CandidateId == null ? (int?)Candidate.Channel.MailingList : null,
-                EligibilityRulesPassed = "false",
                 OptOutOfSms = false,
                 DoNotBulkEmail = false,
                 DoNotEmail = false,

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -64,7 +64,6 @@ namespace GetIntoTeachingApi.Models
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
                 ChannelId = CandidateId == null ? (int?)Candidate.Channel.Event : null,
-                EligibilityRulesPassed = "false",
                 OptOutOfSms = false,
                 DoNotBulkEmail = true,
                 DoNotEmail = false,

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -99,7 +99,6 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Telephone.Should().Be(request.Telephone);
             candidate.CallbackInformation.Should().Be(request.CallbackInformation);
             candidate.ChannelId.Should().BeNull();
-            candidate.EligibilityRulesPassed.Should().Be("false");
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -65,7 +65,6 @@ namespace GetIntoTeachingApiTests.Models
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.Telephone.Should().Be(request.Telephone);
             candidate.ChannelId.Should().BeNull();
-            candidate.EligibilityRulesPassed.Should().Be("false");
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeTrue();
             candidate.DoNotEmail.Should().BeFalse();


### PR DESCRIPTION
This flag is only required if a phone call is being created, which only happens as part of the teacher training adviser sign up.