### PR TITLE
Add PEN_TEST_SHARED_SECRET

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.Linq;
+using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Utils;
@@ -34,7 +35,9 @@ namespace GetIntoTeachingApi.Auth
 
             var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", string.Empty);
 
-            if (token != _env.SharedSecret)
+            var secrets = new[] { _env.SharedSecret, _env.PenTestSharedSecret };
+
+            if (!secrets.Contains(token))
             {
                 _logger.LogWarning("SharedSecretHandler - Token is not valid");
                 return Task.FromResult(AuthenticateResult.Fail("Token is not valid"));

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -21,6 +21,7 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
+        public string PenTestSharedSecret => Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
     }
 }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -19,6 +19,7 @@
         string CrmClientSecret { get; }
         string NotifyApiKey { get; }
         string SharedSecret { get; }
+        string PenTestSharedSecret { get; }
         string GoogleApiKey { get; }
     }
 }

--- a/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
@@ -21,6 +21,7 @@ namespace GetIntoTeachingApiTests.Auth
         {
             var mockEnv = new Mock<IEnv>();
             mockEnv.Setup(m => m.SharedSecret).Returns("shared_secret");
+            mockEnv.Setup(m => m.PenTestSharedSecret).Returns("pen_test_shared_secret");
 
             var mockOptionsMonitor = new Mock<IOptionsMonitor<SharedSecretSchemeOptions>>();
             mockOptionsMonitor.Setup(m => m.Get("SharedSecretHandler")).Returns(new SharedSecretSchemeOptions());
@@ -36,6 +37,8 @@ namespace GetIntoTeachingApiTests.Auth
         [Theory]
         [InlineData("Bearer shared_secret", true)]
         [InlineData("shared_secret", true)]
+        [InlineData("Bearer pen_test_shared_secret", true)]
+        [InlineData("pen_test_shared_secret", true)]
         [InlineData("Bearer incorrect_shared_secret", false)]
         [InlineData("Bearer ", false)]
         [InlineData("", false)]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -208,6 +208,17 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
+        public void PenTestSharedSecret_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
+            Environment.SetEnvironmentVariable("PEN_TEST_SHARED_SECRET", "pen-test-shared-secret");
+
+            _env.PenTestSharedSecret.Should().Be("pen-test-shared-secret");
+
+            Environment.SetEnvironmentVariable("PEN_TEST_SHARED_SECRET", previous);
+        }
+
+        [Fact]
         public void GoogleApiKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -22,15 +22,16 @@ resource "cloudfoundry_app" "api_application" {
         route = cloudfoundry_route.api_route.id
     }    
     environment = {
-         CRM_CLIENT_ID     = var.CRM_CLIENT_ID
-         CRM_CLIENT_SECRET = var.CRM_CLIENT_SECRET
-         CRM_SERVICE_URL   = var.CRM_SERVICE_URL
-         CRM_TENANT_ID     = var.CRM_TENANT_ID
-         NOTIFY_API_KEY    = var.NOTIFY_API_KEY
-         TOTP_SECRET_KEY   = var.TOTP_SECRET_KEY
-         SHARED_SECRET     = var.SHARED_SECRET
-         SENTRY_URL        = var.SENTRY_URL
-         GOOGLE_API_KEY    = var.GOOGLE_API_KEY
+         CRM_CLIENT_ID          = var.CRM_CLIENT_ID
+         CRM_CLIENT_SECRET      = var.CRM_CLIENT_SECRET
+         CRM_SERVICE_URL        = var.CRM_SERVICE_URL
+         CRM_TENANT_ID          = var.CRM_TENANT_ID
+         NOTIFY_API_KEY         = var.NOTIFY_API_KEY
+         TOTP_SECRET_KEY        = var.TOTP_SECRET_KEY
+         SHARED_SECRET          = var.SHARED_SECRET
+         PEN_TEST_SHARED_SECRET = var.PEN_TEST_SHARED_SECRET
+         SENTRY_URL             = var.SENTRY_URL
+         GOOGLE_API_KEY         = var.GOOGLE_API_KEY
          ASPNETCORE_ENVIRONMENT = var.ASPNETCORE_ENVIRONMENT
          DATABASE_INSTANCE_NAME = cloudfoundry_service_instance.postgres2.name
          HANGFIRE_INSTANCE_NAME = cloudfoundry_service_instance.hangfire.name

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -71,6 +71,7 @@ variable "CRM_CLIENT_ID" {}
 variable "CRM_TENANT_ID" {} 
 variable "CRM_CLIENT_SECRET" {}
 variable "SHARED_SECRET" {}
+variable "PEN_TEST_SHARED_SECRET" {}
 variable "NOTIFY_API_KEY" {}
 variable "TOTP_SECRET_KEY" {}
 variable "SENTRY_URL" {}


### PR DESCRIPTION
In order to allow the penetration test team to connect to the API without exposing our `SHARED_SECRET` we are adding another valid secret that they can use.

This PR should be reverted once the penetration test is complete.