### PR TITLE
Correct the subscription attribute names

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -165,57 +165,57 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
 
-        [EntityField("dfe_GITISTTAServiceIsSubscriber")]
+        [EntityField("dfe_gitisttaserviceissubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }
-        [EntityField("dfe_GITISTTAServiceSubscriptionChannel", typeof(OptionSetValue))]
+        [EntityField("dfe_gitisttaservicesubscriptionchannel", typeof(OptionSetValue))]
         public int? TeacherTrainingAdviserSubscriptionChannelId { get; set; }
-        [EntityField("dfe_GITISTTAServiceStartDate")]
+        [EntityField("dfe_gitisttaservicestartdate")]
         public DateTime? TeacherTrainingAdviserSubscriptionStartAt { get; set; }
-        [EntityField("dfe_GITISTTAServiceDoNotBulkEmail")]
+        [EntityField("dfe_gitisttaservicedonotbulkemail")]
         public bool? TeacherTrainingAdviserSubscriptionDoNotBulkEmail { get; set; }
-        [EntityField("dfe_GITISTTAServiceDoNotBulkPostalMail")]
+        [EntityField("dfe_gitisttaservicedonotbulkpostalmail")]
         public bool? TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail { get; set; }
-        [EntityField("dfe_GITISTTAServiceDoNotEmail")]
+        [EntityField("dfe_gitisttaservicedonotemail")]
         public bool? TeacherTrainingAdviserSubscriptionDoNotEmail { get; set; }
-        [EntityField("dfe_GITISTTAServiceDoNotPostalMail")]
+        [EntityField("dfe_gitisttaservicedonotpostalmail")]
         public bool? TeacherTrainingAdviserSubscriptionDoNotPostalMail { get; set; }
-        [EntityField("dfe_GITISTTAServiceDoNotSendMM")]
+        [EntityField("dfe_gitisttaservicedonotsendmm")]
         public bool? TeacherTrainingAdviserSubscriptionDoNotSendMm { get; set; }
 
-        [EntityField("dfe_GITISMailingListServiceIsSubscriber")]
+        [EntityField("dfe_gitismailinglistserviceissubscriber")]
         public bool? HasMailingListSubscription { get; set; }
-        [EntityField("dfe_GITISMailingListServiceSubscriptionChannel", typeof(OptionSetValue))]
+        [EntityField("dfe_gitismlservicesubscriptionchannel", typeof(OptionSetValue))]
         public int? MailingListSubscriptionChannelId { get; set; }
-        [EntityField("dfe_GITISMailingListServiceStartDate")]
+        [EntityField("dfe_gitismailinglistservicestartdate")]
         public DateTime? MailingListSubscriptionStartAt { get; set; }
-        [EntityField("dfe_GITISMailingListServiceDoNotBulkEmail")]
+        [EntityField("dfe_gitismailinglistservicedonotbulkemail")]
         public bool? MailingListSubscriptionDoNotBulkEmail { get; set; }
-        [EntityField("dfe_GITISMailingListServiceDoNotBulkPostalMail")]
+        [EntityField("dfe_gitismlservicedonotbulkpostalmail")]
         public bool? MailingListSubscriptionDoNotBulkPostalMail { get; set; }
-        [EntityField("dfe_GITISMailingListServiceDoNotEmail")]
+        [EntityField("dfe_gitismailinglistservicedonotemail")]
         public bool? MailingListSubscriptionDoNotEmail { get; set; }
-        [EntityField("dfe_GITISMailingListServiceDoNotPostalMail")]
+        [EntityField("dfe_gitismailinglistservicedonotpostalmail")]
         public bool? MailingListSubscriptionDoNotPostalMail { get; set; }
-        [EntityField("dfe_GITISMailingListServiceDoNotSendMM")]
+        [EntityField("dfe_gitismailinglistservicedonotsendmm")]
         public bool? MailingListSubscriptionDoNotSendMm { get; set; }
 
-        [EntityField("dfe_GITISEventsServiceIsSubscriber")]
+        [EntityField("dfe_gitiseventsserviceissubscriber")]
         public bool? HasEventsSubscription { get; set; }
-        [EntityField("dfe_GITISEventsServiceSubscriptionChannel", typeof(OptionSetValue))]
+        [EntityField("dfe_gitiseventsservicesubscriptionchannel", typeof(OptionSetValue))]
         public int? EventsSubscriptionChannelId { get; set; }
-        [EntityField("GITISEventsServiceSubscriptionType", typeof(OptionSetValue))]
+        [EntityField("dfe_gitiseventsservicesubscriptiontype", typeof(OptionSetValue))]
         public int? EventsSubscriptionTypeId { get; set; }
-        [EntityField("dfe_GITISEventsServiceStartDate")]
+        [EntityField("dfe_gitiseventsservicestartdate")]
         public DateTime? EventsSubscriptionStartAt { get; set; }
-        [EntityField("dfe_GITISEventsServiceDoNotBulkEmail")]
+        [EntityField("dfe_gitiseventsservicedonotbulkemail")]
         public bool? EventsSubscriptionDoNotBulkEmail { get; set; }
-        [EntityField("dfe_GITISEventsServiceDoNotBulkPostalMail")]
+        [EntityField("dfe_gitiseventsservicedonotbulkpostalmail")]
         public bool? EventsSubscriptionDoNotBulkPostalMail { get; set; }
-        [EntityField("dfe_GITISEventsServiceDoNotEmail")]
+        [EntityField("dfe_gitiseventsservicedonotemail")]
         public bool? EventsSubscriptionDoNotEmail { get; set; }
-        [EntityField("dfe_GITISEventsServiceDoNotPostalMail")]
+        [EntityField("dfe_gitiseventsservicedonotpostalmail")]
         public bool? EventsSubscriptionDoNotPostalMail { get; set; }
-        [EntityField("dfe_GITISEventsServiceDoNotSendMM")]
+        [EntityField("dfe_gitiseventsservicedonotsendmm")]
         public bool? EventsSubscriptionDoNotSendMm { get; set; }
 
         [EntityRelationship("msevtmgt_contact_msevtmgt_eventregistration_Contact", typeof(TeachingEventRegistration))]

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -87,36 +87,36 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_GITISTTAServiceSubscriptionChannel" && a.Type == typeof(OptionSetValue));
-            type.GetProperty("HasTeacherTrainingAdviserSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceIsSubscriber");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceStartDate");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceDoNotBulkEmail");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceDoNotBulkPostalMail");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceDoNotEmail");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceDoNotPostalMail");
-            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISTTAServiceDoNotSendMM");
+                a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("HasTeacherTrainingAdviserSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaserviceissubscriber");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicestartdate");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicedonotbulkemail");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicedonotbulkpostalmail");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicedonotemail");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicedonotpostalmail");
+            type.GetProperty("TeacherTrainingAdviserSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitisttaservicedonotsendmm");
 
             type.GetProperty("MailingListSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_GITISMailingListServiceSubscriptionChannel" && a.Type == typeof(OptionSetValue));
