### PR TITLE
Convert all DateTime instances to be UTC

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -265,7 +265,7 @@ namespace GetIntoTeachingApi.Models
 
             if (AssignmentStatusId == (int)AssignmentStatus.WaitingToBeAssigned)
             {
-                StatusIsWaitingToBeAssignedAt = DateTime.Now;
+                StatusIsWaitingToBeAssignedAt = DateTime.UtcNow;
             }
 
             return base.ShouldMap(crm);

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -24,7 +24,7 @@ namespace GetIntoTeachingApi.Models
         public string Description { get; set; } = "Online consent as part of web registration";
         [JsonIgnore]
         [EntityField("dfe_timeofconsent")]
-        public DateTime AcceptedAt { get; set; } = DateTime.Now;
+        public DateTime AcceptedAt { get; set; } = DateTime.UtcNow;
 
         public CandidatePrivacyPolicy()
             : base()

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => DateTime.Now);
+            RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => DateTime.UtcNow);
             RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);

--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.FirstName).MaximumLength(256);
             RuleFor(request => request.LastName).MaximumLength(256);
             RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.Now);
+            RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.UtcNow);
             RuleFor(request => request)
                 .Must(SpecifyTwoAdditionalRequiredAttributes)
                 .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -40,7 +40,7 @@ namespace GetIntoTeachingApi.Services
         public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
         {
             return _service.CreateQuery("dfe_callbackbookingquota", Context())
-                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") > DateTime.Now &&
+                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") > DateTime.UtcNow &&
                                    entity.GetAttributeValue<DateTime>("dfe_starttime") <
                                    DateTime.UtcNow.AddDays(MaximumCallbackBookingQuotaDaysInAdvance))
                 .OrderBy((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime"))

--- a/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
@@ -41,7 +41,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static CallbackBookingQuota MockQuota()
         {
-            return new CallbackBookingQuota() { Id = Guid.NewGuid(), StartAt = DateTime.Now, NumberOfBookings = 4 };
+            return new CallbackBookingQuota() { Id = Guid.NewGuid(), StartAt = DateTime.UtcNow, NumberOfBookings = 4 };
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -72,7 +72,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static PrivacyPolicy MockPrivacyPolicy()
         {
-            return new PrivacyPolicy { Id = Guid.NewGuid(), Text = "Example text", CreatedAt = DateTime.Now };
+            return new PrivacyPolicy { Id = Guid.NewGuid(), Text = "Example text", CreatedAt = DateTime.UtcNow };
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
@@ -47,7 +47,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void AcceptedAt_DefaultValue_IsNow()
         {
-            new CandidatePrivacyPolicy().AcceptedAt.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(10));
+            new CandidatePrivacyPolicy().AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -238,7 +238,7 @@ namespace GetIntoTeachingApiTests.Models
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "123456789",
-                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.Now }
+                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.UtcNow }
             };
 
             var phoneCallEntity = new Entity("phonecall");
@@ -295,7 +295,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.ToEntity(mockCrm.Object, context);
 
             candidateEntity.GetAttributeValue<DateTime>("dfe_waitingtobeassigneddate")
-                .Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(20));
+                .Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(20));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -15,15 +15,15 @@ namespace GetIntoTeachingApiTests.Models
             var latestQualification = new CandidateQualification()
             {
                 Id = Guid.NewGuid(),
-                CreatedAt = DateTime.Now.AddDays(10),
+                CreatedAt = DateTime.UtcNow.AddDays(10),
                 UkDegreeGradeId = 1,
             };
 
             var qualifications = new List<CandidateQualification>()
             {
-                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(3) },
                 latestQualification,
-                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(5) },
             };
 
             var candidate = new Candidate()

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApiTests.Models
             var latestQualification = new CandidateQualification()
             {
                 Id = Guid.NewGuid(),
-                CreatedAt = DateTime.Now.AddDays(10),
+                CreatedAt = DateTime.UtcNow.AddDays(10),
                 DegreeStatusId = 1,
                 UkDegreeGradeId = 2,
                 TypeId = 3,
@@ -24,23 +24,23 @@ namespace GetIntoTeachingApiTests.Models
 
             var qualifications = new List<CandidateQualification>()
             {
-                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(3) },
                 latestQualification,
-                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(5) },
             };
 
             var latestPastTeachingPosition = new CandidatePastTeachingPosition()
             {
                 Id = Guid.NewGuid(),
-                CreatedAt = DateTime.Now.AddDays(10),
+                CreatedAt = DateTime.UtcNow.AddDays(10),
                 SubjectTaughtId = Guid.NewGuid(),
             };
 
             var pastTeachingPositions = new List<CandidatePastTeachingPosition>()
             {
-                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(3) },
+                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(3) },
                 latestPastTeachingPosition,
