### PR TITLE
Exclude early years/other event types

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -23,8 +23,6 @@ namespace GetIntoTeachingApi.Models
             TrainToTeachEvent = 222750001,
             OnlineEvent = 222750008,
             SchoolOrUniversityEvent = 222750009,
-            EarlyYearEvent = 222750010,
-            OtherTypeOfEvent = 222750011,
         }
 
         [EntityField("dfe_event_type", typeof(OptionSetValue))]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -98,7 +98,12 @@ namespace GetIntoTeachingApiTests.Services
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(status)).Any();
             var hasFutureDatedCondition = conditions.Where(c => c.AttributeName == "msevtmgt_eventenddate" &&
                 c.Operator == ConditionOperator.GreaterThan).Any();
-            var types = new HashSet<object>(Enum.GetValues(typeof(TeachingEvent.EventType)).Cast<int>().ToArray().Cast<object>());
+            var types = new HashSet<object>() {
+                (int)TeachingEvent.EventType.TrainToTeachEvent,
+                (int)TeachingEvent.EventType.OnlineEvent,
+                (int)TeachingEvent.EventType.ApplicationWorkshop,
+                (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
+            };
             var hasTypeCondition = conditions.Where(c => c.AttributeName == "dfe_event_type" &&
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(types)).Any();
 


### PR DESCRIPTION
It has been decided that we do not want to show Early Year/Other event types in the Get into Teaching website, so this commit removes them.

Explicitly assert event types in the test to ensure accidentally removing an enum from `TeachingEvent` doesn't result in the events of that type from being excluded (the connection was not explicit previously).