### PR TITLE
Update request models to reflect UI changes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
@@ -186,6 +187,16 @@ namespace GetIntoTeachingApi.Models
         public bool IsReturningToTeaching()
         {
             return PastTeachingPositions.Count > 0;
+        }
+
+        public bool HasGcseMathsAndEnglish()
+        {
+            return new[] { HasGcseEnglishId, HasGcseMathsId }.All(g => g == (int)GcseStatus.HasOrIsPlanningOnRetaking);
+        }
+
+        public bool IsPlanningToRetakeGcseMathsAndEnglish()
+        {
+            return new[] { PlanningToRetakeGcseMathsId, PlanningToRetakeGcseEnglishId }.All(g => g == (int)GcseStatus.HasOrIsPlanningOnRetaking);
         }
 
         protected override bool ShouldMap(ICrmService crm)

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -135,8 +135,6 @@ namespace GetIntoTeachingApi.Models
         public string AddressCity { get; set; }
         [EntityField("address1_postalcode")]
         public string AddressPostcode { get; set; }
-        [EntityField("dfe_websitecallbackdescription")]
-        public string CallbackInformation { get; set; }
         [EntityField("dfe_dfesnumber")]
         public string TeacherId { get; set; }
         [EntityField("dfe_eligibilityrulespassed")]

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -21,7 +21,6 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
-        public string CallbackInformation { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -61,7 +60,6 @@ namespace GetIntoTeachingApi.Models
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
             Telephone = candidate.Telephone;
-            CallbackInformation = candidate.CallbackInformation;
 
             AlreadySubscribedToMailingList = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.MailingList);
             AlreadySubscribedToEvents = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.Event);
@@ -79,7 +77,6 @@ namespace GetIntoTeachingApi.Models
                 LastName = LastName,
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
-                CallbackInformation = CallbackInformation,
                 ChannelId = CandidateId == null ? (int?)Candidate.Channel.MailingList : null,
                 OptOutOfSms = false,
                 DoNotBulkEmail = false,

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -20,11 +20,9 @@ namespace GetIntoTeachingApi.Models
         public int? DegreeTypeId { get; set; }
         public int? InitialTeacherTrainingYearId { get; set; }
         public int? PreferredEducationPhaseId { get; set; }
-        public int? HasGcseEnglishId { get; set; }
-        public int? HasGcseMathsId { get; set; }
+        public int? HasGcseMathsAndEnglishId { get; set; }
         public int? HasGcseScienceId { get; set; }
-        public int? PlanningToRetakeGcseEnglishId { get; set; }
-        public int? PlanningToRetakeGcseMathsId { get; set; }
+        public int? PlanningToRetakeGcseMathsAndEnglishId { get; set; }
         public int? PlanningToRetakeCgseScienceId { get; set; }
 
         public string Email { get; set; }
@@ -63,12 +61,18 @@ namespace GetIntoTeachingApi.Models
 
             InitialTeacherTrainingYearId = candidate.InitialTeacherTrainingYearId;
             PreferredEducationPhaseId = candidate.PreferredEducationPhaseId;
-            HasGcseEnglishId = candidate.HasGcseEnglishId;
-            HasGcseMathsId = candidate.HasGcseMathsId;
             HasGcseScienceId = candidate.HasGcseScienceId;
             PlanningToRetakeCgseScienceId = candidate.PlanningToRetakeCgseScienceId;
-            PlanningToRetakeGcseEnglishId = candidate.PlanningToRetakeGcseEnglishId;
-            PlanningToRetakeGcseMathsId = candidate.PlanningToRetakeGcseMathsId;
+
+            if (candidate.HasGcseMathsAndEnglish())
+            {
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking;
+            }
+
+            if (candidate.IsPlanningToRetakeGcseMathsAndEnglish())
+            {
+                PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking;
+            }
 
             Email = candidate.Email;
             FirstName = candidate.FirstName;
@@ -122,11 +126,11 @@ namespace GetIntoTeachingApi.Models
                 TeacherId = TeacherId,
                 InitialTeacherTrainingYearId = InitialTeacherTrainingYearId,
                 PreferredEducationPhaseId = PreferredEducationPhaseId,
