### PR TITLE
Latest CRM event schema changes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,6 +31,7 @@ jobs:
             /n:"get-into-teaching-api" \
             /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cpd.exclusions="GetIntoTeachingApi/Migrations/*.cs" \
             /d:sonar.cs.opencover.reportsPaths="GetIntoTeachingApiTests/coverage.opencover.xml" \
             /d:sonar.cs.vstest.reportsPaths="**/*.trx" \
             /d:sonar.coverage.exclusions="\

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -245,6 +245,19 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
+        [Route("teaching_event/status")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of teaching event status.",
+            OperationId = "GetTeachingEventStatus",
+            Tags = new[] { "Types" })]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public async Task<IActionResult> GetTeachingEventStatus()
+        {
+            return Ok(await _store.GetPickListItems("msevtmgt_event", "dfe_eventstatus").ToListAsync());
+        }
+
+        [HttpGet]
+        [CrmETag]
         [Route("teaching_event_registration/channels")]
         [SwaggerOperation(
             Summary = "Retrieves the list of teaching event registration channels.",

--- a/GetIntoTeachingApi/Migrations/20200810073833_UpdateEventSchema.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20200810073833_UpdateEventSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200810073833_UpdateEventSchema")]
+    partial class UpdateEventSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20200810073833_UpdateEventSchema.cs
+++ b/GetIntoTeachingApi/Migrations/20200810073833_UpdateEventSchema.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class UpdateEventSchema : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddressState",
+                table: "TeachingEventBuildings");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalName",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsOnline",
+                table: "TeachingEvents",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Message",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderContactEmail",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderOrganiser",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderTargetAudience",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderWebsiteUrl",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatusId",
+                table: "TeachingEvents",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Summary",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VideoUrl",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Venue",
+                table: "TeachingEventBuildings",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExternalName",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "IsOnline",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "Message",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderContactEmail",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderOrganiser",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderTargetAudience",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderWebsiteUrl",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "StatusId",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "Summary",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "VideoUrl",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "Venue",
+                table: "TeachingEventBuildings");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AddressState",
+                table: "TeachingEventBuildings",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -2,6 +2,7 @@
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -10,12 +11,34 @@ namespace GetIntoTeachingApi.Models
     {
         [EntityField("dfe_event_type", typeof(OptionSetValue))]
         public int TypeId { get; set; }
+        [EntityField("dfe_eventstatus", typeof(OptionSetValue))]
+        public int StatusId { get; set; }
         [EntityField("msevtmgt_readableeventid")]
         public string ReadableId { get; set; }
+        [EntityField("dfe_isonlineevent")]
+        public bool IsOnline { get; set; }
         [EntityField("msevtmgt_name")]
         public string Name { get; set; }
+        [EntityField("dfe_externaleventtitle")]
+        public string ExternalName { get; set; }
+        [EntityField("dfe_eventsummary_ml")]
+        public string Summary { get; set; }
+        [EntityField("dfe_miscellaneousmessage_ml")]
+        [SwaggerSchema("Used to push miscellaneous messages to users " +
+            "(if an event is close to being booked out, for example).")]
+        public string Message { get; set; }
         [EntityField("msevtmgt_description")]
         public string Description { get; set; }
+        [EntityField("dfe_videolink")]
+        public string VideoUrl { get; set; }
+        [EntityField("dfe_providerwebsite")]
+        public string ProviderWebsiteUrl { get; set; }
+        [EntityField("dfe_providertargetaudience_ml")]
+        public string ProviderTargetAudience { get; set; }
+        [EntityField("dfe_providerorganiser")]
+        public string ProviderOrganiser { get; set; }
+        [EntityField("dfe_providercontactemailaddress")]
+        public string ProviderContactEmail { get; set; }
         [EntityField("msevtmgt_eventstartdate")]
         public DateTime StartAt { get; set; }
         [EntityField("msevtmgt_eventenddate")]

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -9,6 +9,13 @@ namespace GetIntoTeachingApi.Models
     [Entity("msevtmgt_event")]
     public class TeachingEvent : BaseModel
     {
+        public enum Status
+        {
+            Open = 222750000,
+            Closed = 222750001,
+            Draft = 222750002,
+        }
+
         [EntityField("dfe_event_type", typeof(OptionSetValue))]
         public int TypeId { get; set; }
         [EntityField("dfe_eventstatus", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -10,6 +10,8 @@ namespace GetIntoTeachingApi.Models
     [Entity("msevtmgt_building")]
     public class TeachingEventBuilding : BaseModel
     {
+        [EntityField("msevtmgt_name")]
+        public string Venue { get; set; }
         [EntityField("msevtmgt_addressline1")]
         public string AddressLine1 { get; set; }
         [EntityField("msevtmgt_addressline2")]
@@ -18,8 +20,6 @@ namespace GetIntoTeachingApi.Models
         public string AddressLine3 { get; set; }
         [EntityField("msevtmgt_city")]
         public string AddressCity { get; set; }
-        [EntityField("msevtmgt_stateprovince")]
-        public string AddressState { get; set; }
         [EntityField("msevtmgt_postalcode")]
         public string AddressPostcode { get; set; }
         [JsonIgnore]

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -160,6 +160,13 @@ namespace GetIntoTeachingApi.Services
             var query = new QueryExpression("msevtmgt_event");
             query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEvent)));
 
+            var status = new[] { (int)TeachingEvent.Status.Open, (int)TeachingEvent.Status.Closed };
+            var statusCondition = new ConditionExpression("dfe_eventstatus", ConditionOperator.In, status);
+            var futureDatedCondition = new ConditionExpression("msevtmgt_eventenddate", ConditionOperator.GreaterThan, DateTime.UtcNow);
+            var filter = new FilterExpression(LogicalOperator.And);
+            filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition });
+            query.Criteria.AddFilter(filter);
+
             var link = query.AddLink("msevtmgt_building", "msevtmgt_building", "msevtmgt_buildingid", JoinOperator.LeftOuter);
             link.Columns.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEventBuilding)));
             link.EntityAlias = "msevtmgt_event_building";

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -194,6 +194,7 @@ namespace GetIntoTeachingApi.Services
             await SyncTypes(crm.GetPickListItems("dfe_candidatequalification", "dfe_type"));
             await SyncTypes(crm.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"));
             await SyncTypes(crm.GetPickListItems("msevtmgt_event", "dfe_event_type"));
+            await SyncTypes(crm.GetPickListItems("msevtmgt_event", "dfe_eventstatus"));
             await SyncTypes(crm.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation"));
             await SyncTypes(crm.GetPickListItems("phonecall", "dfe_channelcreation"));
             await SyncTypes(crm.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"));

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -248,6 +248,18 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public async void GetTeachingEventStatus_ReturnsAllStatus()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_eventstatus")).Returns(mockEntities.AsAsyncQueryable());
+
+            var response = await _controller.GetTeachingEventStatus();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
+        [Fact]
         public async void GetTeachingEventRegistrationChannels_ReturnsAllChannels()
         {
             var mockEntities = MockTypeEntities();

--- a/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
@@ -14,11 +14,11 @@ namespace GetIntoTeachingApiTests.Models
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_building");
 
+            type.GetProperty("Venue").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
             type.GetProperty("AddressLine1").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_addressline1");
             type.GetProperty("AddressLine2").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_addressline2");
             type.GetProperty("AddressLine3").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_addressline3");
             type.GetProperty("AddressCity").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_city");
-            type.GetProperty("AddressState").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_stateprovince");
             type.GetProperty("AddressPostcode").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_postalcode");
         }
     }

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -14,13 +14,24 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(TeachingEvent);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_event");
-
+            
             type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_event_type" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_eventstatus" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_readableeventid");
+            type.GetProperty("IsOnline").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_isonlineevent");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
+            type.GetProperty("ExternalName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");
             type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
+            type.GetProperty("Summary").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventsummary_ml");
+            type.GetProperty("VideoUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_videolink");
+            type.GetProperty("ProviderWebsiteUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerwebsite");
+            type.GetProperty("ProviderTargetAudience").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providertargetaudience_ml");
+            type.GetProperty("ProviderOrganiser").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerorganiser");
+            type.GetProperty("ProviderContactEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providercontactemailaddress");
+            type.GetProperty("Message").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_miscellaneousmessage_ml");
             type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventstartdate");
             type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventenddate");
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -291,6 +291,7 @@ namespace GetIntoTeachingApiTests.Services
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatequalification", "dfe_type"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase"));
             mockCrm.Verify(m => m.GetPickListItems("msevtmgt_event", "dfe_event_type"));
+            mockCrm.Verify(m => m.GetPickListItems("msevtmgt_event", "dfe_eventstatus"));
             mockCrm.Verify(m => m.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation"));
             mockCrm.Verify(m => m.GetPickListItems("phonecall", "dfe_channelcreation"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype"));


### PR DESCRIPTION
- Update TeachingEvent/Building to match latest schema

- Exclude draft/past events from sync operation

We do not want to display events on the website if they are not in an open/closed status (so draft or other). Events that are in the past should also be excluded from displaying; we are checking the event end date to ensure it is in the future, but the criteria around this may change (it may transpire that we want to display events until the day after they end).

- Exclude migrations from Sonarcloud duplication check

---

The low test coverage is down to this PR mainly adding accessor methods, for which there is little point in testing -- they will be exercised by the integration tests when we get those in place.