### PR TITLE
Google api postcode fallback

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using GeocodeSharp.Google;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using NetTopologySuite.Geometries;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public class GeocodeClientAdapter : IGeocodeClientAdapter
+    {
+        private readonly IMetricService _metrics;
+        private readonly GeocodeClient _client;
+
+        public GeocodeClientAdapter(IEnv env, IMetricService metrics)
+        {
+            _metrics = metrics;
+            _client = new GeocodeClient(env.GoogleApiKey);
+        }
+
+        public async Task<Point> GeocodePostcodeAsync(string postcode)
+        {
+            _metrics.GoogleApiCalls.Inc(1);
+
+            var response = await _client.GeocodeAddress(postcode);
+
+            if (response.Status != GeocodeStatus.Ok)
+            {
+                return null;
+            }
+
+            var result = response.Results.FirstOrDefault();
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            var location = result.Geometry.Location;
+            return new Point(new Coordinate(location.Longitude, location.Latitude));
+        }
+    }
+}

--- a/GetIntoTeachingApi/Adapters/IGeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IGeocodeClientAdapter.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using NetTopologySuite.Geometries;
+
+namespace GetIntoTeachingApi.Adapters
+{
+    public interface IGeocodeClientAdapter
+    {
+        Task<Point> GeocodePostcodeAsync(string postcode);
+    }
+}

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="CsvHelper" Version="15.0.5" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
+		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.11" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -7,6 +7,9 @@ namespace GetIntoTeachingApi.Models
 {
     public class Location
     {
+        public static readonly Regex PostcodeRegex = new Regex(
+            @"^([A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$", RegexOptions.IgnoreCase);
+
         [Key]
         public string Postcode { get; set; }
         [Column(TypeName = "geography")]

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
@@ -10,7 +9,6 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidateValidator : AbstractValidator<Candidate>
     {
-        private const string PostcodeRegex = @"^([A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$";
         private readonly IStore _store;
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
@@ -26,7 +24,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
-            RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(new Regex(PostcodeRegex, RegexOptions.IgnoreCase));
+            RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(Location.PostcodeRegex);
             RuleFor(candidate => candidate.EligibilityRulesPassed)
                 .Must(value => _validEligibilityRulesPassedValues.Contains(value))
                 .Unless(candidate => candidate.EligibilityRulesPassed == null)

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
@@ -14,9 +14,10 @@ namespace GetIntoTeachingApi.Models.Validators
             _store = store;
 
             RuleFor(request => request.Postcode)
-                .Must(store.IsValidPostcode)
-                .Unless(request => request.Postcode == null && request.Radius == null)
-                .WithMessage("Must be a valid postcode.");
+                .NotEmpty()
+                .MaximumLength(40)
+                .Matches(Location.PostcodeRegex)
+                .Unless(request => request.Postcode == null && request.Radius == null);
             RuleFor(request => request.TypeId)
                 .Must(id => TypeIds().Contains(id.ToString()))
                 .Unless(request => request.TypeId == null)

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -8,5 +8,6 @@ namespace GetIntoTeachingApi.Services
         Histogram LocationSyncDuration { get; }
         Histogram LocationBatchDuration { get; }
         Gauge HangfireJobs { get; }
+        Counter GoogleApiCalls { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -19,6 +19,5 @@ namespace GetIntoTeachingApi.Services
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
-        bool IsValidPostcode(string postcode);
     }
 }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -13,7 +13,7 @@ namespace GetIntoTeachingApi.Services
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
-            .CreateCounter("api_google_pai_calls", "Number of Google API calls.");
+            .CreateCounter("api_google_api_calls", "Number of Google API calls.");
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -12,10 +12,13 @@ namespace GetIntoTeachingApi.Services
             .CreateHistogram("api_location_batch_duration_seconds", "Histogram of location batch processing durations.");
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
+        private static readonly Counter _googleApiCalls = Metrics
+            .CreateCounter("api_google_pai_calls", "Number of Google API calls.");
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
         public Histogram LocationBatchDuration => _locationBatchDuration;
         public Gauge HangfireJobs => _hangfireJobs;
+        public Counter GoogleApiCalls => _googleApiCalls;
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -123,20 +123,16 @@ namespace GetIntoTeachingApi.Services
             return await _dbContext.TeachingEvents.FirstOrDefaultAsync(teachingEvent => teachingEvent.ReadableId == readableId);
         }
 
-        public bool IsValidPostcode(string postcode)
-        {
-            if (string.IsNullOrEmpty(postcode))
-            {
-                return false;
-            }
-
-            return _dbContext.Locations.Any(l => l.Postcode == Location.SanitizePostcode(postcode));
-        }
-
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {
             var origin = await CoordinateForPostcode(request.Postcode);
+
+            // If we can't locate them, return no results.
+            if (origin == null)
+            {
+                return new List<TeachingEvent>();
+            }
 
             // Exclude events we don't have a location for.
             teachingEvents = teachingEvents.Where(te => te.Building != null && te.Building.Coordinate != null);

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -48,6 +48,7 @@ namespace GetIntoTeachingApi
 
             services.AddSingleton<IMetricService, MetricService>();
             services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
+            services.AddSingleton<IGeocodeClientAdapter, GeocodeClientAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
             services.AddSingleton<INotifyService, NotifyService>();
             services.AddSingleton<IHangfireService, HangfireService>();

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -21,5 +21,6 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
+        public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
     }
 }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -19,5 +19,6 @@
         string CrmClientSecret { get; }
         string NotifyApiKey { get; }
         string SharedSecret { get; }
