### PR TITLE
Use external TeachingEvent name

### DIFF
--- a/GetIntoTeachingApi/Migrations/20200814122533_RemoveExternalTitleFromTeachingEvent.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20200814122533_RemoveExternalTitleFromTeachingEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200814122533_RemoveExternalTitleFromTeachingEvent")]
+    partial class RemoveExternalTitleFromTeachingEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20200814122533_RemoveExternalTitleFromTeachingEvent.cs
+++ b/GetIntoTeachingApi/Migrations/20200814122533_RemoveExternalTitleFromTeachingEvent.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class RemoveExternalTitleFromTeachingEvent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExternalName",
+                table: "TeachingEvents");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalName",
+                table: "TeachingEvents",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -37,10 +37,8 @@ namespace GetIntoTeachingApi.Models
         public string WebFeedId { get; set; }
         [EntityField("dfe_isonlineevent")]
         public bool IsOnline { get; set; }
-        [EntityField("msevtmgt_name")]
-        public string Name { get; set; }
         [EntityField("dfe_externaleventtitle")]
-        public string ExternalName { get; set; }
+        public string Name { get; set; }
         [EntityField("dfe_eventsummary_ml")]
         public string Summary { get; set; }
         [EntityField("dfe_miscellaneousmessage_ml")]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -23,8 +23,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_readableeventid");
             type.GetProperty("WebFeedId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventwebfeedid");
             type.GetProperty("IsOnline").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_isonlineevent");
-            type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
-            type.GetProperty("ExternalName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");
+            type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");
             type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
             type.GetProperty("Summary").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventsummary_ml");
             type.GetProperty("VideoUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_videolink");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -416,13 +416,13 @@ namespace GetIntoTeachingApiTests.Services
         private static IQueryable<Entity> MockTeachingEvents()
         {
             var event1 = new Entity("msevtmgt_event");
-            event1["msevtmgt_name"] = "Event 1";
+            event1["dfe_externaleventtitle"] = "Event 1";
 
             var event2 = new Entity("msevtmgt_event");
-            event2["msevtmgt_name"] = "Event 2";
+            event2["dfe_externaleventtitle"] = "Event 2";
 
             var event3 = new Entity("msevtmgt_event");
-            event3["msevtmgt_name"] = "Event 3";
+            event3["dfe_externaleventtitle"] = "Event 3";
 
             return new[] { event1, event2, event3 }.AsQueryable();
         }


### PR DESCRIPTION
An event has an internal and external event name; previously we were exposing both, but we don't actually need to display the internal event name anywhere on the website, so it makes more sense to just have one event name pointing to the external name attribute in Dynamics.