### PR TITLE
Move de-duplication logic into TeachingEventRegistration model

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -233,8 +233,6 @@ namespace GetIntoTeachingApi.Models
                     return crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId);
                 case "Subscriptions" when Id != null && value.Id == null:
                     return crm.CandidateYetToSubscribeToServiceOfType((Guid)Id, value.TypeId);
-                case "TeachingEventRegistrations" when Id != null && value.Id == null:
-                    return crm.CandidateYetToRegisterForTeachingEvent((Guid)Id, value.EventId);
                 default:
                     return true;
             }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -33,5 +33,17 @@ namespace GetIntoTeachingApi.Models
             : base(entity, crm)
         {
         }
+
+        protected override bool ShouldMap(ICrmService crm)
+        {
+            var alreadyRegistered = !crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
+
+            if (alreadyRegistered)
+            {
+                return false;
+            }
+
+            return base.ShouldMap(crm);
+        }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -152,6 +152,12 @@ namespace GetIntoTeachingApi.Services
         {
             using var context = Context();
             var entity = model.ToEntity(this, context);
+
+            if (entity == null)
+            {
+                return;
+            }
+
             _service.SaveChanges(context);
             model.Id = entity.Id;
         }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -221,28 +221,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void ToEntity_WhenAlreadyRegisteredForEvent_DoesNotCreateTeachingEventEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var teachingEvent = new TeachingEventRegistration() { EventId = Guid.NewGuid() };
-            var candidate = new Candidate()
-            {
-                Id = Guid.NewGuid(),
-                TeachingEventRegistrations = new List<TeachingEventRegistration>() { teachingEvent }
-            };
-
-            mockCrm.Setup(m => m.MappableEntity("contact", (Guid)candidate.Id, context)).Returns(new Entity("contact"));
-            mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent((Guid)candidate.Id, (Guid)teachingEvent.EventId)).Returns(false);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Never);
-        }
-
-        [Fact]
         public void ToEntity_WhenPrivacyPolicyAlreadyAccepted_DoesNotCreatePrivacyPolicyEntity()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -348,6 +348,19 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void Save_WhenToEntityReturnsNull_DoesNotSaveContext()
+        {
+            var entity = new Entity() { Id = Guid.NewGuid() };
+            var mockCandidate = new Mock<Candidate>();
+            mockCandidate.Setup(m => m.ToEntity(_crm, _context)).Returns<Entity>(null);
+
+            _crm.Save(mockCandidate.Object);
+
+            _mockService.Verify(mock => mock.SaveChanges(_context), Times.Never);
+            mockCandidate.Object.Id.Should().BeNull();
+        }
+
+        [Fact]
         public void AddLink_ProxiesToService()
         {
             var source = new Entity("parent");


### PR DESCRIPTION
Previously we saved the `TeachingEventRegistration` as part of saving a `Candidate`, but this was later changed so that the registration is saved independently (a deep insert on `Candidate` doesn't work for reasons unknown).

The de-duplication logic was left in the `Candidate` model - this moves it into the `TeachingEventRegistration` model, so if a registration already exists for the user against the event a call to `ToEntity` returns `null` and the `Save` operation on the `CrmService` just returns.