### PR TITLE
Filter out inapplicable event types

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -17,6 +17,16 @@ namespace GetIntoTeachingApi.Models
             Draft = 222750002,
         }
 
+        public enum EventType
+        {
+            ApplicationWorkshop = 222750000,
+            TrainToTeachEvent = 222750001,
+            OnlineEvent = 222750008,
+            SchoolOrUniversityEvent = 222750009,
+            EarlyYearEvent = 222750010,
+            OtherTypeOfEvent = 222750011,
+        }
+
         [EntityField("dfe_event_type", typeof(OptionSetValue))]
         public int TypeId { get; set; }
         [EntityField("dfe_eventstatus", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -164,8 +164,10 @@ namespace GetIntoTeachingApi.Services
             var status = new[] { (int)TeachingEvent.Status.Open, (int)TeachingEvent.Status.Closed };
             var statusCondition = new ConditionExpression("dfe_eventstatus", ConditionOperator.In, status);
             var futureDatedCondition = new ConditionExpression("msevtmgt_eventenddate", ConditionOperator.GreaterThan, DateTime.UtcNow);
+            var types = Enum.GetValues(typeof(TeachingEvent.EventType)).Cast<int>().ToArray();
+            var typeCondition = new ConditionExpression("dfe_event_type", ConditionOperator.In, types);
             var filter = new FilterExpression(LogicalOperator.And);
-            filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition });
+            filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition, typeCondition });
             query.Criteria.AddFilter(filter);
 
             var link = query.AddLink("msevtmgt_building", "msevtmgt_building", "msevtmgt_buildingid", JoinOperator.LeftOuter);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Xrm.Sdk.Query;
 using Xunit;
 using static Microsoft.PowerPlatform.Cds.Client.CdsServiceClient;
 using FluentAssertions.Common;
+using System.Linq.Dynamic.Core;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -77,7 +78,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetTeachingEvents_ReturnsAllNonDraftFutureDatedTeachingEvents()
+        public void GetTeachingEvents_ReturnsAllNonDraftFutureDatedTeachingEventsOfTheCorrectType()
         {
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
                 q => VerifyTeachingEventsQueryExpression(q)))).Returns(MockTeachingEvents());
@@ -97,8 +98,11 @@ namespace GetIntoTeachingApiTests.Services
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(status)).Any();
             var hasFutureDatedCondition = conditions.Where(c => c.AttributeName == "msevtmgt_eventenddate" &&
                 c.Operator == ConditionOperator.GreaterThan).Any();
+            var types = new HashSet<object>(Enum.GetValues(typeof(TeachingEvent.EventType)).Cast<int>().ToArray().Cast<object>());
+            var hasTypeCondition = conditions.Where(c => c.AttributeName == "dfe_event_type" &&
+                c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(types)).Any();
 
-            return hasEntityName && hasStatusCondition && hasFutureDatedCondition;
+            return hasEntityName && hasStatusCondition && hasFutureDatedCondition && hasTypeCondition;
         }
 
         [Fact]


### PR DESCRIPTION
On the Get into Teaching website we only want to display a subset of the events that are available in the CRM, namely:

- Application workshops
- Train to teach events
- Online events
- School or University events
- Early year events
- "other" types of events