### PR TITLE
Remove teaching_events/upcoming endpoint

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -7,7 +7,6 @@ using GetIntoTeachingApi.Services;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -17,7 +16,6 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class TeachingEventsController : ControllerBase
     {
-        private const int MaximumUpcomingRequests = 50;
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly ICrmService _crm;
         private readonly IStore _store;
@@ -33,29 +31,6 @@ namespace GetIntoTeachingApi.Controllers
             _jobClient = jobClient;
             _crm = crm;
             _tokenService = tokenService;
-        }
-
-        [HttpGet]
-        [CrmETag]
-        [Route("upcoming")]
-        [SwaggerOperation(
-            Summary = "Retrieves the upcoming teaching events.",
-            Description = @"
-Retrieves the upcoming teaching events; limited to 10 by default, but this can be increased to a 
-maximum of 50 using the `limit` query parameter.",
-            OperationId = "GetUpcomingTeachingEvents",
-            Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(IEnumerable<TeachingEvent>), 200)]
-        [ProducesResponseType(400)]
-        public async Task<IActionResult> GetUpcoming([FromQuery, SwaggerParameter("Number of results to return (maximum of 50).")] int limit = 10)
-        {
-            if (limit > MaximumUpcomingRequests)
-            {
-                return BadRequest();
-            }
-
-            var upcomingEvents = _store.GetUpcomingTeachingEvents(limit);
-            return Ok(await upcomingEvents.ToListAsync());
         }
 
         [HttpGet]

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -15,7 +15,6 @@ namespace GetIntoTeachingApi.Services
         Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();
         IQueryable<PrivacyPolicy> GetPrivacyPolicies();
         Task<PrivacyPolicy> GetPrivacyPolicyAsync(Guid id);
-        IQueryable<TeachingEvent> GetUpcomingTeachingEvents(int limit);
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -76,14 +76,6 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.PrivacyPolicies;
         }
 
-        public IQueryable<TeachingEvent> GetUpcomingTeachingEvents(int limit)
-        {
-            return _dbContext.TeachingEvents
-                .Where((teachingEvent) => teachingEvent.StartAt > DateTime.Now)
-                .OrderBy(teachingEvent => teachingEvent.StartAt)
-                .Take(limit);
-        }
-
         public async Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request)
         {
             IQueryable<TeachingEvent> teachingEvents = _dbContext.TeachingEvents

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -47,7 +47,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new [] { "GetUpcoming", "Get", "Search" };
+            var methods = new [] { "Get", "Search" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }
@@ -94,7 +94,7 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public async void GetUpcoming_ValidRequest_ReturnsTeachingEvents()
+        public async void Search_ValidRequest_ReturnsTeachingEvents()
         {
             var request = new TeachingEventSearchRequest() { Postcode = "KY12 8FG" };
             var mockEvents = MockEvents();
@@ -104,26 +104,6 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             ok.Value.Should().Be(mockEvents);
-        }
-
-        [Fact]
-        public async void GetUpcoming_LimitMoreThan50_RespondsWithBadRequest()
-        {
-            var response = await _controller.GetUpcoming(51);
-
-            response.Should().BeOfType<BadRequestResult>();
-        }
-
-        [Fact]
-        public async void GetUpcoming_ReturnsUpcomingTeachingEvents()
-        {
-            var mockEvents = MockEvents();
-            _mockStore.Setup(mock => mock.GetUpcomingTeachingEvents(3)).Returns(mockEvents.AsAsyncQueryable());
-
-            var response = await _controller.GetUpcoming(3);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().BeEquivalentTo(mockEvents);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -459,16 +459,6 @@ namespace GetIntoTeachingApiTests.Services
             result.ReadableId.Should().Be(events.First().ReadableId);
         }
 
-        [Fact]
-        public async void GetUpcomingTeachingEvents_ReturnsUpcomingEventsInOrder()
-        {
-            await SeedMockTeachingEventsAsync();
-            var result = _store.GetUpcomingTeachingEvents(3);
-
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4", "Event 1" },
-                options => options.WithStrictOrdering());
-        }
-
         private static IEnumerable<TeachingEvent> MockTeachingEvents()
         {
             var sharedBuildingId = Guid.NewGuid();


### PR DESCRIPTION
The `teaching_events/search` endpoint was updated so that the postcode is optional, so you can effectively get the upcoming teaching events using that endpoint - making this dedicated endpoint redundant.