### PR TITLE
Changes to the event sign up when opting-in to the mailing list

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -63,6 +63,7 @@ namespace GetIntoTeachingApi.Models
         public enum SubscriptionType
         {
             SingleEvent = 222750001,
+            LocalEvent = 222750000,
         }
 
         public enum PreferredEducationPhase

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -60,6 +60,11 @@ namespace GetIntoTeachingApi.Models
             Events = 222750000,
         }
 
+        public enum SubscriptionType
+        {
+            SingleEvent = 222750001,
+        }
+
         public enum PreferredEducationPhase
         {
             Primary = 222750000,
@@ -197,6 +202,8 @@ namespace GetIntoTeachingApi.Models
         public bool? HasEventsSubscription { get; set; }
         [EntityField("dfe_GITISEventsServiceSubscriptionChannel", typeof(OptionSetValue))]
         public int? EventsSubscriptionChannelId { get; set; }
+        [EntityField("GITISEventsServiceSubscriptionType", typeof(OptionSetValue))]
+        public int? EventsSubscriptionTypeId { get; set; }
         [EntityField("dfe_GITISEventsServiceStartDate")]
         public DateTime? EventsSubscriptionStartAt { get; set; }
         [EntityField("dfe_GITISEventsServiceDoNotBulkEmail")]

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -21,8 +21,6 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
-        [SwaggerSchema(WriteOnly = true)]
-        public bool SubscribeToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -115,11 +113,6 @@ namespace GetIntoTeachingApi.Models
             candidate.MailingListSubscriptionDoNotPostalMail = true;
             candidate.MailingListSubscriptionDoNotSendMm = false;
 
-            if (!SubscribeToEvents)
-            {
-                return;
-            }
-
             candidate.HasEventsSubscription = true;
             candidate.EventsSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Events;
             candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
@@ -128,6 +121,15 @@ namespace GetIntoTeachingApi.Models
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
             candidate.EventsSubscriptionDoNotPostalMail = true;
             candidate.EventsSubscriptionDoNotSendMm = false;
+
+            if (string.IsNullOrWhiteSpace(AddressPostcode))
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
+            }
+            else
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
+            }
         }
 
         private void AcceptPrivacyPolicy(Candidate candidate)

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -124,7 +124,15 @@ namespace GetIntoTeachingApi.Models
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
             candidate.EventsSubscriptionDoNotPostalMail = true;
             candidate.EventsSubscriptionDoNotSendMm = !SubscribeToEvents;
-            candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
+
+            if (string.IsNullOrWhiteSpace(AddressPostcode))
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
+            }
+            else
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
+            }
 
             if (!SubscribeToMailingList)
             {

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -24,8 +24,8 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
-        [SwaggerSchema(WriteOnly = true)]
-        public bool SubscribeToEvents { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public bool SubscribeToEvents => AddressPostcode != null && SubscribeToMailingList;
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -124,6 +124,7 @@ namespace GetIntoTeachingApi.Models
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
             candidate.EventsSubscriptionDoNotPostalMail = true;
             candidate.EventsSubscriptionDoNotSendMm = !SubscribeToEvents;
+            candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
 
             if (!SubscribeToMailingList)
             {

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.AcceptedPolicyId).NotEmpty();
             RuleFor(request => request.ConsiderationJourneyStageId).NotNull();
             RuleFor(request => request.DegreeStatusId).NotNull();
+            RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
@@ -12,6 +12,9 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.Email).NotEmpty();
             RuleFor(request => request.EventId).NotEmpty();
             RuleFor(request => request.AcceptedPolicyId).NotEmpty();
+            RuleFor(request => request.ConsiderationJourneyStageId).NotNull().When(request => request.SubscribeToMailingList);
+            RuleFor(request => request.DegreeStatusId).NotNull().When(request => request.SubscribeToMailingList);
+            RuleFor(request => request.PreferredTeachingSubjectId).NotNull().When(request => request.SubscribeToMailingList);
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
         }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -108,6 +108,8 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("EventsSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_GITISEventsServiceSubscriptionChannel" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("EventsSubscriptionTypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "GITISEventsServiceSubscriptionType" && a.Type == typeof(OptionSetValue));
             type.GetProperty("HasEventsSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceIsSubscriber");
             type.GetProperty("EventsSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceStartDate");
             type.GetProperty("EventsSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotBulkEmail");

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -74,7 +74,6 @@ namespace GetIntoTeachingApiTests.Models
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
-                SubscribeToEvents = true,
             };
 
             var candidate = request.Candidate;
@@ -116,10 +115,22 @@ namespace GetIntoTeachingApiTests.Models
             candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
             candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
             candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
+            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
 
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
             candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);
             candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
+        }
+
+        [Fact]
+        public void Candidate_AddressPostcodeNotProvided_EventsSubscriptionTypeIsSingleEvent()
+        {
+            var request = new MailingListAddMember()
+            {
+                AddressPostcode = null,
+            };
+
+            request.Candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
         }
 
         [Fact]
@@ -136,14 +147,6 @@ namespace GetIntoTeachingApiTests.Models
             var request = new MailingListAddMember() { CandidateId = Guid.NewGuid() };
 
             request.Candidate.ChannelId.Should().BeNull();
