### PR TITLE
Return AuthenticateResult.NoResult() if no Authorization header present

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -29,8 +29,7 @@ namespace GetIntoTeachingApi.Auth
         {
             if (!Request.Headers.ContainsKey("Authorization"))
             {
-                _logger.LogWarning("SharedSecretHandler - Authorization header not set");
-                return Task.FromResult(AuthenticateResult.Fail("Authorization header not set"));
+                return Task.FromResult(AuthenticateResult.NoResult());
             }
 
             var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", string.Empty);

--- a/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
@@ -53,15 +53,15 @@ namespace GetIntoTeachingApiTests.Auth
         }
 
         [Fact]
-        public async void InitializeAsync_NoAuthorizationHeader_LogsWarning()
+        public async void InitializeAsync_NoAuthorizationHeader_ReturnsNoResult()
         {
             var context = new DefaultHttpContext();
             var scheme = new AuthenticationScheme("SharedSecretHandler", null, typeof(SharedSecretHandler));
             await _handler.InitializeAsync(scheme, context);
 
-            await _handler.AuthenticateAsync();
+            var result = await _handler.AuthenticateAsync();
 
-            _mockLogger.VerifyWarningWasCalled("SharedSecretHandler - Authorization header not set");
+            result.Should().BeEquivalentTo(AuthenticateResult.NoResult());
         }
 
         [Fact]


### PR DESCRIPTION
The auth schema is called for all requests, regardless of if they require authentication. If a request does not contain an `Authorization` header we returned a failure result, which causes a log message to be written out (twice,
as we were logging it independently as well). This is not actually an issue for endpoints that do not require authentication - instead, we should be returning `AuthenticationResult.NoResult()`.