### PR TITLE
Add additional properties to TeachingEventRegistration

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -113,6 +113,8 @@ namespace GetIntoTeachingApi.Models
                 {
                     EventId = (Guid)EventId,
                     ChannelId = (int)TeachingEventRegistration.Channel.Event,
+                    IsCancelled = false,
+                    RegistrationNotificationSeen = false,
                 });
             }
         }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -19,6 +19,10 @@ namespace GetIntoTeachingApi.Models
         public Guid EventId { get; set; }
         [EntityField("dfe_channelcreation", typeof(OptionSetValue))]
         public int? ChannelId { get; set; }
+        [EntityField("msevtmgt_iscanceled")]
+        public bool? IsCancelled { get; set; }
+        [EntityField("msevtmgt_registrationnotificationseen")]
+        public bool? RegistrationNotificationSeen { get; set; }
 
         public TeachingEventRegistration()
             : base()

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -73,9 +73,14 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotSendMm.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            
             candidate.Subscriptions.First().TypeId.Should().Be((int)Subscription.ServiceType.Event);
             candidate.Subscriptions.Last().TypeId.Should().Be((int)Subscription.ServiceType.MailingList);
+
             candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
+            candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.Event);
+            candidate.TeachingEventRegistrations.First().IsCancelled.Should().BeFalse();
+            candidate.TeachingEventRegistrations.First().RegistrationNotificationSeen.Should().BeFalse();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -19,6 +19,14 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "msevtmgt_contactid" && a.Type == typeof(EntityReference));
             type.GetProperty("EventId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msevtmgt_eventid" && a.Type == typeof(EntityReference));
+
+            type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));
+
+            type.GetProperty("IsCancelled").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "msevtmgt_iscanceled");
+            type.GetProperty("RegistrationNotificationSeen").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "msevtmgt_registrationnotificationseen");
         }
     }
 }


### PR DESCRIPTION
According to the latest schema we should be passing `msevtmgt_iscanceled` and `msevtmgt_registrationnotificationseen` as `false` to new teaching event registrations. There is also two new fields `msevtmgt_publishingstate` and `msevtmgt_syncedwithprovider`, however after consulting with the CRM team we should be fine to leave these as the defaults (which are `No` and `Pending`).