### PR TITLE
Only de-duplicate on active subscriptions

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -109,6 +109,7 @@ namespace GetIntoTeachingApi.Services
         {
             return _service.CreateQuery("dfe_servicesubscription", Context()).FirstOrDefault(entity =>
                 entity.GetAttributeValue<EntityReference>("dfe_contact").Id == candidateId &&
+                entity.GetAttributeValue<OptionSetValue>("statecode").Value == (int)Subscription.SubscriptionStatus.Active &&
                 entity.GetAttributeValue<OptionSetValue>("dfe_servicesubscriptiontype").Value == serviceSubscriptionTypeId) == null;
         }
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -184,12 +184,30 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void CandidateYetToSubscribeToServiceOfType_WhenNotYetSubscribed_ReturnsFalse()
+        public void CandidateYetToSubscribeToServiceOfType_WhenNotYetSubscribed_ReturnsTrue()
         {
             var candidate = new Candidate() { Id = Guid.NewGuid() };
             var entity = new Entity();
             entity["dfe_contact"] = new EntityReference("contact", (Guid)candidate.Id);
             entity["dfe_servicesubscriptiontype"] = new OptionSetValue((int)Subscription.ServiceType.Event);
+            entity["statecode"] = new OptionSetValue((int)Subscription.SubscriptionStatus.Active);
+
+            _mockService.Setup(m => m.CreateQuery("dfe_servicesubscription", _context))
+                .Returns(new List<Entity> { entity }.AsQueryable());
+
+            var result = _crm.CandidateYetToSubscribeToServiceOfType((Guid)candidate.Id, (int)Subscription.ServiceType.MailingList);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void CandidateYetToSubscribeToServiceOfType_WhenExistingSubscriptionIsInactive_ReturnsTrue()
+        {
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            var entity = new Entity();
+            entity["dfe_contact"] = new EntityReference("contact", (Guid)candidate.Id);
+            entity["dfe_servicesubscriptiontype"] = new OptionSetValue((int)Subscription.ServiceType.MailingList);
+            entity["statecode"] = new OptionSetValue((int)Subscription.SubscriptionStatus.InActive);
 
             _mockService.Setup(m => m.CreateQuery("dfe_servicesubscription", _context))
                 .Returns(new List<Entity> { entity }.AsQueryable());
@@ -206,6 +224,7 @@ namespace GetIntoTeachingApiTests.Services
             var entity = new Entity();
             entity["dfe_contact"] = new EntityReference("contact", (Guid)candidate.Id);
             entity["dfe_servicesubscriptiontype"] = new OptionSetValue((int)Subscription.ServiceType.TeacherTrainingAdviser);
+            entity["statecode"] = new OptionSetValue((int)Subscription.SubscriptionStatus.Active);
 
             _mockService.Setup(m => m.CreateQuery("dfe_servicesubscription", _context))
                 .Returns(new List<Entity> { entity }.AsQueryable());


### PR DESCRIPTION
If a Candidate already has a subscription of the same type that is active, then we shouldn't create another instance of the subscription. Previously, we were not taking into account the `statecode` of the Candidate's existing subscriptions and therefore a new Subscription was not being created when it should have been (if a user subscribed, opted-out and then re-subscribed).