### PR TITLE
Change RadiusInKm to method

### DIFF
--- a/GetIntoTeachingApi/Fixtures/ukpostcodes.dev.csv
+++ b/GetIntoTeachingApi/Fixtures/ukpostcodes.dev.csv
@@ -1,2 +1,3 @@
 ﻿id,postcode,latitude,longitude
 1,KY11 9YU,56.02748,-3.35870
+2,WC1B 3LS,51.51727,-0.12847

--- a/GetIntoTeachingApi/Models/TeachingEventSearchRequest.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventSearchRequest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -16,7 +15,7 @@ namespace GetIntoTeachingApi.Models
         public DateTime? StartAfter { get; set; }
         [SwaggerSchema("Set to filter results to those that start before a given date.")]
         public DateTime? StartBefore { get; set; }
-        [JsonIgnore]
-        public double? RadiusInKm => Radius * 1.60934;
+
+        public double? RadiusInKm() => Radius * 1.60934;
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -130,13 +130,13 @@ namespace GetIntoTeachingApi.Services
 
             // Approximate distance filtering in the database, with a suitable error margin (treats distance as an arc degree).
             teachingEvents = teachingEvents.Where(te => EarthCircumferenceInKm *
-                te.Building.Coordinate.Distance(origin) / 360 < request.RadiusInKm + ErrorMarginInKm);
+                te.Building.Coordinate.Distance(origin) / 360 < request.RadiusInKm() + ErrorMarginInKm);
 
             var inMemoryTeachingEvents = await teachingEvents.ToListAsync();
 
             // Project coordinates onto UK coordinate system for final, accurate distance filtering.
             return inMemoryTeachingEvents.Where(te => te.Building.Coordinate.ProjectTo(DbConfiguration.UkSrid)
-                    .IsWithinDistance(origin.ProjectTo(DbConfiguration.UkSrid), (double)request.RadiusInKm * 1000));
+                    .IsWithinDistance(origin.ProjectTo(DbConfiguration.UkSrid), (double)request.RadiusInKm() * 1000));
         }
 
         private async Task SyncTeachingEvents(ICrmService crm)

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -85,6 +85,7 @@ namespace GetIntoTeachingApiTests.Jobs
             var expectedLocationBatch = new List<dynamic>
             {
                 new { Postcode = "ky119yu", Latitude = 56.02748, Longitude = -3.35870 },
+                new { Postcode = "wc1b3ls", Latitude = 51.51727, Longitude = -0.12847 },
             };
 
             _mockJobClient.Verify(x => x.Create(

--- a/GetIntoTeachingApiTests/Models/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventSearchRequestTests.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData(null, null)]
         public void RadiusInKm_ConvertsCorrectly(int? miles, double? km)
         {
-            new TeachingEventSearchRequest() { Radius = miles }.RadiusInKm.Should().BeApproximately(km, 4);
+            new TeachingEventSearchRequest() { Radius = miles }.RadiusInKm().Should().BeApproximately(km, 4);
         }
     }
 }


### PR DESCRIPTION
Previously it was appearing in the Swagger documentation and apparently `JsonIgnore` doesn't work when `[FromQuery]` so instead of writing a custom schema filter to exclude it we can more easily exclude it by making it a method instead of a property.