### PR TITLE
Retrieve TeachingEvent by ReadableId instead of Id

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Jobs;
@@ -82,16 +81,16 @@ maximum of 50 using the `limit` query parameter.",
 
         [HttpGet]
         [CrmETag]
-        [Route("{id}")]
+        [Route("{readableId}")]
         [SwaggerOperation(
             Summary = "Retrieves an event.",
             OperationId = "GetTeachingEvent",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Get([FromRoute, SwaggerParameter("The `id` of the `TeachingEvent`.", Required = true)] Guid id)
+        public async Task<IActionResult> Get([FromRoute, SwaggerParameter("The `readableId` of the `TeachingEvent`.", Required = true)] string readableId)
         {
-            var teachingEvent = await _store.GetTeachingEventAsync(id);
+            var teachingEvent = await _store.GetTeachingEventAsync(readableId);
 
             if (teachingEvent == null)
             {

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -10,6 +10,8 @@ namespace GetIntoTeachingApi.Models
     {
         [EntityField("dfe_event_type", typeof(OptionSetValue))]
         public int TypeId { get; set; }
+        [EntityField("msevtmgt_readableeventid")]
+        public string ReadableId { get; set; }
         [EntityField("msevtmgt_name")]
         public string Name { get; set; }
         [EntityField("msevtmgt_description")]

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApi.Services
         IQueryable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
+        Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         bool IsValidPostcode(string postcode);
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -115,6 +115,11 @@ namespace GetIntoTeachingApi.Services
             return await _dbContext.TeachingEvents.FirstOrDefaultAsync(teachingEvent => teachingEvent.Id == id);
         }
 
+        public async Task<TeachingEvent> GetTeachingEventAsync(string readableId)
+        {
+            return await _dbContext.TeachingEvents.FirstOrDefaultAsync(teachingEvent => teachingEvent.ReadableId == readableId);
+        }
+
         public bool IsValidPostcode(string postcode)
         {
             if (string.IsNullOrEmpty(postcode))

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -129,10 +129,10 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public async void Get_ReturnsTeachingEvent()
         {
-            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
-            _mockStore.Setup(mock => mock.GetTeachingEventAsync((Guid)teachingEvent.Id)).ReturnsAsync(teachingEvent);
+            var teachingEvent = new TeachingEvent() { ReadableId = "123" };
+            _mockStore.Setup(mock => mock.GetTeachingEventAsync(teachingEvent.ReadableId)).ReturnsAsync(teachingEvent);
 
-            var response = await _controller.Get((Guid)teachingEvent.Id);
+            var response = await _controller.Get(teachingEvent.ReadableId);
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().Be(teachingEvent);
@@ -143,7 +143,7 @@ namespace GetIntoTeachingApiTests.Controllers
         {
             _mockStore.Setup(mock => mock.GetTeachingEventAsync(It.IsAny<Guid>())).ReturnsAsync(null as TeachingEvent);
 
-            var response = await _controller.Get(Guid.NewGuid());
+            var response = await _controller.Get("-1");
 
             response.Should().BeOfType<NotFoundResult>();
         }

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_event_type" && a.Type == typeof(OptionSetValue));
 
+            type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_readableeventid");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
             type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
             type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventstartdate");

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -409,12 +409,21 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async void GetTeachingEvent_ReturnsMatchingEvent()
+        public async void GetTeachingEvent_WithId_ReturnsMatchingEvent()
         {
-            await SeedMockTeachingEventsAsync();
-            var result = await _store.GetTeachingEventAsync(FindEventGuid);
+            var events = await SeedMockTeachingEventsAsync();
+            var result = await _store.GetTeachingEventAsync((Guid)events.First().Id);
 
-            result.Id.Should().Be(FindEventGuid);
+            result.Id.Should().Be(events.First().Id);
+        }
+
+        [Fact]
+        public async void GetTeachingEvent_WithReadableId_ReturnsMatchingEvent()
+        {
+            var events = await SeedMockTeachingEventsAsync();
+            var result = await _store.GetTeachingEventAsync(events.First().ReadableId);
+
+            result.ReadableId.Should().Be(events.First().ReadableId);
         }
 
         [Fact]
@@ -457,6 +466,7 @@ namespace GetIntoTeachingApiTests.Services
             var event1 = new TeachingEvent()
             {
                 Id = Guid.NewGuid(),
+                ReadableId = "1",
                 Name = "Event 1",
                 StartAt = DateTime.Now.AddDays(5),
                 Building = new TeachingEventBuilding()
@@ -469,6 +479,7 @@ namespace GetIntoTeachingApiTests.Services
             var event2 = new TeachingEvent()
             {
                 Id = FindEventGuid,
+                ReadableId = "2",
                 Name = "Event 2",
                 StartAt = DateTime.Now.AddDays(1),
                 TypeId = 123,
@@ -483,6 +494,7 @@ namespace GetIntoTeachingApiTests.Services
             var event3 = new TeachingEvent()
             {
                 Id = Guid.NewGuid(),
+                ReadableId = "3",
                 Name = "Event 3",
                 StartAt = DateTime.Now.AddDays(10),
                 Building = new TeachingEventBuilding()
@@ -496,6 +508,7 @@ namespace GetIntoTeachingApiTests.Services
             var event4 = new TeachingEvent()
             {
                 Id = Guid.NewGuid(),
+                ReadableId = "4",
                 Name = "Event 4",
                 StartAt = DateTime.Now.AddDays(3),
                 TypeId = 123,
@@ -510,6 +523,7 @@ namespace GetIntoTeachingApiTests.Services
             var event5 = new TeachingEvent()
             {
                 Id = Guid.NewGuid(),
+                ReadableId = "5",
                 Name = "Event 5",
                 StartAt = DateTime.Now.AddDays(15),
             };
@@ -517,6 +531,7 @@ namespace GetIntoTeachingApiTests.Services
             var event6 = new TeachingEvent()
             {
                 Id = Guid.NewGuid(),
+                ReadableId = "6",
                 Name = "Event 6",
                 StartAt = DateTime.Now.AddDays(60),
                 Building = new TeachingEventBuilding()


### PR DESCRIPTION
Currently we put the event id, which is a long Guid, into the URL in the front-end to be able to retrieve the specific event from the API when the page loads. We want more SEO friendly URLs, so we're changing the API to expose the readable id of the event (which is a CRM-created permalink) and then using this as the lookup in the `GetTeachingEvent` operation.

An example of the readable id: `439_-_Online_TTT_-_London-Summer_20203437949823`