### PR TITLE
Relax postcode validation

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
@@ -9,8 +10,7 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidateValidator : AbstractValidator<Candidate>
     {
-        private const string PostcodeRegex = @"^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]
-            {1,2})|(([AZa-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})$";
+        private const string PostcodeRegex = @"^([A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$";
         private readonly IStore _store;
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
-            RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(PostcodeRegex);
+            RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(new Regex(PostcodeRegex, RegexOptions.IgnoreCase));
             RuleFor(candidate => candidate.EligibilityRulesPassed)
                 .Must(value => _validEligibilityRulesPassedValues.Contains(value))
                 .Unless(candidate => candidate.EligibilityRulesPassed == null)

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -382,6 +382,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("KY11 9YU", false)]
         [InlineData("CA48LE", false)]
         [InlineData("CA4 8LE", false)]
+        [InlineData("ky119yu", false)]
         [InlineData("KY999 9YU", true)]
         [InlineData("AZ1VS1", true)]
         public void Validate_AddressPostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)


### PR DESCRIPTION
In case the validators in the API mismatch those used in the client, we want to ensure the API has a more relaxed approach to the validation (to avoid a submission that the client thinks is valid returning an error from the API).