### PR TITLE
Document validation behaviour for request models

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -33,7 +33,14 @@ namespace GetIntoTeachingApi.Controllers
         [SwaggerOperation(
             Summary = "Adds a new member to the mailing list.",
             Description = "If the `CandidateId` is specified then the existing candidate will be " +
-                          "added to the mailing list, otherwise a new candidate will be created.",
+                          "added to the mailing list, otherwise a new candidate will be created." +
+                          "\n\n" +
+                          "Validation errors may be present on the `MailingListAddMember` object as " +
+                          "well as the hidden `Candidate` model that is mapped to; property names are " +
+                          "consistent, so you should check for inclusion of the field in the key " +
+                          "when linking an error message back to a property on the request model. For " +
+                          "example, an error on `UkDegreeGradeId` can return under the keys " +
+                          "`Candidate.Qualifications[0].UkDegreeGradeId` and `UkDegreeGradeId`.",
             OperationId = "AddMailingListMember",
             Tags = new[] { "Mailing List" })]
         [ProducesResponseType(204)]

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -31,6 +31,12 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         [HttpPost]
         [SwaggerOperation(
             Summary = "Sign up a candidate for the Teacher Training Adviser service.",
+            Description = "Validation errors may be present on the `TeacherTrainingAdviserSignUp` object as " +
+                          "well as the hidden `Candidate` model that is mapped to; property names are " +
+                          "consistent, so you should check for inclusion of the field in the key " +
+                          "when linking an error message back to a property on the request model. For " +
+                          "example, an error on `DegreeSubject` can return under the keys " +
+                          "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
             OperationId = "SignUpTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" })]
         [ProducesResponseType(204)]

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -106,7 +106,14 @@ maximum of 50 using the `limit` query parameter.",
         [SwaggerOperation(
             Summary = "Adds an attendee to a teaching event.",
             Description = "If the `CandidateId` is specified then the existing candidate will be " +
-                          "registered for the event, otherwise a new candidate will be created.",
+                          "registered for the event, otherwise a new candidate will be created." +
+                          "\n\n" +
+                          "Validation errors may be present on the `TeachingEventAddAttendee` object as " +
+                          "well as the hidden `Candidate` model that is mapped to; property names are " +
+                          "consistent, so you should check for inclusion of the field in the key " +
+                          "when linking an error message back to a property on the request model. For " +
+                          "example, an error on `AcceptedPolicyId` can return under the keys " +
+                          "`Candidate.PrivacyPolicy.AcceptedPolicyId` and `AcceptedPolicyId`.",
             OperationId = "AddTeachingEventAttendee",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(204)]

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -30,7 +30,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_degreestatus", typeof(OptionSetValue))]
         public int? DegreeStatusId { get; set; }
         [EntityField("dfe_subject")]
-        public string Subject { get; set; }
+        public string DegreeSubject { get; set; }
         [EntityField("createdon")]
         public DateTime? CreatedAt { get; set; }
 

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApi.Models
             if (latestQualification != null)
             {
                 QualificationId = latestQualification.Id;
-                DegreeSubject = latestQualification.Subject;
+                DegreeSubject = latestQualification.DegreeSubject;
                 UkDegreeGradeId = latestQualification.UkDegreeGradeId;
                 DegreeStatusId = latestQualification.DegreeStatusId;
                 DegreeTypeId = latestQualification.TypeId;
@@ -165,7 +165,7 @@ namespace GetIntoTeachingApi.Models
                     Id = QualificationId,
                     UkDegreeGradeId = UkDegreeGradeId,
                     DegreeStatusId = DegreeStatusId,
-                    Subject = DegreeSubject,
+                    DegreeSubject = DegreeSubject,
                     TypeId = DegreeTypeId,
                 });
             }

--- a/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Unless(qualification => qualification.TypeId == null)
                 .WithMessage("Must be a valid qualification types.");
 
-            RuleFor(qualification => qualification.Subject).MaximumLength(600);
+            RuleFor(qualification => qualification.DegreeSubject).MaximumLength(600);
         }
 
         private IEnumerable<string> UkDegreeGradeIds()

