### PR TITLE
Fix status check job failure

### DIFF
--- a/GetIntoTeachingApi/Jobs/StatusCheckJob.cs
+++ b/GetIntoTeachingApi/Jobs/StatusCheckJob.cs
@@ -1,0 +1,21 @@
+﻿using GetIntoTeachingApi.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class StatusCheckJob : BaseJob
+    {
+        private readonly ILogger<StatusCheckJob> _logger;
+
+        public StatusCheckJob(IEnv env, ILogger<StatusCheckJob> logger)
+            : base(env)
+        {
+            _logger = logger;
+        }
+
+        public void Run()
+        {
+            _logger.LogInformation("Hangfire - Status Check");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/HangfireService.cs
+++ b/GetIntoTeachingApi/Services/HangfireService.cs
@@ -1,18 +1,16 @@
 ﻿using System;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using Hangfire;
-using Microsoft.Extensions.Logging;
 
 namespace GetIntoTeachingApi.Services
 {
     public class HangfireService : IHangfireService
     {
-        private readonly ILogger<HangfireService> _logger;
         private readonly IBackgroundJobClient _jobClient;
 
-        public HangfireService(IBackgroundJobClient jobClient, ILogger<HangfireService> logger)
+        public HangfireService(IBackgroundJobClient jobClient)
         {
-            _logger = logger;
             _jobClient = jobClient;
         }
 
@@ -20,7 +18,7 @@ namespace GetIntoTeachingApi.Services
         {
             try
             {
-                _jobClient.Enqueue(() => _logger.LogInformation("Hangfire - Status Check"));
+                _jobClient.Enqueue<StatusCheckJob>((x) => x.Run());
             }
             catch (Exception e)
             {

--- a/GetIntoTeachingApiTests/Jobs/StatusCheckJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/StatusCheckJobTests.cs
@@ -1,0 +1,23 @@
+﻿using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class StatusCheckJobTests
+    {
+        [Fact]
+        public void Run_LogsInfo()
+        {
+            var mockLogger = new Mock<ILogger<StatusCheckJob>>();
+            var job = new StatusCheckJob(new Env(), mockLogger.Object);
+
+            job.Run();
+
+            mockLogger.VerifyInformationWasCalled("Hangfire - Status Check");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/HangfireServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/HangfireServiceTests.cs
@@ -10,18 +10,11 @@ namespace GetIntoTeachingApiTests.Services
 {
     public class HangfireServiceTests
     {
-        private readonly Mock<ILogger<HangfireService>> _mockLogger;
-
-        public HangfireServiceTests()
-        {
-            _mockLogger = new Mock<ILogger<HangfireService>>();
-        }
-
         [Fact]
         public void CheckStatus_WhenHealthy_ReturnsOk()
         {
             var mockJobClient = new Mock<IBackgroundJobClient>();
-            var hangfire = new HangfireService(mockJobClient.Object, _mockLogger.Object);
+            var hangfire = new HangfireService(mockJobClient.Object);
 
             hangfire.CheckStatus().Should().Be(HealthCheckResponse.StatusOk);
         }
@@ -29,7 +22,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void CheckStatus_WhenUnhealthy_ReturnsError()
         {
-            var hangfire = new HangfireService(null, _mockLogger.Object);
+            var hangfire = new HangfireService(null);
 
             hangfire.CheckStatus().Should().Contain("Value cannot be null");
         }


### PR DESCRIPTION
We are seeing a job failure every time the status check endpoint is hit because the `ILogger` that was called in the wider scope is not available. This PR moves the logger to be dependency injected into a new job class, which should resolve the issue.

> System.ArgumentNullException
Value cannot be null. (Parameter 'factory')

> System.ArgumentNullException: Value cannot be null. (Parameter 'factory')
   at Microsoft.Extensions.Logging.Logger`1..ctor(ILoggerFactory factory)
   at lambda_method(Closure , Object[] )