-            type.GetProperty("HasMailingListSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceIsSubscriber");
-            type.GetProperty("MailingListSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceStartDate");
-            type.GetProperty("MailingListSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceDoNotBulkEmail");
-            type.GetProperty("MailingListSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceDoNotBulkPostalMail");
-            type.GetProperty("MailingListSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceDoNotEmail");
-            type.GetProperty("MailingListSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceDoNotPostalMail");
-            type.GetProperty("MailingListSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISMailingListServiceDoNotSendMM");
+                a => a.Name == "dfe_gitismlservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("HasMailingListSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistserviceissubscriber");
+            type.GetProperty("MailingListSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistservicestartdate");
+            type.GetProperty("MailingListSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistservicedonotbulkemail");
+            type.GetProperty("MailingListSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismlservicedonotbulkpostalmail");
+            type.GetProperty("MailingListSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistservicedonotemail");
+            type.GetProperty("MailingListSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistservicedonotpostalmail");
+            type.GetProperty("MailingListSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitismailinglistservicedonotsendmm");
 
             type.GetProperty("EventsSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_GITISEventsServiceSubscriptionChannel" && a.Type == typeof(OptionSetValue));
+                a => a.Name == "dfe_gitiseventsservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));
             type.GetProperty("EventsSubscriptionTypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "GITISEventsServiceSubscriptionType" && a.Type == typeof(OptionSetValue));
-            type.GetProperty("HasEventsSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceIsSubscriber");
-            type.GetProperty("EventsSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceStartDate");
-            type.GetProperty("EventsSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotBulkEmail");
-            type.GetProperty("EventsSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotBulkPostalMail");
-            type.GetProperty("EventsSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotEmail");
-            type.GetProperty("EventsSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotPostalMail");
-            type.GetProperty("EventsSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_GITISEventsServiceDoNotSendMM");
+                a => a.Name == "dfe_gitiseventsservicesubscriptiontype" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("HasEventsSubscription").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsserviceissubscriber");
+            type.GetProperty("EventsSubscriptionStartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicestartdate");
+            type.GetProperty("EventsSubscriptionDoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicedonotbulkemail");
+            type.GetProperty("EventsSubscriptionDoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicedonotbulkpostalmail");
+            type.GetProperty("EventsSubscriptionDoNotEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicedonotemail");
+            type.GetProperty("EventsSubscriptionDoNotPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicedonotpostalmail");
+            type.GetProperty("EventsSubscriptionDoNotSendMm").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_gitiseventsservicedonotsendmm");
 
             type.GetProperty("Qualifications").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_contact_dfe_candidatequalification_ContactId" &&


### PR DESCRIPTION
The subscription attribute names for the new schema changes are incorrectly cased; this fixes the casing. It wasn't picked up when originally shipped due to the interface to the CRM being temporarily disabled for user research sessions.