### PR TITLE
Add WebFeedId to TeachingEvent and prevent sign ups if null (take #2)

### DIFF
--- a/GetIntoTeachingApi/GlobalSuppressions.cs
+++ b/GetIntoTeachingApi/GlobalSuppressions.cs
@@ -17,3 +17,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Not necessary.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:Partial elements should be documented", Justification = "Auto-generated migrations.", Scope = "type", Target = "~T:GetIntoTeachingApi.Migrations.InitialCreate")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:Partial elements should be documented", Justification = "Auto-generated migrations.", Scope = "type", Target = "~T:GetIntoTeachingApi.Migrations.TeachingEventBuildingOnDeleteNullify")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:Partial elements should be documented", Justification = "Auto-generated migrations.", Scope = "type", Target = "~T:GetIntoTeachingApi.Migrations.AddWebFeedIdToTeachingEvent")]

--- a/GetIntoTeachingApi/Migrations/20200814063617_AddWebFeedIdToTeachingEvent.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20200814063617_AddWebFeedIdToTeachingEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200814063617_AddWebFeedIdToTeachingEvent")]
+    partial class AddWebFeedIdToTeachingEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20200814063617_AddWebFeedIdToTeachingEvent.cs
+++ b/GetIntoTeachingApi/Migrations/20200814063617_AddWebFeedIdToTeachingEvent.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class AddWebFeedIdToTeachingEvent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "WebFeedId",
+                table: "TeachingEvents",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WebFeedId",
+                table: "TeachingEvents");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -33,6 +33,10 @@ namespace GetIntoTeachingApi.Models
         public int StatusId { get; set; }
         [EntityField("msevtmgt_readableeventid")]
         public string ReadableId { get; set; }
+        [EntityField("dfe_eventwebfeedid")]
+        [SwaggerSchema("If set, the API will accept new attendees for " +
+            "this event (an external sign up should be used if this value is nil).")]
+        public string WebFeedId { get; set; }
         [EntityField("dfe_isonlineevent")]
         public bool IsOnline { get; set; }
         [EntityField("msevtmgt_name")]

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationValidator.cs
@@ -18,6 +18,10 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Must(id => BeAValidTeachingEvent(id))
                 .WithMessage("Must be a valid teaching event.");
 
+            RuleFor(registration => registration.EventId)
+                .Must(id => BeAvailableForOnlineRegistrations(id))
+                .WithMessage("Attendence cannot be registered for this event via the API (it has no WebFeedId).");
+
             RuleFor(registration => registration.ChannelId)
                 .Must(id => ChannelIds().Contains(id.ToString()))
                 .Unless(registration => registration.Id != null)
@@ -31,6 +35,13 @@ namespace GetIntoTeachingApi.Models.Validators
         private IEnumerable<string> ChannelIds()
         {
             return _store.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation").Select(channel => channel.Id);
+        }
+
+        private bool BeAvailableForOnlineRegistrations(Guid id)
+        {
+            var teachingEvent = _store.GetTeachingEventAsync(id).GetAwaiter().GetResult();
+
+            return teachingEvent?.WebFeedId != null;
         }
 
         private bool BeAValidTeachingEvent(Guid id)

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -21,6 +21,7 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_eventstatus" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_readableeventid");
+            type.GetProperty("WebFeedId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventwebfeedid");
             type.GetProperty("IsOnline").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_isonlineevent");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
             type.GetProperty("ExternalName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventRegistrationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventRegistrationValidatorTests.cs
@@ -24,7 +24,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var mockTeachingEvent = new TeachingEvent { Id = Guid.NewGuid() };
+            var mockTeachingEvent = new TeachingEvent { Id = Guid.NewGuid(), WebFeedId = "123" };
             var mockPickListItem = new TypeEntity { Id = "123" };
 
             _mockStore
@@ -49,6 +49,33 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_EventIdIsInvalid_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(registration => registration.EventId, Guid.NewGuid());
+        }
+
+        [Fact]
+        public void Validate_EventDoesNotAcceptOnlineRegistrations_HasError()
+        {
+            var mockTeachingEvent = new TeachingEvent { Id = Guid.NewGuid(), WebFeedId = null };
+            var mockPickListItem = new TypeEntity { Id = "123" };
+
+            _mockStore
+                .Setup(mock => mock.GetTeachingEventAsync((Guid)mockTeachingEvent.Id))
+                .ReturnsAsync(mockTeachingEvent);
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+
+            var registration = new TeachingEventRegistration()
+            {
+                EventId = (Guid)mockTeachingEvent.Id,
+                ChannelId = int.Parse(mockPickListItem.Id),
+            };
+
+            var result = _validator.TestValidate(registration);
+
+            result.IsValid.Should().BeFalse();
+
+            result.ShouldHaveValidationErrorFor("EventId")
+                .WithErrorMessage("Attendence cannot be registered for this event via the API (it has no WebFeedId).");
         }
 
         [Fact]


### PR DESCRIPTION
- Add WebFeedId to TeachingEvent

- Only accept online registrations for applicable events

If an event does not have a WebFeedId it is not possible to register for this event via the GITIS CRM. This commit adds a relevant validation check to reject such payloads from the client apps.

The original PR was rolled back as the migrations were missing.