### PR TITLE
Migrate terraform from 12 to 13

### DIFF
--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -1,3 +1,14 @@
+terraform {
+ required_version = "~> 0.13"
+
+  required_providers {
+    cloudfoundry = {
+      source  = "terraform-registry.us-east.philips-healthsuite.com/philips-forks/cloudfoundry"
+      version = "0.12.2-202008131826"
+    }
+  }
+}
+
 provider "cloudfoundry" {
     api_url = var.api_url
     user = var.user

--- a/terraform/paas/versions.tf
+++ b/terraform/paas/versions.tf
@@ -1,3 +1,0 @@
-terraform {
-  required_version = ">= 0.12.28"
-}


### PR DESCRIPTION
Terraform has updated, so I have had to update the provider for cloudfoundry, which is not a simple task 