-                HasGcseEnglishId = HasGcseEnglishId,
-                HasGcseMathsId = HasGcseMathsId,
+                HasGcseEnglishId = HasGcseMathsAndEnglishId,
+                HasGcseMathsId = HasGcseMathsAndEnglishId,
                 HasGcseScienceId = HasGcseScienceId,
-                PlanningToRetakeGcseEnglishId = PlanningToRetakeGcseEnglishId,
-                PlanningToRetakeGcseMathsId = PlanningToRetakeGcseMathsId,
+                PlanningToRetakeGcseEnglishId = PlanningToRetakeGcseMathsAndEnglishId,
+                PlanningToRetakeGcseMathsId = PlanningToRetakeGcseMathsAndEnglishId,
                 PlanningToRetakeCgseScienceId = PlanningToRetakeCgseScienceId,
                 ChannelId = CandidateId == null ? (int?)Candidate.Channel.TeacherTrainingAdviser : null,
                 EligibilityRulesPassed = "false",

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -27,7 +27,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
             RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(PostcodeRegex);
-            RuleFor(candidate => candidate.CallbackInformation).MaximumLength(600);
             RuleFor(candidate => candidate.EligibilityRulesPassed)
                 .Must(value => _validEligibilityRulesPassedValues.Contains(value))
                 .Unless(candidate => candidate.EligibilityRulesPassed == null)

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -13,8 +13,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.AddressPostcode).NotEmpty();
             RuleFor(request => request.AcceptedPolicyId).NotEmpty();
             RuleFor(request => request.ConsiderationJourneyStageId).NotNull();
-            RuleFor(request => request.CallbackInformation).NotEmpty()
-                .When(request => request.Telephone != null);
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -111,34 +111,24 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be secondary when past teaching positions are present.");
 
             RuleFor(request => request)
-                .Must(request => HasOrIsPlanningOnRetakingEnglish(request) &&
-                HasOrIsPlanningOnRetakingMaths(request) && HasOrIsPlanningOnRetakingScience(request))
+                .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request) && HasOrIsPlanningOnRetakingScience(request))
                 .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
                 .WithMessage("Must have or be retaking all GCSEs when preferred education phase is primary.");
 
             RuleFor(request => request)
-                .Must(request => HasOrIsPlanningOnRetakingEnglish(request) && HasOrIsPlanningOnRetakingMaths(request))
+                .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request))
                 .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
                 .WithMessage("Must have or be retaking Maths and English GCSEs when preferred education phase is secondary.");
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }
 
-        private static bool HasOrIsPlanningOnRetakingEnglish(TeacherTrainingAdviserSignUp request)
+        private static bool HasOrIsPlanningOnRetakingEnglishAndMaths(TeacherTrainingAdviserSignUp request)
         {
             return new[]
             {
-                request.HasGcseEnglishId,
-                request.PlanningToRetakeGcseEnglishId,
-            }.Any(value => (int?)Candidate.GcseStatus.HasOrIsPlanningOnRetaking == value);
-        }
-
-        private static bool HasOrIsPlanningOnRetakingMaths(TeacherTrainingAdviserSignUp request)
-        {
-            return new[]
-            {
-                request.HasGcseMathsId,
-                request.PlanningToRetakeGcseMathsId,
+                request.HasGcseMathsAndEnglishId,
+                request.PlanningToRetakeGcseMathsAndEnglishId,
             }.Any(value => (int?)Candidate.GcseStatus.HasOrIsPlanningOnRetaking == value);
         }
 

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -78,7 +78,6 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("DoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotpostalmail");
             type.GetProperty("DoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotsendmm");
             type.GetProperty("OptOutOfSms").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_optoutsms");
-            type.GetProperty("CallbackInformation").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitecallbackdescription");
             type.GetProperty("EligibilityRulesPassed").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eligibilityrulespassed");
             type.GetProperty("PreferredPhoneNumberTypeId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_preferredphonenumbertype");
             type.GetProperty("PreferredContactMethodId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "preferredcontactmethodcode");

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -376,6 +376,30 @@ namespace GetIntoTeachingApiTests.Models
             candidate.FullName.Should().Be("John Doe");
         }
 