-                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.Now.AddDays(5) },
+                new CandidatePastTeachingPosition() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(5) },
             };
 
             var candidate = new Candidate()
@@ -59,7 +59,7 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                DateOfBirth = DateTime.Now,
+                DateOfBirth = DateTime.UtcNow,
                 Telephone = "1234567",
                 TeacherId = "abc123",
                 AddressLine1 = "Address 1",
@@ -128,7 +128,7 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                DateOfBirth = DateTime.Now,
+                DateOfBirth = DateTime.UtcNow,
                 Telephone = "1234567",
                 TeacherId = "abc123",
                 DegreeSubject = "Maths",
@@ -136,7 +136,7 @@ namespace GetIntoTeachingApiTests.Models
                 AddressLine2 = "Address 2",
                 AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
-                PhoneCallScheduledAt = DateTime.Now,
+                PhoneCallScheduledAt = DateTime.UtcNow,
             };
 
             var candidate = request.Candidate;
@@ -371,7 +371,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData("+447564 375 482")]
         public void Candidate_UkTelephone_PhoneCallDestinationIsCorrect(string telephone)
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.Now };
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
         }
@@ -381,7 +381,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData("+57564 375 482")]
         public void Candidate_InternationalTelephone_PhoneCallDestinationIsCorrect(string telephone)
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.Now };
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.International);
         }
@@ -389,7 +389,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_NullTelephone_PhoneCallDestinationIsCorrect()
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = null, PhoneCallScheduledAt = DateTime.Now };
+            var request = new TeacherTrainingAdviserSignUp() { Telephone = null, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().BeNull();
         }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -74,7 +74,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 FirstName = "first",
                 LastName = "last",
                 Email = "email@candidate.com",
-                DateOfBirth = DateTime.Now.AddYears(-18),
+                DateOfBirth = DateTime.UtcNow.AddYears(-18),
                 Telephone = "07584 734 576",
                 AddressLine1 = "line1",
                 AddressLine2 = "line2",
@@ -172,7 +172,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var candidate = new Candidate
             {
-                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.Now.AddDays(-10) }
+                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.UtcNow.AddDays(-10) }
             };
             var result = _validator.TestValidate(candidate);
 
@@ -230,7 +230,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_DateOfBirthInFuture_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.DateOfBirth, DateTime.Now.AddDays(1));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.DateOfBirth, DateTime.UtcNow.AddDays(1));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.Now.AddDays(-18) };
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.UtcNow.AddDays(-18) };
 
             var result = _validator.TestValidate(request);
 
@@ -53,7 +53,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_DateOfBirthInFuture_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, DateTime.Now.AddDays(1));
+            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, DateTime.UtcNow.AddDays(1));
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_SpecifyThreeAdditionalRequiredAttributes_HasNoError()
         {
-            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.Now.AddDays(-18) };
+            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.UtcNow.AddDays(-18) };
 
             var result = _validator.TestValidate(request);
 

--- a/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             var phoneCall = new PhoneCall()
             {
-                ScheduledAt = DateTime.Now.AddDays(2),
+                ScheduledAt = DateTime.UtcNow.AddDays(2),
                 ChannelId = int.Parse(mockPickListItem.Id),
             };
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                DateOfBirth = DateTime.Now,
+                DateOfBirth = DateTime.UtcNow,
                 TeacherId = "abc123",
                 DegreeSubject = "Maths",
                 Telephone = "1234567",
@@ -52,7 +52,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 AddressLine2 = "Line 2",
                 AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
-                PhoneCallScheduledAt = DateTime.Now,
+                PhoneCallScheduledAt = DateTime.UtcNow,
             };
 
             var result = _validator.TestValidate(request);
@@ -177,7 +177,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                PhoneCallScheduledAt = DateTime.Now,
+                PhoneCallScheduledAt = DateTime.UtcNow,
                 Telephone = null,
             };
 
@@ -191,7 +191,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                PhoneCallScheduledAt = DateTime.Now,
+                PhoneCallScheduledAt = DateTime.UtcNow,
                 Telephone = "123456",
             };
 
@@ -220,7 +220,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
-                PhoneCallScheduledAt = DateTime.Now,
+                PhoneCallScheduledAt = DateTime.UtcNow,
             };
 
             var result = _validator.TestValidate(request);

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -35,8 +35,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 Postcode = "KY11 9HF",
                 Radius = 10,
                 TypeId = int.Parse(mockPickListItem.Id),
-                StartAfter = DateTime.Now.AddDays(-1),
-                StartBefore = DateTime.Now.AddDays(1)
+                StartAfter = DateTime.UtcNow.AddDays(-1),
+                StartBefore = DateTime.UtcNow.AddDays(1)
             };
 
             var result = _validator.TestValidate(request);
