### PR TITLE
Latest schema changes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -185,6 +185,11 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
+        public bool HasActiveSubscriptionOfType(Subscription.ServiceType type)
+        {
+            return ActiveSubscriptions().Any(s => s.TypeId == (int)type);
+        }
+
         public bool IsReturningToTeaching()
         {
             return PastTeachingPositions.Count > 0;
@@ -233,6 +238,11 @@ namespace GetIntoTeachingApi.Models
                 default:
                     return true;
             }
+        }
+
+        private IEnumerable<Subscription> ActiveSubscriptions()
+        {
+            return Subscriptions.Where(s => s.StatusId == (int)Subscription.SubscriptionStatus.Active);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -70,6 +70,7 @@ namespace GetIntoTeachingApi.Models
         public enum GcseStatus
         {
             HasOrIsPlanningOnRetaking = 222750000,
+            NotAnswered = 222750001,
         }
 
         [JsonIgnore]

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApi.Models
         public enum DegreeType
         {
             Degree = 222750000,
-            DegreeEquivalent = 222750007,
+            DegreeEquivalent = 222750005,
         }
 
         [EntityField("dfe_type", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -84,6 +84,7 @@ namespace GetIntoTeachingApi.Models
                 DoNotBulkPostalMail = true,
                 DoNotPostalMail = true,
                 DoNotSendMm = false,
+                EligibilityRulesPassed = "false",
             };
 
             AddSubscriptions(candidate);
@@ -97,19 +98,29 @@ namespace GetIntoTeachingApi.Models
         {
             candidate.Qualifications.Add(new CandidateQualification()
             {
-                Id = QualificationId, 
-                DegreeStatusId = DegreeStatusId, 
+                Id = QualificationId,
+                DegreeStatusId = DegreeStatusId,
                 TypeId = (int)CandidateQualification.DegreeType.Degree,
             });
         }
 
         private void AddSubscriptions(Candidate candidate)
         {
-            candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
+            candidate.Subscriptions.Add(new Subscription()
+            {
+                TypeId = (int)Subscription.ServiceType.MailingList,
+                DoNotPostalMail = true,
+                DoNotBulkPostalMail = true,
+            });
 
             if (SubscribeToEvents)
             {
-                candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
+                candidate.Subscriptions.Add(new Subscription()
+                {
+                    TypeId = (int)Subscription.ServiceType.Event,
+                    DoNotBulkPostalMail = true,
+                    DoNotPostalMail = true,
+                });
             }
         }
 

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -95,7 +95,12 @@ namespace GetIntoTeachingApi.Models
 
         private void AddQualification(Candidate candidate)
         {
-            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, DegreeStatusId = DegreeStatusId });
+            candidate.Qualifications.Add(new CandidateQualification()
+            {
+                Id = QualificationId, 
+                DegreeStatusId = DegreeStatusId, 
+                TypeId = (int)CandidateQualification.DegreeType.Degree,
+            });
         }
 
         private void AddSubscriptions(Candidate candidate)

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -61,8 +61,8 @@ namespace GetIntoTeachingApi.Models
             AddressPostcode = candidate.AddressPostcode;
             Telephone = candidate.Telephone;
 
-            AlreadySubscribedToMailingList = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.MailingList);
-            AlreadySubscribedToEvents = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.Event);
+            AlreadySubscribedToMailingList = candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.MailingList);
+            AlreadySubscribedToEvents = candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.Event);
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -86,20 +86,34 @@ namespace GetIntoTeachingApi.Models
                 DoNotSendMm = false,
             };
 
-            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, DegreeStatusId = DegreeStatusId });
-            candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
+            AddSubscriptions(candidate);
+            AddQualification(candidate);
+            AcceptPrivacyPolicy(candidate);
 
-            if (AcceptedPolicyId != null)
-            {
-                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
-            }
+            return candidate;
+        }
+
+        private void AddQualification(Candidate candidate)
+        {
+            candidate.Qualifications.Add(new CandidateQualification() { Id = QualificationId, DegreeStatusId = DegreeStatusId });
+        }
+
+        private void AddSubscriptions(Candidate candidate)
+        {
+            candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
 
             if (SubscribeToEvents)
             {
                 candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
             }
+        }
 
