### PR TITLE
Added calls to Slack

### DIFF
--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -30,12 +30,14 @@ jobs:
           name: AnchoreReports
           path: ./anchore-reports/
 
-      - name:  Send Message to Sentry.io
-        if: always()
-        uses: sfawcett123/sentry-event@v1
-        with:
-             MESSAGE: "Test (CVE) Application - get-into-teaching-api"
-             STATE:  ${{job.status}}
-             ENVIRON: "Development"
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
         env:
-            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -96,6 +96,13 @@ jobs:
              wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
              chmod +x ${{ env.CF_PROVIDER_DIR }}
    
+       - name: Wait for any previous runs to complete
+         uses: softprops/turnstyle@v1
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           continue-after-seconds: 180
+
        - name: Terraform Init
          run: |
              cd terraform/paas && pwd
@@ -135,13 +142,14 @@ jobs:
          run: |
              tests/confidence/healthcheck.sh "get-into-teaching-api-dev"  "${{steps.sha.outputs.short}}" 
 
-       - name:  Send Message to Sentry.io
-         if: always()
-         uses: sfawcett123/sentry-event@v1
-         with:
-             MESSAGE: "Release Application - get-into-teaching-api"
-             STATE:  ${{job.status}}
-             ENVIRON: "Development Test"
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
          env:
-            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -41,3 +41,15 @@ jobs:
              terraform apply -auto-approve plan
          env:
              ARM_ACCESS_KEY:           "${{ secrets.DEV_ARM_ACCESS_KEY  }}"
+
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
+         env:
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+               

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,29 +12,39 @@ jobs:
   test_dot_net:
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.200
+
     - name: Install NotifyBintray
       run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
+
     - name: Install dependencies
       run: sudo dotnet restore && sudo apt-get update && sudo apt-get install -y libsqlite3-mod-spatialite
+
     - name: Build
       run: sudo dotnet build --configuration Release --no-restore /warnaserror
+
     - name: Test
       run: sudo dotnet test --no-restore --verbosity normal
+
     - name: Lint Dockerfile
       uses: brpaz/hadolint-action@master
       with:
         dockerfile: "Dockerfile"
-    - name:  Send Message to Sentry.io
-      if: always()
-      uses: sfawcett123/sentry-event@v1
-      with:
-             MESSAGE: "Test Application - get-into-teaching-api"
-             STATE:  ${{job.status}}
-             ENVIRON: "Development"
+
+    - name: Slack Notification
+      if: failure()
+      uses: rtCamp/action-slack-notify@master
       env:
-           SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
              wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
              chmod +x ${{ env.CF_PROVIDER_DIR }}
    
+       - name: Wait for any previous runs to complete
+         uses: softprops/turnstyle@v1
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           continue-after-seconds: 180
+
        - name: Terraform Init
          run: |
              cd terraform/paas && pwd
@@ -71,12 +78,23 @@ jobs:
          run: |
              tests/confidence/healthcheck.sh "get-into-teaching-api-test"  "${{ steps.sha.outputs.short}}" 
 
-       - name:  Send Message to Sentry.io
-         if: always()
-         uses: sfawcett123/sentry-event@v1
-         with:
-             MESSAGE: "Release Application - get-into-teaching-api"
-             STATE:  ${{job.status}}
-             ENVIRON: "Test"
+       - name: Create Sentry release
+         if: success()
+         uses: getsentry/action-release@v1.0.0
          env:
-            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+         with:
+           environment: qa
+
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
+         env:
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,15 +12,20 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Install NotifyBintray
         run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
+
       - name: Install dotnet-sonarscanner
         run:  dotnet tool install --global dotnet-sonarscanner --version 4.8.0
+
       - name: Install dependencies
         run:  sudo dotnet restore && sudo apt-get update && sudo apt-get install -y libsqlite3-mod-spatialite
+
       - name: SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,12 +54,13 @@ jobs:
             sudo dotnet test --no-build --logger:trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
           dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
-      - name:  Send Message to Sentry.io
-        if: always()
-        uses: sfawcett123/sentry-event@v1
-        with:
-             MESSAGE: "Test Application - get-into-teaching-api"
-             STATE:  ${{job.status}}
-             ENVIRON: "Development"
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
         env:
-            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
- Replaced all the pipeline calls to sentry.io with calls to slack, but only on failure.
- Also added in a wait before terraform to ensure no two pipelines try to run terraform at same time