@@ -49,8 +49,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeachingEventSearchRequest()
             {
-                StartAfter = DateTime.Now.AddDays(1),
-                StartBefore = DateTime.Now
+                StartAfter = DateTime.UtcNow.AddDays(1),
+                StartBefore = DateTime.UtcNow
             };
 
             var result = _validator.TestValidate(request);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -400,7 +400,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";
-            candidate1["modifiedon"] = DateTime.Now;
+            candidate1["modifiedon"] = DateTime.UtcNow;
             candidate1["dfe_duplicatescorecalculated"] = 10.0;
 
             var candidate2 = new Entity("contact");
@@ -408,7 +408,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate2["emailaddress1"] = "john@doe.com";
             candidate2["firstname"] = "New John";
             candidate2["lastname"] = "Doe";
-            candidate2["modifiedon"] = DateTime.Now;
+            candidate2["modifiedon"] = DateTime.UtcNow;
             candidate2["dfe_duplicatescorecalculated"] = 9.5;
 
             var candidate3 = new Entity("contact");
@@ -416,7 +416,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate3["emailaddress1"] = "john@doe.com";
             candidate3["firstname"] = "Old John";
             candidate3["lastname"] = "Doe";
-            candidate3["modifiedon"] = DateTime.Now.AddDays(-5);
+            candidate3["modifiedon"] = DateTime.UtcNow.AddDays(-5);
             candidate3["dfe_duplicatescorecalculated"] = 8.3;
 
             var candidate4 = new Entity("contact");
@@ -424,7 +424,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate4["emailaddress1"] = "inactive@doe.com";
             candidate4["firstname"] = "Inactive";
             candidate4["lastname"] = "Doe";
-            candidate4["modifiedon"] = DateTime.Now;
+            candidate4["modifiedon"] = DateTime.UtcNow;
             candidate4["dfe_duplicatescorecalculated"] = 7.1;
 
             var candidate5 = new Entity("contact");
@@ -432,7 +432,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate5["emailaddress1"] = "master@record.com";
             candidate5["firstname"] = "Child";
             candidate5["lastname"] = "Record";
-            candidate5["modifiedon"] = DateTime.Now;
+            candidate5["modifiedon"] = DateTime.UtcNow;
             candidate5["birthdate"] = new DateTime(2000, 1, 1);
             candidate5["dfe_duplicatescorecalculated"] = 2.4;
 
@@ -441,7 +441,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate6["emailaddress1"] = "master@record.com";
             candidate6["firstname"] = "Child1";
             candidate6["lastname"] = "Record";
-            candidate6["modifiedon"] = DateTime.Now;
+            candidate6["modifiedon"] = DateTime.UtcNow;
             candidate6["birthdate"] = new DateTime(2000, 1, 1);
             candidate6["dfe_duplicatescorecalculated"] = null;
 
@@ -450,7 +450,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate7["emailaddress1"] = "master@record.com";
             candidate7["firstname"] = "Master";
             candidate7["lastname"] = "Record";
-            candidate7["modifiedon"] = DateTime.Now.AddDays(-5);
+            candidate7["modifiedon"] = DateTime.UtcNow.AddDays(-5);
             candidate7["birthdate"] = new DateTime(2000, 1, 1);
             candidate7["dfe_duplicatescorecalculated"] = 3.7;
 