+        [Theory]
+        [InlineData((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, true)]
+        [InlineData(-1, (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, false)]
+        [InlineData((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, -1, false)]
+        [InlineData(-1, -1, false)]
+        public void HasGcseMathsAndEnglishId_ReturnsCorrectly(int hasGcseEnglishId, int hasGcseMathsId, bool expected)
+        {
+            var candidate = new Candidate() { HasGcseEnglishId = hasGcseEnglishId, HasGcseMathsId = hasGcseMathsId };
+
+            candidate.HasGcseMathsAndEnglish().Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, true)]
+        [InlineData(-1, (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, false)]
+        [InlineData((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking, -1, false)]
+        [InlineData(-1, -1, false)]
+        public void IsPlanningToRetakeGcseMathsAndEnglishId_ReturnsCorrectly(int planningToRetakeGcseEnglishId, int planningToRetakeGcseMathsId, bool expected)
+        {
+            var candidate = new Candidate() { PlanningToRetakeGcseEnglishId = planningToRetakeGcseEnglishId, PlanningToRetakeGcseMathsId = planningToRetakeGcseMathsId };
+
+            candidate.IsPlanningToRetakeGcseMathsAndEnglish().Should().Be(expected);
+        }
+
         [Fact]
         public void PreferredPhoneNumberType_DefaultValue_IsCorrect()
         {

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -38,7 +38,6 @@ namespace GetIntoTeachingApiTests.Models
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                CallbackInformation = "Callback info",
                 Qualifications = qualifications,
                 Subscriptions = subscriptions,
             };
@@ -53,7 +52,6 @@ namespace GetIntoTeachingApiTests.Models
             response.LastName.Should().Be(candidate.LastName);
             response.Telephone.Should().Be(candidate.Telephone);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
-            response.CallbackInformation.Should().Be(candidate.CallbackInformation);
 
             response.QualificationId.Should().Be(latestQualification.Id);
             response.DegreeStatusId.Should().Be(latestQualification.DegreeStatusId);
@@ -78,7 +76,6 @@ namespace GetIntoTeachingApiTests.Models
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                CallbackInformation = "Test information",
                 SubscribeToEvents = true,
             };
 
@@ -93,7 +90,6 @@ namespace GetIntoTeachingApiTests.Models
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.Telephone.Should().Be(request.Telephone);
-            candidate.CallbackInformation.Should().Be(request.CallbackInformation);
             candidate.ChannelId.Should().BeNull();
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -52,12 +52,12 @@ namespace GetIntoTeachingApiTests.Models
                 CountryId = Guid.NewGuid(),
                 InitialTeacherTrainingYearId = 1,
                 PreferredEducationPhaseId = 2,
-                HasGcseEnglishId = 3,
-                HasGcseMathsId = 4,
-                HasGcseScienceId = 5,
-                PlanningToRetakeGcseEnglishId = 6,
-                PlanningToRetakeGcseMathsId = 7,
-                PlanningToRetakeCgseScienceId = 8,
+                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                PlanningToRetakeGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                PlanningToRetakeCgseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -80,12 +80,10 @@ namespace GetIntoTeachingApiTests.Models
             response.CountryId.Should().Be(candidate.CountryId);
             response.InitialTeacherTrainingYearId.Should().Be(candidate.InitialTeacherTrainingYearId);
             response.PreferredEducationPhaseId.Should().Be(candidate.PreferredEducationPhaseId);
-            response.HasGcseEnglishId.Should().Be(candidate.HasGcseEnglishId);
-            response.HasGcseMathsId.Should().Be(candidate.HasGcseMathsId);
+            response.HasGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
             response.HasGcseScienceId.Should().Be(candidate.HasGcseScienceId);
             response.PlanningToRetakeCgseScienceId.Should().Be(candidate.PlanningToRetakeCgseScienceId);
-            response.PlanningToRetakeGcseEnglishId.Should().Be(candidate.PlanningToRetakeGcseEnglishId);
-            response.PlanningToRetakeGcseMathsId.Should().Be(candidate.PlanningToRetakeGcseMathsId);
+            response.PlanningToRetakeGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
@@ -125,11 +123,9 @@ namespace GetIntoTeachingApiTests.Models
                 DegreeTypeId = 2,
                 InitialTeacherTrainingYearId = 3,
                 PreferredEducationPhaseId = 4,
-                HasGcseEnglishId = 5,
-                HasGcseMathsId = 6,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = 7,
-                PlanningToRetakeGcseEnglishId = 7,
-                PlanningToRetakeGcseMathsId = 8,
+                PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeCgseScienceId = 9,
                 Email = "email@address.com",
                 FirstName = "John",
@@ -152,11 +148,11 @@ namespace GetIntoTeachingApiTests.Models
             candidate.CountryId.Should().Equals(request.CountryId);
             candidate.InitialTeacherTrainingYearId.Should().Equals(request.InitialTeacherTrainingYearId);
             candidate.PreferredEducationPhaseId.Should().Equals(request.PreferredEducationPhaseId);
-            candidate.HasGcseEnglishId.Should().Equals(request.HasGcseEnglishId);
-            candidate.HasGcseMathsId.Should().Equals(request.HasGcseMathsId);
+            candidate.HasGcseEnglishId.Should().Equals(request.HasGcseMathsAndEnglishId);
+            candidate.HasGcseMathsId.Should().Equals(request.HasGcseMathsAndEnglishId);
             candidate.HasGcseScienceId.Should().Equals(request.HasGcseScienceId);
-            candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseEnglishId);
-            candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsId);
+            candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
+            candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeCgseScienceId.Should().Equals(request.PlanningToRetakeCgseScienceId);
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -80,7 +80,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 AddressLine2 = "line2",
                 AddressCity = "city",
                 AddressPostcode = "KY119YU",
-                CallbackInformation = "some information",
                 HasGcseMathsId = int.Parse(mockPickListItem.Id),
                 HasGcseEnglishId = int.Parse(mockPickListItem.Id),
                 AdviserEligibilityId = int.Parse(mockPickListItem.Id),
@@ -395,18 +394,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressPostcode, postcode);
             }
