### PR TITLE
Temporarily disable sending data to the CRM

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -57,7 +57,8 @@ namespace GetIntoTeachingApi.Jobs
 
         private void SaveCandidate(Candidate candidate)
         {
-            _crm.Save(candidate);
+            // TODO: temporarily disabled to avoid collecting PII in a UR session.
+            // _crm.Save(candidate);
         }
 
         private IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -33,6 +33,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 _mockContext.Object, _mockLogger.Object);
         }
 
+        /* TODO: temporarily disabled to avoid collecting PII in a UR session.
         [Fact]
         public void Run_OnSuccess_SavesCandidate()
         {
@@ -58,7 +59,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockCrm.Verify(mock => mock.Save(registration), Times.Once);
             registration.CandidateId.Should().Be(candidateId);
-        }
+        }*/
 
         [Fact]
         public void Run_OnFailure_EmailsCandidate()


### PR DESCRIPTION
We are conducting a UX session on Wednesday and don't want to collect any personally identifiable information that then gets sent to the CRM. The easiest way to prevent this is to disable the API from writing any candidate information to the CRM.