-            return candidate;
+        private void AcceptPrivacyPolicy(Candidate candidate)
+        {
+            if (AcceptedPolicyId != null)
+            {
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Subscription.cs
+++ b/GetIntoTeachingApi/Models/Subscription.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Models
         public enum SubscriptionStatus
         {
             Active,
+            InActive,
         }
 
         public enum ServiceType

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -145,6 +145,28 @@ namespace GetIntoTeachingApi.Models
                 DoNotSendMm = false,
             };
 
+            if (HasGcseMathsAndEnglishId == null)
+            {
+                candidate.HasGcseMathsId = (int)Candidate.GcseStatus.NotAnswered;
+                candidate.HasGcseEnglishId = (int)Candidate.GcseStatus.NotAnswered;
+            }
+
+            if (HasGcseScienceId == null)
+            {
+                candidate.HasGcseScienceId = (int)Candidate.GcseStatus.NotAnswered;
+            }
+
+            if (PlanningToRetakeGcseMathsAndEnglishId == null)
+            {
+                candidate.PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.NotAnswered;
+                candidate.PlanningToRetakeGcseEnglishId = (int)Candidate.GcseStatus.NotAnswered;
+            }
+
+            if (PlanningToRetakeGcseScienceId == null)
+            {
+                candidate.PlanningToRetakeGcseScienceId = (int)Candidate.GcseStatus.NotAnswered;
+            }
+
             if (AcceptedPolicyId != null)
             {
                 candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
@@ -162,7 +184,7 @@ namespace GetIntoTeachingApi.Models
                 };
             }
 
-            if (UkDegreeGradeId != null || DegreeStatusId != null || DegreeSubject != null || DegreeTypeId != null)
+            if (ContainsQualification())
             {
                 candidate.Qualifications.Add(new CandidateQualification()
                 {
@@ -174,7 +196,7 @@ namespace GetIntoTeachingApi.Models
                 });
             }
 
-            if (SubjectTaughtId != null)
+            if (ContainsPastTeachingPosition())
             {
                 candidate.PastTeachingPositions.Add(new CandidatePastTeachingPosition()
                 {
@@ -223,6 +245,16 @@ namespace GetIntoTeachingApi.Models
             }
 
             return (int)PhoneCall.Destination.Uk;
+        }
+
+        private bool ContainsQualification()
+        {
+            return UkDegreeGradeId != null || DegreeStatusId != null || DegreeSubject != null || DegreeTypeId != null;
+        }
+
+        private bool ContainsPastTeachingPosition()
+        {
+            return SubjectTaughtId != null;
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -85,7 +85,7 @@ namespace GetIntoTeachingApi.Models
             AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
 
-            AlreadySubscribedToTeacherTrainingAdviser = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.TeacherTrainingAdviser);
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.TeacherTrainingAdviser);
 
             var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
 

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -49,8 +48,8 @@ namespace GetIntoTeachingApi.Models
             AddressPostcode = candidate.AddressPostcode;
             Telephone = candidate.Telephone;
 
-            AlreadySubscribedToMailingList = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.MailingList);
-            AlreadySubscribedToEvents = candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.Event);
+            AlreadySubscribedToMailingList = candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.MailingList);
+            AlreadySubscribedToEvents = candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.Event);
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -64,19 +64,24 @@ namespace GetIntoTeachingApi.Models
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
                 ChannelId = CandidateId == null ? (int?)Candidate.Channel.Event : null,
-                OptOutOfSms = false,
-                DoNotBulkEmail = true,
-                DoNotEmail = false,
-                DoNotBulkPostalMail = true,
-                DoNotPostalMail = true,
-                DoNotSendMm = true,
             };
 
             AddTeachingEventRegistration(candidate);
             AcceptPrivacyPolicy(candidate);
             AddSubscriptions(candidate);
+            ConfigureConsent(candidate);
 
             return candidate;
