### PR TITLE
Only expose SwaggerUI on non-production environments

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -166,10 +166,13 @@ The GIT API aims to provide:
                 c.SerializeAsV2 = !env.IsDevelopment;
             });
 
-            app.UseSwaggerUI(c =>
+            if (!env.IsProduction)
             {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Get into Teaching API V1");
-            });
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Get into Teaching API V1");
+                });
+            }
 
             app.UseRouting();
 


### PR DESCRIPTION
The SwaggerUI exposes the internal IP address of the host machine, so we only want this to be accessible on non-production environments to facilitate testing.