### PR TITLE
Set TeachingEventBuilding OnDelete to nullify foreign key

### DIFF
--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -28,7 +28,8 @@ namespace GetIntoTeachingApi.Database
                     break;
             }
 
-            modelBuilder.Entity<TeachingEvent>().HasOne(c => c.Building);
+            modelBuilder.Entity<TeachingEvent>().HasOne(c => c.Building).WithOne(b => b.TeachingEvent)
+                .HasForeignKey<TeachingEvent>(e => e.BuildingId).OnDelete(DeleteBehavior.SetNull);
             modelBuilder.Entity<TypeEntity>().HasKey(t => new { t.Id, t.EntityName, t.AttributeName });
         }
     }

--- a/GetIntoTeachingApi/Migrations/20200811151658_TeachingEventBuildingOnDeleteNullify.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20200811151658_TeachingEventBuildingOnDeleteNullify.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200811151658_TeachingEventBuildingOnDeleteNullify")]
+    partial class TeachingEventBuildingOnDeleteNullify
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20200811151658_TeachingEventBuildingOnDeleteNullify.cs
+++ b/GetIntoTeachingApi/Migrations/20200811151658_TeachingEventBuildingOnDeleteNullify.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class TeachingEventBuildingOnDeleteNullify : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TeachingEvents_TeachingEventBuildings_BuildingId",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TeachingEvents_BuildingId",
+                table: "TeachingEvents");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeachingEvents_BuildingId",
+                table: "TeachingEvents",
+                column: "BuildingId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TeachingEvents_TeachingEventBuildings_BuildingId",
+                table: "TeachingEvents",
+                column: "BuildingId",
+                principalTable: "TeachingEventBuildings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TeachingEvents_TeachingEventBuildings_BuildingId",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TeachingEvents_BuildingId",
+                table: "TeachingEvents");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeachingEvents_BuildingId",
+                table: "TeachingEvents",
+                column: "BuildingId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TeachingEvents_TeachingEventBuildings_BuildingId",
+                table: "TeachingEvents",
+                column: "BuildingId",
+                principalTable: "TeachingEventBuildings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -52,6 +53,8 @@ namespace GetIntoTeachingApi.Models
         public DateTime EndAt { get; set; }
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
+        [JsonIgnore]
+        public Guid? BuildingId { get; set; }
 
         public TeachingEvent()
             : base()

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -25,6 +25,8 @@ namespace GetIntoTeachingApi.Models
         [JsonIgnore]
         [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }
+        [JsonIgnore]
+        public TeachingEvent TeachingEvent { get; set; }
 
         public TeachingEventBuilding()
             : base()

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -157,8 +157,6 @@ namespace GetIntoTeachingApi.Services
             }
 
             await SyncModels(teachingEvents, _dbContext.TeachingEvents);
-
-            await _dbContext.SaveChangesAsync();
         }
 
         private async Task SyncPrivacyPolicies(ICrmService crm)

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -98,7 +98,8 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SyncAsync_DeletesOrphanedTeachingEventsAndBuildings()
         {
-            var teachingEvents = (await SeedMockTeachingEventsAsync()).ToList();
+            await SeedMockTeachingEventsAsync();
+            var teachingEvents = MockTeachingEvents().ToList();
             var mockCrm = new Mock<ICrmService>();
             mockCrm.Setup(m => m.GetTeachingEvents()).Returns(teachingEvents.GetRange(0, 1));
 


### PR DESCRIPTION
Currently when a building is deleted from the CRM the sync job fails as it tries to delete the building with the foreign key constraint in the `TeachingEvent` still present. This updates the cascade operation to nullify the foreign key when deleting a `TeachingEventBuilding`.

This should resolve the error:

> MessageText: update or delete on table "TeachingEventBuildings" violates foreign key constraint "FK_TeachingEvents_TeachingEventBuildings_BuildingId" on table "TeachingEvents"
    Detail: Key (Id)=(02ae40ce-9b9d-e911-a95e-000d3ab6413d) is still referenced from table "TeachingEvents".