### PR TITLE
Remove unused JsonIgnore attributes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -80,7 +79,6 @@ namespace GetIntoTeachingApi.Models
             NotAnswered = 222750001,
         }
 
-        [JsonIgnore]
         public string FullName => $"{this.FirstName} {this.LastName}";
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
@@ -114,16 +112,12 @@ namespace GetIntoTeachingApi.Models
         public int? AdviserEligibilityId { get; set; }
         [EntityField("dfe_isadvisorrequiredos", typeof(OptionSetValue))]
         public int? AdviserRequirementId { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_preferredphonenumbertype", typeof(OptionSetValue))]
         public int? PreferredPhoneNumberTypeId { get; set; } = (int)PhoneNumberType.Home;
-        [JsonIgnore]
         [EntityField("preferredcontactmethodcode", typeof(OptionSetValue))]
         public int? PreferredContactMethodId { get; set; } = (int)ContactMethod.Any;
-        [JsonIgnore]
         [EntityField("msgdpr_gdprconsent", typeof(OptionSetValue))]
         public int? GdprConsentId { get; set; } = (int)GdprConsent.Consent;
-        [JsonIgnore]
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("emailaddress1")]
@@ -160,16 +154,13 @@ namespace GetIntoTeachingApi.Models
         public bool? DoNotSendMm { get; set; }
         [EntityField("dfe_optoutsms")]
         public bool? OptOutOfSms { get; set; }
-        [JsonIgnore]
         [EntityField("msdyn_gdproptout")]
         public bool? OptOutOfGdpr { get; set; } = false;
-        [JsonIgnore]
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
 
         [EntityField("dfe_GITISTTAServiceIsSubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_GITISTTAServiceSubscriptionChannel", typeof(OptionSetValue))]
         public int? TeacherTrainingAdviserSubscriptionChannelId { get; set; }
         [EntityField("dfe_GITISTTAServiceStartDate")]
@@ -187,7 +178,6 @@ namespace GetIntoTeachingApi.Models
 
         [EntityField("dfe_GITISMailingListServiceIsSubscriber")]
         public bool? HasMailingListSubscription { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_GITISMailingListServiceSubscriptionChannel", typeof(OptionSetValue))]
         public int? MailingListSubscriptionChannelId { get; set; }
         [EntityField("dfe_GITISMailingListServiceStartDate")]
@@ -205,7 +195,6 @@ namespace GetIntoTeachingApi.Models
 
         [EntityField("dfe_GITISEventsServiceIsSubscriber")]
         public bool? HasEventsSubscription { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_GITISEventsServiceSubscriptionChannel", typeof(OptionSetValue))]
         public int? EventsSubscriptionChannelId { get; set; }
         [EntityField("dfe_GITISEventsServiceStartDate")]

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -13,16 +12,12 @@ namespace GetIntoTeachingApi.Models
 
         [EntityField("dfe_privacypolicynumber", typeof(EntityReference), "dfe_privacypolicy")]
         public Guid AcceptedPolicyId { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_consentreceivedby", typeof(OptionSetValue))]
         public int ConsentReceivedById { get; set; } = Consent;
-        [JsonIgnore]
         [EntityField("dfe_meanofconsent", typeof(OptionSetValue))]
         public int MeanOfConsentId { get; set; } = Consent;
-        [JsonIgnore]
         [EntityField("dfe_name")]
         public string Description { get; set; } = "Online consent as part of web registration";
-        [JsonIgnore]
         [EntityField("dfe_timeofconsent")]
         public DateTime AcceptedAt { get; set; } = DateTime.UtcNow;
 

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -22,24 +21,18 @@ namespace GetIntoTeachingApi.Models
 
         [EntityField("dfe_channelcreation", typeof(OptionSetValue))]
         public int? ChannelId { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_destination", typeof(OptionSetValue))]
         public int? DestinationId { get; set; }
         [EntityField("scheduledstart")]
         public DateTime ScheduledAt { get; set; }
-        [JsonIgnore]
         [EntityField("phonenumber")]
         public string Telephone { get; set; }
-        [JsonIgnore]
         [EntityField("subject")]
         public string Subject { get; set; }
-        [JsonIgnore]
         [EntityField("dfe_appointmentflag")]
         public bool IsAppointment { get; set; } = false;
-        [JsonIgnore]
         [EntityField("dfe_appointmentrequired")]
         public bool AppointmentRequired { get; set; } = false;
-        [JsonIgnore]
         [EntityField("directioncode")]
         public bool IsDirectionCode { get; set; } = true;
 


### PR DESCRIPTION
The Candidate/PhoneCall/CandidatePrivacyPolicy models are no longer directly exposed to the client (instead we return explicit response models) - we no longer need the `JsonIgnore` attributes to prevent fields from being serialized.