### PR TITLE
Track cache hit/miss as a metric

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApi.Adapters
 
         public async Task<Point> GeocodePostcodeAsync(string postcode)
         {
-            _metrics.GoogleApiCalls.Inc(1);
+            _metrics.GoogleApiCalls.Inc();
 
             var response = await _client.GeocodeAddress(postcode);
 

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -9,5 +9,6 @@ namespace GetIntoTeachingApi.Services
         Histogram LocationBatchDuration { get; }
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }
+        Counter CacheLookups { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -14,11 +14,17 @@ namespace GetIntoTeachingApi.Services
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
             .CreateCounter("api_google_api_calls", "Number of Google API calls.");
+        private static readonly Counter _cacheLookups = Metrics
+            .CreateCounter("api_cache_lookups", "Number of cache lookups.", new CounterConfiguration
+            {
+                LabelNames = new[] { "outcome" },
+            });
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
         public Histogram LocationBatchDuration => _locationBatchDuration;
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;
+        public Counter CacheLookups => _cacheLookups;
     }
 }

--- a/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using FluentAssertions;
 using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Services;
 using Hangfire;
 using Hangfire.Storage;
 using Microsoft.AspNetCore.Http;
@@ -59,7 +60,7 @@ namespace GetIntoTeachingApiTests.Filters
             var mockStorage = new Mock<JobStorage>();
             mockStorage.Setup(m => m.GetConnection()).Returns(_mockStorageConnection.Object);
 
-            _filter = new CrmETagAttribute(mockStorage.Object);
+            _filter = new CrmETagAttribute(mockStorage.Object, new MetricService());
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -387,8 +387,10 @@ namespace GetIntoTeachingApiTests.Services
 
         private static IQueryable<Entity> MockCandidates()
         {
-            var candidate1 = new Entity("contact");
-            candidate1.Id = JaneDoeGuid;
+            var candidate1 = new Entity("contact")
+            {
+                Id = JaneDoeGuid
+            };
             candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
             candidate1["statecode"] = Candidate.Status.Active;
             candidate1["emailaddress1"] = "jane@doe.com";

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -43,5 +43,12 @@ namespace GetIntoTeachingApiTests.Services
         {
             _metrics.GoogleApiCalls.Name.Should().Be("api_google_api_calls");
         }
+
+        [Fact]
+        public void CacheLookups_ReturnsMetric()
+        {
+            _metrics.CacheLookups.Name.Should().Be("api_cache_lookups");
+            _metrics.CacheLookups.LabelNames.Should().BeEquivalentTo(new[] { "outcome" });
+        }
     }
 }


### PR DESCRIPTION
We could probably work this out from the existing metrics that track all HTTP requests (inferring a cache hit as a `304` response) but the endpoints we cache are not completely obvious (i.e. not all `GET` requests), so this will make it easier.