### PR TITLE
Supress StyleCop warning

### DIFF
--- a/GetIntoTeachingApi/GlobalSuppressions.cs
+++ b/GetIntoTeachingApi/GlobalSuppressions.cs
@@ -16,3 +16,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Convention.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Not necessary.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:Partial elements should be documented", Justification = "Auto-generated migrations.", Scope = "type", Target = "~T:GetIntoTeachingApi.Migrations.InitialCreate")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:Partial elements should be documented", Justification = "Auto-generated migrations.", Scope = "type", Target = "~T:GetIntoTeachingApi.Migrations.TeachingEventBuildingOnDeleteNullify")]


### PR DESCRIPTION
The auto-generated migrations are safe to exclude from StyleCop linting.