--- a/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_type" && a.Type == typeof(OptionSetValue));
             type.GetProperty("DegreeStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_degreestatus" && a.Type == typeof(OptionSetValue));
 
-            type.GetProperty("Subject").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_subject");
+            type.GetProperty("DegreeSubject").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_subject");
             type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "createdon");
         }
     }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApiTests.Models
                 DegreeStatusId = 1,
                 UkDegreeGradeId = 2,
                 TypeId = 3,
-                Subject = "English"
+                DegreeSubject = "English"
             };
 
             var qualifications = new List<CandidateQualification>()
@@ -99,7 +99,7 @@ namespace GetIntoTeachingApiTests.Models
             response.QualificationId.Should().Be(latestQualification.Id);
             response.DegreeStatusId.Should().Be(latestQualification.DegreeStatusId);
             response.UkDegreeGradeId.Should().Be(latestQualification.UkDegreeGradeId);
-            response.DegreeSubject.Should().Be(latestQualification.Subject);
+            response.DegreeSubject.Should().Be(latestQualification.DegreeSubject);
             response.DegreeTypeId.Should().Be(latestQualification.TypeId);
 
             response.PastTeachingPositionId.Should().Be(latestPastTeachingPosition.Id);
@@ -195,7 +195,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
             candidate.Qualifications.First().UkDegreeGradeId.Should().Be(request.UkDegreeGradeId);
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
-            candidate.Qualifications.First().Subject.Should().Be(request.DegreeSubject);
+            candidate.Qualifications.First().DegreeSubject.Should().Be(request.DegreeSubject);
             candidate.Qualifications.First().TypeId.Should().Be(request.DegreeTypeId);
 
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.TeacherTrainingAdviser);

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateQualificationValidatorTests.cs
@@ -38,7 +38,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var qualification = new CandidateQualification()
             {
                 UkDegreeGradeId = int.Parse(mockPickListItem.Id),
-                Subject = "History",
+                DegreeSubject = "History",
                 DegreeStatusId = int.Parse(mockPickListItem.Id),
                 TypeId = int.Parse(mockPickListItem.Id),
             };
@@ -87,7 +87,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SubjectTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(qualification => qualification.Subject, new string('a', 601));
+            _validator.ShouldHaveValidationErrorFor(qualification => qualification.DegreeSubject, new string('a', 601));
         }
 
         private static TypeEntity NewMock(dynamic id)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can hit the API endpoints directly from the Swagger UI - hit the `Authorize`
 
 The majority of the validation should be performed against the core models linked to Dynamics entities (any model that inherits from `BaseModel`). The validation in these models should make sure that the data is correct, but remain loose around which fields are required; often a model will be reused in different contexts and the required fields will change. `Candidate` is a good example of this; the request models `MailingListAddMember`, `TeacherTrainingAdviserSignUp` and `TeachingEventAddAttendee` all map onto `Candidate`, however the required fields are different for each.
 
+Property names in request models should be consistent with any hidden `BaseModel` models they encapsulate and map to; this way the client can resolve the validation error messages back to the original request attributes. For example, the `MailingListAddMember.UkDegreeGradeId` maps to and is consistent with `MailingListAddMember.Candidate.Qualifications[0].UkDegreeGradeId`.
+
 ### Testing
 
 [XUnit](https://xunit.net/) is used for testing; all tests can be found in the `GetIntoTeachingTests` project. We also use [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for mocking any dependencies and [FluentAssertions](https://fluentassertions.com) for assertions.


### PR DESCRIPTION
- Rename Subject to DegreeSubject for consistency

The property names of request models should be consistent with the `BaseModel` models that they map to, that way the error message keys can be reconciled back with the request model.

- Document validation error mapping in request models

An error may be present on the request model or a hidden `BaseModel` model that it maps to. The client needs to check for the inclusion of the request model field in any error keys when reconciling errors with particular fields. This commit documents the behaviour in the endpoints that use request models.

- Update README.md with request model validation notes