+        string GoogleApiKey { get; }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -30,8 +30,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 .Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_event_type"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
 
-            _mockStore.Setup(mock => mock.IsValidPostcode("KY11 9HF")).Returns(true);
-
             var request = new TeachingEventSearchRequest()
             {
                 Postcode = "KY11 9HF",
@@ -71,7 +69,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor(request => request.Postcode).WithErrorMessage("Must be a valid postcode.");
+            result.ShouldHaveValidationErrorFor(request => request.Postcode);
         }
 
         [Fact]
@@ -90,6 +88,26 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_PostcodeIsEmpty_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.Postcode, "");
+        }
+
+        [Theory]
+        [InlineData("KY119YU", false)]
+        [InlineData("KY11 9YU", false)]
+        [InlineData("CA48LE", false)]
+        [InlineData("CA4 8LE", false)]
+        [InlineData("ky119yu", false)]
+        [InlineData("KY999 9YU", true)]
+        [InlineData("AZ1VS1", true)]
+        public void Validate_PostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
+        {
+            if (hasError)
+            {
+                _validator.ShouldHaveValidationErrorFor(request => request.Postcode, postcode);
+            }
+            else
+            {
+                _validator.ShouldNotHaveValidationErrorFor(request => request.Postcode, postcode);
+            }
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Services;
+using Prometheus;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class MetricServiceTests
+    {
+        private readonly IMetricService _metrics;
+
+        public MetricServiceTests()
+        {
+            _metrics = new MetricService();
+        }
+
+        [Fact]
+        public void CrmSyncDuration_ReturnsMetric()
+        {
+            _metrics.CrmSyncDuration.Name.Should().Be("api_crm_sync_duration_seconds");
+        }
+
+        [Fact]
+        public void LocationSyncDuration_ReturnsMetric()
+        {
+            _metrics.LocationSyncDuration.Name.Should().Be("api_location_sync_duration_seconds");
+        }
+
+        [Fact]
+        public void LocationBatchDuration_ReturnsMetric()
+        {
+            _metrics.LocationBatchDuration.Name.Should().Be("api_location_batch_duration_seconds");
+        }
+
+        [Fact]
+        public void HangfireJobs_ReturnsMetric()
+        {
+            _metrics.HangfireJobs.Name.Should().Be("api_hangfire_jobs");
+        }
+
+        [Fact]
+        public void GoogleApiCalls_ReturnsMetric()
+        {
+            _metrics.GoogleApiCalls.Name.Should().Be("api_google_api_calls");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -139,7 +139,7 @@ namespace GetIntoTeachingApiTests.Services
                 .First(te => te.Building.AddressPostcode == postcode);
             teachingEvent.Building.Coordinate.Should().Be(coordinate);
         }
-
+        
         [Fact]
         public async void SyncAsync_InsertsNewPrivacyPolicies()
         {
@@ -393,6 +393,18 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SearchTeachingEvents_FilteredByRadiusWithFailedPostcodeGeocoding_ReturnsEmpty()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAsync();
+            var request = new TeachingEventSearchRequest() { Postcode = "TE7 1NG", Radius = 15 };
+
+            var result = await _store.SearchTeachingEventsAsync(request);
+
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
         public async void SearchTeachingEvents_FilteredByType_ReturnsMatching()
         {
             SeedMockLocations();
@@ -455,29 +467,6 @@ namespace GetIntoTeachingApiTests.Services
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4", "Event 1" },
                 options => options.WithStrictOrdering());
-        }
-
-        [Theory]
-        [InlineData("KY11 9YU")]
-        [InlineData("ky11 9yu")]
-        [InlineData("ky119yu")]
-        [InlineData("k y 119 YU")]
-        public void IsValidPostcode_WithValidPostcode_ReturnsTrue(string postcode)
-        {
-            SeedMockLocations();
-            _store.IsValidPostcode(postcode).Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [InlineData("KY11 9ZZ")]
-        [InlineData("KY11 9HFF")]
-        [InlineData("Non-Geographic")]
-        public void IsValidPostcode_WithInvalidPostcode_ReturnsFalse(string postcode)
-        {
-            SeedMockLocations();
-            _store.IsValidPostcode(postcode).Should().BeFalse();
         }
 
         private static IEnumerable<TeachingEvent> MockTeachingEvents()

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -206,5 +206,16 @@ namespace GetIntoTeachingApiTests.Utils
 
             Environment.SetEnvironmentVariable("SHARED_SECRET", previous);
         }
+
+        [Fact]
+        public void GoogleApiKey_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+            Environment.SetEnvironmentVariable("GOOGLE_API_KEY", "google-api-key");
+
+            _env.GoogleApiKey.Should().Be("google-api-key");
+
+            Environment.SetEnvironmentVariable("GOOGLE_API_KEY", previous);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ HANGFIRE_INSTANCE_NAME=****
 
 # Sentry
 SENTRY_URL=****
+
+# Google
+GOOGLE_API_KEY=****
 ```
 
 The Postgres connections (for Hangfire and our database) are setup dynamically from the `VCAP_SERVICES` environment variable provided by GOV.UK PaaS and not used in development (they are replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:
@@ -137,6 +140,10 @@ Prometheous and Grafana have been added to gather and display Metric information
 ### HTTP Caching
 
 The content that we cache in Postgres that originates from the CRM is served with HTTP ETag cache headers. There is a `CrmETag` annotation that can be added to an action to apply the appropriate cache headers to the response and check the request for the `If-None-Match` header. The ETag value changes when we sync new content from the CRM, meaning if the `If-None-Match` header matches the current `ETag` value we don't even need to fulfill the request, instead returning `304 Not Modified' immediately.
+
+### Postcode Geocoding
+
+We use postcodes to support searching for events around a given location. The application pulls a [free CSV data set](https://www.freemaptools.com/download-uk-postcode-lat-lng.htm) weekly and caches it in Postgres; this makes geocoding 99% of postcodes very fast. For the other 1% of postcodes (recent housing developments, for example) we fallback to Google APIs for geocoding.
 
 ## CRM Changes
 

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -25,6 +25,7 @@ resource "cloudfoundry_app" "api_application" {
          TOTP_SECRET_KEY   = var.TOTP_SECRET_KEY
          SHARED_SECRET     = var.SHARED_SECRET
          SENTRY_URL        = var.SENTRY_URL
+         GOOGLE_API_KEY    = var.GOOGLE_API_KEY
          ASPNETCORE_ENVIRONMENT = var.ASPNETCORE_ENVIRONMENT
          DATABASE_INSTANCE_NAME = cloudfoundry_service_instance.postgres2.name
          HANGFIRE_INSTANCE_NAME = cloudfoundry_service_instance.hangfire.name

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -62,4 +62,5 @@ variable "SHARED_SECRET" {}
 variable "NOTIFY_API_KEY" {}
 variable "TOTP_SECRET_KEY" {}
 variable "SENTRY_URL" {}
+variable "GOOGLE_API_KEY" {}
 


### PR DESCRIPTION
- Fallback to Google API for geocoding postcodes

We have a mostly-static database of postcode geolocations that we use when a candidate searches for events (and to geocode the postcode of the events themselves). This will contain almost all valid UK postcodes, however it is rarely updated (once every few months - we check for updates on a cron job weekly). In the event that a candidate uses a postcode we do not have locally, this commit updates the process to fallback to the Google APIs for geocoding the postcode (this will likely only happen for new housing developments, for example).

- Accept any valid postcode on event search

Previously we validated the postcode on event search by checking to ensure it's in our local database of locations (geocodable postcodes). As our local data set may not be completely up to date, and we now fallback to Google APIs, it's
possible that a valid postcode is passed but not in our database. To account for this, we validate the postcode format (instead of if it exists) and if we fail to geocode the postcode later on in the request cycle we return an empty data set.