### PR TITLE
Revert "Temporarily disable sending data to the CRM"

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -57,8 +57,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private void SaveCandidate(Candidate candidate)
         {
-            // TODO: temporarily disabled to avoid collecting PII in a UR session.
-            // _crm.Save(candidate);
+            _crm.Save(candidate);
         }
 
         private IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -33,7 +33,6 @@ namespace GetIntoTeachingApiTests.Jobs
                 _mockContext.Object, _mockLogger.Object);
         }
 
-        /* TODO: temporarily disabled to avoid collecting PII in a UR session.
         [Fact]
         public void Run_OnSuccess_SavesCandidate()
         {
@@ -59,7 +58,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockCrm.Verify(mock => mock.Save(registration), Times.Once);
             registration.CandidateId.Should().Be(candidateId);
-        }*/
+        }
 
         [Fact]
         public void Run_OnFailure_EmailsCandidate()


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#231 - the UR testing has concluded so this can be re-enabled.