### PR TITLE
Include building when returning TeachingEvent

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -107,12 +107,12 @@ namespace GetIntoTeachingApi.Services
 
         public async Task<TeachingEvent> GetTeachingEventAsync(Guid id)
         {
-            return await _dbContext.TeachingEvents.FirstOrDefaultAsync(teachingEvent => teachingEvent.Id == id);
+            return await _dbContext.TeachingEvents.Include(e => e.Building).FirstOrDefaultAsync(e => e.Id == id);
         }
 
         public async Task<TeachingEvent> GetTeachingEventAsync(string readableId)
         {
-            return await _dbContext.TeachingEvents.FirstOrDefaultAsync(teachingEvent => teachingEvent.ReadableId == readableId);
+            return await _dbContext.TeachingEvents.Include(e => e.Building).FirstOrDefaultAsync(e => e.ReadableId == readableId);
         }
 
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -444,21 +444,23 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async void GetTeachingEvent_WithId_ReturnsMatchingEvent()
+        public async void GetTeachingEventAsync_WithId_ReturnsMatchingEvent()
         {
             var events = await SeedMockTeachingEventsAsync();
             var result = await _store.GetTeachingEventAsync((Guid)events.First().Id);
 
             result.Id.Should().Be(events.First().Id);
+            result.Building.Should().NotBeNull();
         }
 
         [Fact]
-        public async void GetTeachingEvent_WithReadableId_ReturnsMatchingEvent()
+        public async void GetTeachingEventAsync_WithReadableId_ReturnsMatchingEvent()
         {
             var events = await SeedMockTeachingEventsAsync();
             var result = await _store.GetTeachingEventAsync(events.First().ReadableId);
 
             result.ReadableId.Should().Be(events.First().ReadableId);
+            result.Building.Should().NotBeNull();
         }
 
         private static IEnumerable<TeachingEvent> MockTeachingEvents()


### PR DESCRIPTION
As we weren't including the `Building` relationship explicitly it wasn't being returned in the response for requests to get a single teaching event.