+        }
+
+        private void ConfigureConsent(Candidate candidate)
+        {
+            candidate.OptOutOfSms = false;
+            candidate.DoNotBulkEmail = !SubscribeToEvents && !SubscribeToMailingList;
+            candidate.DoNotBulkPostalMail = !SubscribeToMailingList;
+            candidate.DoNotEmail = false;
+            candidate.DoNotPostalMail = !SubscribeToMailingList;
+            candidate.DoNotSendMm = !SubscribeToEvents && !SubscribeToMailingList;
         }
 
         private void AddSubscriptions(Candidate candidate)

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -86,14 +86,23 @@ namespace GetIntoTeachingApi.Models
 
         private void AddSubscriptions(Candidate candidate)
         {
-            if (SubscribeToEvents)
+            candidate.Subscriptions.Add(new Subscription()
             {
-                candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
-            }
+                TypeId = (int)Subscription.ServiceType.Event,
+                DoNotBulkPostalMail = true,
+                DoNotPostalMail = true,
+                DoNotBulkEmail = !SubscribeToEvents,
+                DoNotSendMm = !SubscribeToEvents,
+            });
 
             if (SubscribeToMailingList)
             {
-                candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
+                candidate.Subscriptions.Add(new Subscription()
+                {
+                    TypeId = (int)Subscription.ServiceType.MailingList,
+                    DoNotBulkPostalMail = true,
+                    DoNotPostalMail = true,
+                });
             }
         }
 

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -72,20 +72,15 @@ namespace GetIntoTeachingApi.Models
                 DoNotSendMm = true,
             };
 
-            if (EventId != null)
-            {
-                candidate.TeachingEventRegistrations.Add(new TeachingEventRegistration()
-                {
-                    EventId = (Guid)EventId,
-                    ChannelId = (int)TeachingEventRegistration.Channel.Event,
-                });
-            }
+            AddTeachingEventRegistration(candidate);
+            AcceptPrivacyPolicy(candidate);
+            AddSubscriptions(candidate);
 
-            if (AcceptedPolicyId != null)
-            {
-                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
-            }
+            return candidate;
+        }
 
+        private void AddSubscriptions(Candidate candidate)
+        {
             if (SubscribeToEvents)
             {
                 candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.Event });
@@ -95,8 +90,26 @@ namespace GetIntoTeachingApi.Models
             {
                 candidate.Subscriptions.Add(new Subscription() { TypeId = (int)Subscription.ServiceType.MailingList });
             }
+        }
 
-            return candidate;
+        private void AddTeachingEventRegistration(Candidate candidate)
+        {
+            if (EventId != null)
+            {
+                candidate.TeachingEventRegistrations.Add(new TeachingEventRegistration()
+                {
+                    EventId = (Guid)EventId,
+                    ChannelId = (int)TeachingEventRegistration.Channel.Event,
+                });
+            }
+        }
+
+        private void AcceptPrivacyPolicy(Candidate candidate)
+        {
+            if (AcceptedPolicyId != null)
+            {
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.Email).NotEmpty();
             RuleFor(request => request.AcceptedPolicyId).NotEmpty();
             RuleFor(request => request.ConsiderationJourneyStageId).NotNull();
+            RuleFor(request => request.DegreeStatusId).NotNull();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -10,7 +10,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.LastName).NotEmpty();
             RuleFor(request => request.Email).NotEmpty();
-            RuleFor(request => request.AddressPostcode).NotEmpty();
             RuleFor(request => request.AcceptedPolicyId).NotEmpty();
             RuleFor(request => request.ConsiderationJourneyStageId).NotNull();
 

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -100,6 +100,26 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void HasActiveSubscriptionOfType_ReturnsTrueIfActiveSubscriptionOfTypeExists()
+        {
+            var activeSubscription = new Subscription()
+            {
+                TypeId = (int)Subscription.ServiceType.MailingList,
+                StatusId = (int)Subscription.SubscriptionStatus.Active,
+            };
+            var inActiveSubscription = new Subscription()
+            {
+                TypeId = (int)Subscription.ServiceType.Event,
+                StatusId = (int)Subscription.SubscriptionStatus.InActive
+            };
+            var subscriptions = new List<Subscription>() { activeSubscription, inActiveSubscription };
+            var candidate = new Candidate() { Subscriptions = subscriptions };
+
+            candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.MailingList).Should().BeTrue();
+            candidate.HasActiveSubscriptionOfType(Subscription.ServiceType.Event).Should().BeFalse();
+        }
+
+        [Fact]
         public void ToEntity_WhenRelationshipIsNull_DoesNotCreateEntity()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -104,10 +104,18 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.Subscriptions.First().DoNotBulkPostalMail.Should().BeTrue();
             candidate.Subscriptions.First().DoNotPostalMail.Should().BeTrue();