-        }
-
-        [Fact]
-        public void Validate_CallbackInformationIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.CallbackInformation, null as string);
-        }
-
-        [Fact]
-        public void Validate_CallbackInformationIsTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.CallbackInformation, new string('a', 601));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -40,7 +40,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                CallbackInformation = "Test information",
             };
 
             var result = _validator.TestValidate(request);
@@ -98,20 +97,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_ConsiderationJourneyStageIdIsNull_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.ConsiderationJourneyStageId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_CallbackInformationIsNullWhenTelephoneIsNotNull_HasError()
-        {
-            var request = new MailingListAddMember
-            {
-                CallbackInformation = null,
-                Telephone = "123456",
-            };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor("CallbackInformation");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -37,12 +37,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 DegreeStatusId = 2,
                 InitialTeacherTrainingYearId = 3,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
-                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                HasGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = 7,
                 PlanningToRetakeCgseScienceId = 8,
-                PlanningToRetakeGcseEnglishId = 9,
-                PlanningToRetakeGcseMathsId = 10,
+                PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -599,8 +597,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
-                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                HasGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = -1,
             };
 
@@ -615,8 +612,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
-                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                HasGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeCgseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
             };
 
@@ -631,8 +627,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
-                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                HasGcseMathsId = -1,
+                HasGcseMathsAndEnglishId = -1,
             };
 
             var result = _validator.TestValidate(request);
@@ -646,8 +641,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
-                HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
             };
 
             var result = _validator.TestValidate(request);


### PR DESCRIPTION
- Remove CallbackInformation from Candidate

We are no longer asking for this data when a candidate subscribes to the mailing list.

Combine GCSE maths/english into single field for TeacherTrainingAdviserSignUp

In the front-end we collect GCSE maths and english as a single field; to make mapping back to the API easier we are combining these fields in the API.