-        }
-
-        [Fact]
-        public void Candidate_SubscribeToEventsIsFalse_DoesNotCreateSubscription()
-        {
-            var request = new MailingListAddMember() { SubscribeToEvents = false };
-
-            request.Candidate.HasEventsSubscription.Should().BeNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -12,25 +12,47 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithCandidate_MapsCorrectly()
         {
+            var latestQualification = new CandidateQualification()
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow.AddDays(10),
+                UkDegreeGradeId = 1,
+            };
+
+            var qualifications = new List<CandidateQualification>()
+            {
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(3) },
+                latestQualification,
+                new CandidateQualification() { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow.AddDays(5) },
+            };
+
             var candidate = new Candidate()
             {
                 Id = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                ConsiderationJourneyStageId = 1,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
+                Qualifications = qualifications,
                 HasEventsSubscription = true,
             };
 
             var response = new TeachingEventAddAttendee(candidate);
 
             response.CandidateId.Should().Be(candidate.Id);
+            response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
+            response.ConsiderationJourneyStageId.Should().Be(candidate.ConsiderationJourneyStageId);
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.Telephone.Should().Be(candidate.Telephone);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+
+            response.QualificationId.Should().Be(latestQualification.Id);
+            response.DegreeStatusId.Should().Be(latestQualification.DegreeStatusId);
 
             response.AlreadySubscribedToEvents.Should().BeTrue();
             response.AlreadySubscribedToMailingList.Should().BeFalse();
@@ -43,7 +65,10 @@ namespace GetIntoTeachingApiTests.Models
             {
                 EventId = Guid.NewGuid(),
                 CandidateId = Guid.NewGuid(),
+                QualificationId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
+                ConsiderationJourneyStageId = 1,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -56,6 +81,8 @@ namespace GetIntoTeachingApiTests.Models
             var candidate = request.Candidate;
 
             candidate.Id.Should().Equals(request.CandidateId);
+            candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
@@ -79,6 +106,10 @@ namespace GetIntoTeachingApiTests.Models
             candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.Event);
             candidate.TeachingEventRegistrations.First().IsCancelled.Should().BeFalse();
             candidate.TeachingEventRegistrations.First().RegistrationNotificationSeen.Should().BeFalse();
+
+            candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
+            candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);
+            candidate.Qualifications.First().Id.Should().Be(request.QualificationId);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -112,7 +112,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsTrueAndProvidesPersonalInformation_CorrectSubscription()
+        public void Candidate_SubscribeToMailingListIsTrueAndProvidesAddressPostCode_CorrectSubscription()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, AddressPostcode = "TE7 8KJ" };
 
@@ -135,11 +135,11 @@ namespace GetIntoTeachingApiTests.Models
             candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
             candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
             candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
-            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
+            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsFalseAndDoesNotProvidePersonalInformation_CorrectSubscription()
+        public void Candidate_SubscribeToMailingListIsFalseAndDoesNotProvideAddressPostCode_CorrectSubscription()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = null };
 
@@ -157,7 +157,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsTrueAndDoesNotProvidePersonalInformation_CorrectSubscription()
+        public void Candidate_SubscribeToMailingListIsTrueAndDoesNotProvideAddressPostCode_CorrectSubscription()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, AddressPostcode = null };
 

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -104,5 +104,11 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             _validator.ShouldHaveValidationErrorFor(request => request.DegreeStatusId, null as int?);
         }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, null as Guid?);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -24,13 +24,18 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
+            var mockPickListItem = new TypeEntity { Id = "123" };
+            var mockEntityReference = new TypeEntity { Id = Guid.NewGuid().ToString() };
             var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
 
             var request = new TeachingEventAddAttendee()
             {
                 CandidateId = null,
                 EventId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.Parse(mockEntityReference.Id),
                 AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
+                ConsiderationJourneyStageId = int.Parse(mockPickListItem.Id),
+                DegreeStatusId = int.Parse(mockPickListItem.Id),
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -87,6 +92,66 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_EventIdIsNull_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.EventId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_ConsiderationJourneyStageIdIsNullWhenSigningUpToMailingList_HasError()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, ConsiderationJourneyStageId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request.ConsiderationJourneyStageId);
+        }
+
+        [Fact]
+        public void Validate_ConsiderationJourneyStageIdIsNullWhenNotSigningUpToMailingList_HasNoError()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, ConsiderationJourneyStageId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request.ConsiderationJourneyStageId);
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIdIsNullWhenSigningUpToMailingList_HasError()
+        { 
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, DegreeStatusId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request.DegreeStatusId);
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIdIsNullWhenNotSigningUpToMailingList_HasNoError()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, DegreeStatusId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request.DegreeStatusId);
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNullWhenSigningUpToMailingList_HasError()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, PreferredTeachingSubjectId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId);
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNullWhenNotSigningUpToMailingList_HasNoError()
+        {
+            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, PreferredTeachingSubjectId = null };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request.PreferredTeachingSubjectId);
         }
     }
 }


### PR DESCRIPTION
- Make PreferredTeachingSubjectId required

In the client this is no longer an optional field, so this will enforce the validation in the API.

- Add additional fields to event sign up

When signing up for an event, if a candidate opts-in to the mailing list we will be asking them the 3 additional questions from the mailing list sign up:

* What stage are you at with your degree?
* How close are you to applying for teacher training?
* What subject do you want to teach?

This commit adds the corresponding fields to the `TeachingEventAddAttendee` model and makes them required if the candidate has opted-in to the mailing list.

- Changes to opt-in to event information on mailing list sign up

We no longer have an 'opt in to event information' question on the client; instead we should opt-in the user to event information if they opt-in to the mailing list and provide an address postcode.

- Use correct events subscription type

We now want to always create an event subscription when signing up to the mailing list.

The postcode is optional on the mailing list and events sign up, however if they provide a postcode then the event subscription type should be 'local', otherwise it defaults to 'single'.

---

The models for signing up for the mailing list and events are getting very similar now; it may be worth combining these in the future into a single model used for both actions.