+            candidate.Subscriptions.First().DoNotEmail.Should().BeFalse();
+            candidate.Subscriptions.First().DoNotBulkEmail.Should().BeFalse();
+            candidate.Subscriptions.First().DoNotSendMm.Should().BeFalse(); 
+            candidate.Subscriptions.First().OptOutOfSms.Should().BeFalse(); 
 
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Subscriptions.Last().DoNotBulkPostalMail.Should().BeTrue();
             candidate.Subscriptions.Last().DoNotPostalMail.Should().BeTrue();
+            candidate.Subscriptions.Last().DoNotEmail.Should().BeFalse();
+            candidate.Subscriptions.Last().DoNotBulkEmail.Should().BeFalse();
+            candidate.Subscriptions.Last().DoNotSendMm.Should().BeFalse();
+            candidate.Subscriptions.Last().OptOutOfSms.Should().BeFalse();
 
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
             candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -97,10 +97,18 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotBulkPostalMail.Should().BeTrue();
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
+            candidate.EligibilityRulesPassed.Should().Be("false");
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
+            candidate.Subscriptions.First().DoNotBulkPostalMail.Should().BeTrue();
+            candidate.Subscriptions.First().DoNotPostalMail.Should().BeTrue();
+
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
+            candidate.Subscriptions.Last().DoNotBulkPostalMail.Should().BeTrue();
+            candidate.Subscriptions.Last().DoNotPostalMail.Should().BeTrue();
+
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
             candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);
             candidate.Qualifications.First().Id.Should().Be(request.QualificationId);

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -102,6 +102,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
+            candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);
             candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
         }
 

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -198,6 +198,32 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_GcseIdIsNull_DefaultsToNotAnswered()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                HasGcseMathsAndEnglishId = null,
+                HasGcseScienceId = null,
+                PlanningToRetakeGcseMathsAndEnglishId = null,
+                PlanningToRetakeGcseScienceId = null,
+            };
+
+            var candidate = request.Candidate;
+
+            var gcses = new int?[]
+            { 
+                candidate.HasGcseEnglishId, 
+                candidate.HasGcseMathsId, 
+                candidate.HasGcseScienceId, 
+                candidate.PlanningToRetakeGcseEnglishId, 
+                candidate.PlanningToRetakeGcseMathsId, 
+                candidate.PlanningToRetakeGcseScienceId
+            };
+
+            gcses.Should().AllBeEquivalentTo((int)Candidate.GcseStatus.NotAnswered);
+        }
+
+        [Fact]
         public void Candidate_ChannelIdWhenCandidateIdIsNull_IsTeacherTrainingAdviser()
         {
             var request = new TeacherTrainingAdviserSignUp() { CandidateId = null };

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -230,6 +230,25 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_NotReturningToTeaching_CorrectSubscriptionOptInStatus()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                SubjectTaughtId = null
+            };
+
+            var subscription = request.Candidate.Subscriptions.First();
+
+            subscription.TypeId.Should().Be((int)Subscription.ServiceType.TeacherTrainingAdviser);
+            subscription.DoNotBulkEmail.Should().BeFalse();
+            subscription.DoNotBulkPostalMail.Should().BeFalse();
+            subscription.DoNotPostalMail.Should().BeFalse();
+            subscription.DoNotSendMm.Should().BeFalse();
+            subscription.DoNotEmail.Should().BeFalse();
+            subscription.OptOutOfSms.Should().BeFalse();
+        }
+
+        [Fact]
         public void Candidate_ReturningToTeaching_CorrectSubscriptionOptInStatus()
         {
             var request = new TeacherTrainingAdviserSignUp()
@@ -239,10 +258,13 @@ namespace GetIntoTeachingApiTests.Models
 
             var subscription = request.Candidate.Subscriptions.First();
 
+            subscription.TypeId.Should().Be((int)Subscription.ServiceType.TeacherTrainingAdviser);
             subscription.DoNotBulkEmail.Should().BeTrue();
             subscription.DoNotBulkPostalMail.Should().BeTrue();
             subscription.DoNotPostalMail.Should().BeTrue();
             subscription.DoNotSendMm.Should().BeTrue();
+            subscription.DoNotEmail.Should().BeFalse();
+            subscription.OptOutOfSms.Should().BeFalse();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -171,11 +171,11 @@ namespace GetIntoTeachingApiTests.Models
             candidate.ChannelId.Should().BeNull();
             candidate.EligibilityRulesPassed.Should().Be("true");
             candidate.OptOutOfSms.Should().BeFalse();
-            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeTrue();
             candidate.DoNotEmail.Should().BeFalse();
-            candidate.DoNotBulkPostalMail.Should().BeFalse();
-            candidate.DoNotPostalMail.Should().BeFalse();
-            candidate.DoNotSendMm.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeTrue();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
 
@@ -195,6 +195,54 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Qualifications.First().TypeId.Should().Be(request.DegreeTypeId);
 
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.TeacherTrainingAdviser);
+        }
+
+        [Fact]
+        public void Candidate_ReturningToTeaching_CorrectConsent()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                SubjectTaughtId = Guid.NewGuid()
+            };
+
+            var candidate = request.Candidate;
+
+            candidate.DoNotBulkEmail.Should().BeTrue();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Candidate_InterestedInTeaching_CorrectConsent()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                SubjectTaughtId = null
+            };
+
+            var candidate = request.Candidate;
+
+            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotSendMm.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Candidate_ReturningToTeaching_CorrectSubscriptionOptInStatus()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                SubjectTaughtId = Guid.NewGuid()
+            };
+
+            var subscription = request.Candidate.Subscriptions.First();
+
+            subscription.DoNotBulkEmail.Should().BeTrue();
+            subscription.DoNotBulkPostalMail.Should().BeTrue();
+            subscription.DoNotPostalMail.Should().BeTrue();
+            subscription.DoNotSendMm.Should().BeTrue();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -79,6 +79,44 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_SubscribeToMailingListIsTrue_CorrectOptInStatus()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, SubscribeToEvents = false };
+
+            var subscription = request.Candidate.Subscriptions.Last();
+
+            subscription.TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
+            subscription.DoNotBulkPostalMail.Should().BeTrue();
+            subscription.DoNotPostalMail.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Candidate_SubscribeToEventsIsTrue_CorrectOptInStatus()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToEvents = true, SubscribeToMailingList = false };
+
+            var subscription = request.Candidate.Subscriptions.First();
+
+            subscription.TypeId.Should().Be((int)Subscription.ServiceType.Event);
+            subscription.DoNotBulkPostalMail.Should().BeTrue();
+            subscription.DoNotPostalMail.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Candidate_SubscribeToEventsIsFalse_CorrectOptInStatus()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToEvents = false, SubscribeToMailingList = false };
+
+            var subscription = request.Candidate.Subscriptions.First();
+
+            subscription.TypeId.Should().Be((int)Subscription.ServiceType.Event);
+            subscription.DoNotBulkPostalMail.Should().BeTrue();
+            subscription.DoNotPostalMail.Should().BeTrue();
+            subscription.DoNotBulkEmail.Should().BeTrue();
+            subscription.DoNotSendMm.Should().BeTrue();
+        }
+
+        [Fact]
         public void Candidate_SubscribeToMailingListIsFalse_ConsentIsCorrect()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, SubscribeToEvents = true };
