### PR TITLE
Disable ETag cache in development

### DIFF
--- a/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -14,22 +15,26 @@ namespace GetIntoTeachingApi.Filters
     {
         private readonly JobStorage _hangfireJobStorage;
         private readonly IMetricService _metrics;
+        private readonly IEnv _env;
 
         public CrmETagAttribute()
         {
             _metrics = new MetricService();
             _hangfireJobStorage = JobStorage.Current;
+            _env = new Env();
         }
 
-        public CrmETagAttribute(JobStorage hangfireJobStorage, IMetricService metrics)
+        public CrmETagAttribute(JobStorage hangfireJobStorage, IMetricService metrics, IEnv env)
         {
             _hangfireJobStorage = hangfireJobStorage;
             _metrics = metrics;
+            _env = env;
         }
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            var canCacheRequest = context.HttpContext.Request.Method == "GET";
+            var isGetRequest = context.HttpContext.Request.Method == "GET";
+            var canCacheRequest = isGetRequest && !_env.IsDevelopment;
 
             if (!canCacheRequest)
             {

--- a/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
@@ -34,7 +34,7 @@ namespace GetIntoTeachingApi.Filters
         public void OnActionExecuting(ActionExecutingContext context)
         {
             var isGetRequest = context.HttpContext.Request.Method == "GET";
-            var canCacheRequest = isGetRequest && !_env.IsDevelopment;
+            var canCacheRequest = isGetRequest && !_env.IsDevelopment && !_env.IsTest;
 
             if (!canCacheRequest)
             {

--- a/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
@@ -53,7 +53,7 @@ namespace GetIntoTeachingApiTests.Filters
             );
 
             _mockEnv = new Mock<IEnv>();
-            _mockEnv.Setup(m => m.IsDevelopment).Returns(false);
+            _mockEnv.Setup(m => m.IsTest).Returns(false);
 
             _mockHttpContext = new Mock<HttpContext>();
             _originalResult = new StatusCodeResult((int)HttpStatusCode.OK);
@@ -69,12 +69,14 @@ namespace GetIntoTeachingApiTests.Filters
         }
 
         [Theory]
-        [InlineData("POST", false)]
-        [InlineData("PUT", false)]
-        [InlineData("GET", true)]
-        public void OnActionExecuting_IgnoresIfNotGetOrIsDevelopmentEnv(string method, bool isDevelopment)
+        [InlineData("POST", false, false)]
+        [InlineData("PUT", false, false)]
+        [InlineData("GET", true, false)]
+        [InlineData("GET", false, true)]
+        public void OnActionExecuting_IgnoresIfNotGetOrIsDevelopmentOrTestEnv(string method, bool isDevelopment, bool isTest)
         {
             _mockEnv.Setup(m => m.IsDevelopment).Returns(isDevelopment);
+            _mockEnv.Setup(m => m.IsTest).Returns(isTest);
             _mockHttpContext.Setup(m => m.Request.Method).Returns(method);
 
             _filter.OnActionExecuting(_actionExecutingContext);


### PR DESCRIPTION
Having the ETag caching enabled in development can make it harder to debug issues; particularly around the store sync process - if the sync fails and you hit the endpoint expecting to get types and it then returns an empty response, that will potentially remain cached even if you fix the bug.