### PR TITLE
StatusCake Tags added

### DIFF
--- a/terraform/statuscake/resources.tf
+++ b/terraform/statuscake/resources.tf
@@ -11,4 +11,5 @@ resource statuscake_test alert {
   status_codes  = each.value.status_codes
   basic_user    = var.HTTPAUTH_USERNAME
   basic_pass    = var.HTTPAUTH_PASSWORD
+  test_tags     = [ "GIT" , "BETA" ]
 }

--- a/terraform/statuscake/test.env.tfvars
+++ b/terraform/statuscake/test.env.tfvars
@@ -1,10 +1,10 @@
 alerts =  {
 ftt = {
-    website_name = "get-teacher-training-API (Test)"
+    website_name = "Get Teacher Training API (Beta test)"
     website_url   = "https://get-into-teaching-api-test.london.cloudapps.digital/api/operations/health_check"
     test_type     = "HTTP"
     check_rate    = 300
-    contact_group = [151103]
+    contact_group = [185037]
     trigger_rate  = 0
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"


### PR DESCRIPTION
Status cake deployment added some tags to make it easier to find them in amongst all the other teams

The status cake deployment is manual and only for BETA at the moment. Merge will not effect the applications code base, but will allow the terraform to get into master.