@@ -117,15 +155,15 @@ namespace GetIntoTeachingApiTests.Models
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false };
 
-            request.Candidate.Subscriptions.Count.Should().Be(0);
+            request.Candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.MailingList).Should().BeFalse();
         }
 
         [Fact]
-        public void Candidate_SubscribeToEventsIsFalse_DoesNotCreateSubscription()
+        public void Candidate_SubscribeToEventsIsFalse_StillCreatesSubscription()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToEvents = false };
 
-            request.Candidate.Subscriptions.Count.Should().Be(0);
+            request.Candidate.Subscriptions.Any(s => s.TypeId == (int)Subscription.ServiceType.Event).Should().BeTrue();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -66,16 +66,34 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Telephone.Should().Be(request.Telephone);
             candidate.ChannelId.Should().BeNull();
             candidate.OptOutOfSms.Should().BeFalse();
-            candidate.DoNotBulkEmail.Should().BeTrue();
+            candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();
-            candidate.DoNotBulkPostalMail.Should().BeTrue();
-            candidate.DoNotPostalMail.Should().BeTrue();
-            candidate.DoNotSendMm.Should().BeTrue();
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotSendMm.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
+        }
+
+        [Fact]
+        public void Candidate_SubscribeToMailingListIsFalse_ConsentIsCorrect()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, SubscribeToEvents = true };
+
+            request.Candidate.DoNotBulkPostalMail.Should().BeTrue();
+            request.Candidate.DoNotPostalMail.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Candidate_SubscribeToMailingListAndEventsAreFalse_ConsentIsCorrect()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, SubscribeToEvents = false };
+
+            request.Candidate.DoNotBulkEmail.Should().BeTrue();
+            request.Candidate.DoNotSendMm.Should().BeTrue();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -88,6 +88,10 @@ namespace GetIntoTeachingApiTests.Models
             subscription.TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
             subscription.DoNotBulkPostalMail.Should().BeTrue();
             subscription.DoNotPostalMail.Should().BeTrue();
