### PR TITLE
Do not allow an empty secret

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApi.Auth
 
             var secrets = new[] { _env.SharedSecret, _env.PenTestSharedSecret };
 
-            if (!secrets.Contains(token))
+            if (string.IsNullOrWhiteSpace(token) || !secrets.Contains(token))
             {
                 _logger.LogWarning("SharedSecretHandler - Token is not valid");
                 return Task.FromResult(AuthenticateResult.Fail("Token is not valid"));


### PR DESCRIPTION
If the environment secrets are not defined it will allow a request to authenticate with an empty string (because it matches the secret). To protected against this we perform an empty/null string check on the token and reject it before matching it with a secret.