### PR TITLE
Check Hangfire health without enqueuing a job

### DIFF
--- a/GetIntoTeachingApiTests/Services/HangfireServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/HangfireServiceTests.cs
@@ -2,29 +2,47 @@
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Hangfire;
-using Microsoft.Extensions.Logging;
+using Hangfire.Storage.Monitoring;
+using Hangfire.Storage;
 using Moq;
+using System.Collections.Generic;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Services
 {
     public class HangfireServiceTests
     {
+        private readonly Mock<IStorageConnection> _mockStorageConnection;
+        private readonly Mock<IMonitoringApi> _mockMonitoringApi;
+        private readonly HangfireService _hangfire;
+
+        public HangfireServiceTests()
+        {
+            _mockStorageConnection = new Mock<IStorageConnection>();
+            _mockMonitoringApi = new Mock<IMonitoringApi>();
+
+            var mockStorage = new Mock<JobStorage>();
+            mockStorage.Setup(x => x.GetConnection()).Returns(_mockStorageConnection.Object);
+            mockStorage.Setup(x => x.GetMonitoringApi()).Returns(_mockMonitoringApi.Object);
+
+            _hangfire = new HangfireService(mockStorage.Object);
+        }
+
         [Fact]
         public void CheckStatus_WhenHealthy_ReturnsOk()
         {
-            var mockJobClient = new Mock<IBackgroundJobClient>();
-            var hangfire = new HangfireService(mockJobClient.Object);
+            var servers = new List<ServerDto>() { new ServerDto() { Queues = new[] { "Default" } } };
+            _mockMonitoringApi.Setup(m => m.Servers()).Returns(servers);
 
-            hangfire.CheckStatus().Should().Be(HealthCheckResponse.StatusOk);
+            _hangfire.CheckStatus().Should().Be(HealthCheckResponse.StatusOk);
         }
 
         [Fact]
         public void CheckStatus_WhenUnhealthy_ReturnsError()
         {
-            var hangfire = new HangfireService(null);
+            _mockMonitoringApi.Setup(m => m.Servers()).Returns(new List<ServerDto>());
 
-            hangfire.CheckStatus().Should().Contain("Value cannot be null");
+            _hangfire.CheckStatus().Should().Contain("No workers are processing the Default queue!");
         }
     }
 }


### PR DESCRIPTION
Previously we were enqueuing a job that simply logged something out to ensure that Hangfire was operational. This caused noise in the job statistics and only checked half of the infrastructure - it ensured the database could be contacted but not that there were workers running.

Instead, this commit reads the list of active workers from the database and ensures that at least one of them is processing the expected queue.