+            subscription.DoNotBulkEmail.Should().BeFalse();
+            subscription.DoNotSendMm.Should().BeFalse();
+            subscription.DoNotEmail.Should().BeFalse();
+            subscription.OptOutOfSms.Should().BeFalse();
         }
 
         [Fact]
@@ -100,6 +104,10 @@ namespace GetIntoTeachingApiTests.Models
             subscription.TypeId.Should().Be((int)Subscription.ServiceType.Event);
             subscription.DoNotBulkPostalMail.Should().BeTrue();
             subscription.DoNotPostalMail.Should().BeTrue();
+            subscription.DoNotBulkEmail.Should().BeFalse();
+            subscription.DoNotSendMm.Should().BeFalse();
+            subscription.DoNotEmail.Should().BeFalse();
+            subscription.OptOutOfSms.Should().BeFalse();
         }
 
         [Fact]
@@ -114,6 +122,8 @@ namespace GetIntoTeachingApiTests.Models
             subscription.DoNotPostalMail.Should().BeTrue();
             subscription.DoNotBulkEmail.Should().BeTrue();
             subscription.DoNotSendMm.Should().BeTrue();
+            subscription.DoNotEmail.Should().BeFalse();
+            subscription.OptOutOfSms.Should().BeFalse();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -98,5 +98,11 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             _validator.ShouldHaveValidationErrorFor(request => request.ConsiderationJourneyStageId, null as int?);
         }
+
+        [Fact]
+        public void Validate_DegreeStatusIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.DegreeStatusId, null as int?);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -82,9 +82,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_AddressPostcodeIsNull_HasError()
+        public void Validate_AddressPostcodeIsNull_HasNoError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
+            _validator.ShouldNotHaveValidationErrorFor(request => request.AddressPostcode, null as string);
         }
 
         [Fact]


### PR DESCRIPTION
- Update DegreeEquivalent id

This was changed in the latest schema updates in the CRM.

- Default GCSE values to NotAnswered

If a GCSE question was not asked (and therefore is `null` when passed from the client) we should default to the new `NotAnswered` option in the `OptionSet`.

- Make Postcode optional in MailingListAddMemberValidator

- Update TeacherTrainingAdviserSignUp subscriptions to match latest schema

The CRM schema has been changed so that we should be opting returning to teaching candidates out of bulk email/postal mail, postal mail and marketing material.

- Default DegreeTypeId to Degree for mailing list sign up

- Opt out of postal mail for mailing list sign up

- Update consent on event sign up

- Update subscription when registering for a teaching event

- Test subscription opt-ins individually

These are defaulted to false, but in case that changes its worth testing them explicitly in each scenario.