@@ -469,23 +469,23 @@ namespace GetIntoTeachingApiTests.Services
         private static IQueryable<Entity> MockCallbackBookingQuotas()
         {
             var quota1 = new Entity("dfe_callbackbookingquota");
-            quota1["dfe_starttime"] = DateTime.Now.AddDays(-1);
+            quota1["dfe_starttime"] = DateTime.UtcNow.AddDays(-1);
             quota1["dfe_websitenumberofbookings"] = 1;
 
             var quota2 = new Entity("dfe_callbackbookingquota");
-            quota2["dfe_starttime"] = DateTime.Now.AddDays(10);
+            quota2["dfe_starttime"] = DateTime.UtcNow.AddDays(10);
             quota2["dfe_websitenumberofbookings"] = 2;
 
             var quota3 = new Entity("dfe_callbackbookingquota");
-            quota3["dfe_starttime"] = DateTime.Now.AddDays(1);
+            quota3["dfe_starttime"] = DateTime.UtcNow.AddDays(1);
             quota3["dfe_websitenumberofbookings"] = 3;
 
             var quota4 = new Entity("dfe_callbackbookingquota");
-            quota4["dfe_starttime"] = DateTime.Now.AddMinutes(20);
+            quota4["dfe_starttime"] = DateTime.UtcNow.AddMinutes(20);
             quota4["dfe_websitenumberofbookings"] = 4;
 
             var quota5 = new Entity("dfe_callbackbookingquota");
-            quota5["dfe_starttime"] = DateTime.Now.AddDays(15);
+            quota5["dfe_starttime"] = DateTime.UtcNow.AddDays(15);
             quota5["dfe_websitenumberofbookings"] = 5;
 
             return new[] { quota1, quota2, quota3, quota4, quota5 }.AsQueryable();

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -370,8 +370,8 @@ namespace GetIntoTeachingApiTests.Services
                 Postcode = "KY6 2NJ",
                 Radius = 15,
                 TypeId = 123,
-                StartAfter = DateTime.Now,
-                StartBefore = DateTime.Now.AddDays(3)
+                StartAfter = DateTime.UtcNow,
+                StartBefore = DateTime.UtcNow.AddDays(3)
             };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -423,7 +423,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByStartAfter_ReturnsMatching()
         {
             await SeedMockTeachingEventsAsync();
-            var request = new TeachingEventSearchRequest() { StartAfter = DateTime.Now.AddDays(6) };
+            var request = new TeachingEventSearchRequest() { StartAfter = DateTime.UtcNow.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
@@ -435,7 +435,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByStartBefore_ReturnsMatching()
         {
             await SeedMockTeachingEventsAsync();
-            var request = new TeachingEventSearchRequest() { StartBefore = DateTime.Now.AddDays(6) };
+            var request = new TeachingEventSearchRequest() { StartBefore = DateTime.UtcNow.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
@@ -472,7 +472,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "1",
                 Name = "Event 1",
-                StartAt = DateTime.Now.AddDays(5),
+                StartAt = DateTime.UtcNow.AddDays(5),
                 Building = new TeachingEventBuilding()
                 {
                     Id = sharedBuildingId,
@@ -485,7 +485,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = FindEventGuid,
                 ReadableId = "2",
                 Name = "Event 2",
-                StartAt = DateTime.Now.AddDays(1),
+                StartAt = DateTime.UtcNow.AddDays(1),
                 TypeId = 123,
                 Building = new TeachingEventBuilding()
                 {
@@ -500,7 +500,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "3",
                 Name = "Event 3",
-                StartAt = DateTime.Now.AddDays(10),
+                StartAt = DateTime.UtcNow.AddDays(10),
                 Building = new TeachingEventBuilding()
                 {
                     Id = Guid.NewGuid(),
@@ -514,7 +514,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "4",
                 Name = "Event 4",
-                StartAt = DateTime.Now.AddDays(3),
+                StartAt = DateTime.UtcNow.AddDays(3),
                 TypeId = 123,
                 Building = new TeachingEventBuilding()
                 {
@@ -529,7 +529,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "5",
                 Name = "Event 5",
-                StartAt = DateTime.Now.AddDays(15),
+                StartAt = DateTime.UtcNow.AddDays(15),
             };
 
             var event6 = new TeachingEvent()
@@ -537,7 +537,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "6",
                 Name = "Event 6",
-                StartAt = DateTime.Now.AddDays(60),
+                StartAt = DateTime.UtcNow.AddDays(60),
                 Building = new TeachingEventBuilding()
                 {
                     Id = sharedBuildingId,
@@ -550,7 +550,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "7",
                 Name = "Event 7",
-                StartAt = DateTime.Now.AddYears(1),
+                StartAt = DateTime.UtcNow.AddYears(1),
                 Building = new TeachingEventBuilding()
                 {
                     Id = Guid.NewGuid(),
@@ -575,9 +575,9 @@ namespace GetIntoTeachingApiTests.Services
 
         private static IEnumerable<PrivacyPolicy> MockPrivacyPolicies()
         {
-            var policy1 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 1", CreatedAt = DateTime.Now.AddDays(-10) };
-            var policy2 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 2", CreatedAt = DateTime.Now };
-            var policy3 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 3", CreatedAt = DateTime.Now.AddDays(-5) };
+            var policy1 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 1", CreatedAt = DateTime.UtcNow.AddDays(-10) };
+            var policy2 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 2", CreatedAt = DateTime.UtcNow };
+            var policy3 = new PrivacyPolicy() { Id = Guid.NewGuid(), Text = "Policy 3", CreatedAt = DateTime.UtcNow.AddDays(-5) };
 
             return new [] { policy1, policy2, policy3 };
         }


### PR DESCRIPTION
The API should be time zone agnostic; currently most of the date instantiations use `DateTime.Now`, which returns a date in the time zone of the system. Instead, this commit changes to use `DateTime.UtcNow`, which will return a UTC date that is consistent with what the CRM expects/uses.