### PR TITLE
Clarify `DateTime` as a `date`

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -28,6 +28,7 @@ namespace GetIntoTeachingApi.Models
         public string Email { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        [SwaggerSchema(Format = "date")]
         public DateTime? DateOfBirth { get; set; }
         public string TeacherId { get; set; }
         public string DegreeSubject { get; set; }


### PR DESCRIPTION
Since C# doesn't have the notion of a date without a time, we need to specify the swagger format as `date` so that when we generate a client in Ruby it uses the `Date` object instead of the `DateTime` object.