### PR TITLE
Increase TOTP window to 15 minutes

### DIFF
--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApi.Services
     {
         // The amount of time a user has to verify their access token is:
         // (VerificationWindow * StepsInSeconds) + Remaining Seconds in Current Step
-        public static readonly int VerificationWindow = 2;
+        public static readonly int VerificationWindow = 30;
         public static readonly int StepInSeconds = 30;
         private const int Length = 6;
         private readonly IEnv _env;
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApi.Services
                 timestamp,
                 token,
                 out _,
-                new VerificationWindow(previous: VerificationWindow, future: VerificationWindow));
+                new VerificationWindow(previous: VerificationWindow, future: 0));
         }
 
         private Totp CreateTotp(ExistingCandidateRequest request)

--- a/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
@@ -76,7 +76,7 @@ namespace GetIntoTeachingApiTests.Services
         public void IsValid_WithExpiredToken_ReturnsFalse()
         {
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
-            var secondsToOutsideOfWindow = CandidateAccessTokenService.StepInSeconds * (2 * CandidateAccessTokenService.VerificationWindow);
+            var secondsToOutsideOfWindow = (CandidateAccessTokenService.StepInSeconds * CandidateAccessTokenService.VerificationWindow) + 1;
             var dateTimeOutsideOfWindow = DateTime.UtcNow.AddSeconds(-secondsToOutsideOfWindow);
             var token = _service.GenerateToken(request);
             _service.IsValid(token, request, dateTimeOutsideOfWindow).Should().BeFalse();


### PR DESCRIPTION
Currently the TOTP window is 30 seconds (+ the time remaining in the current 'step', which is a maximum of 30 seconds). It has been decided that this is too short and a window of 15 minutes is more suitable. This commit increases the window to 15 minutes (30 * 30 second 'steps').

The future window has been reduced from 1 to 0 as the server is both generating and consuming the TOTPs it should never be the case that a code is valid in a following step.