### PR TITLE
Run CRM sync hourly

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -182,7 +182,7 @@ The GIT API aims to provide:
             app.UseAuthorization();
 
             // Configure recurring jobs.
-            RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), Cron.Daily);
+            RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), Cron.Hourly);
             RecurringJob.AddOrUpdate<LocationSyncJob>(
                 JobConfiguration.LocationSyncJobId,
                 (x) => x.RunAsync("https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip"),


### PR DESCRIPTION
The events data may change during the course of a day and the output could be that an event needs to be hidden/removed. Syncing hourly will ensure that changes to events populate through to the API/website in a timely fasion.