### PR TITLE
Updates to PhoneCall modelling

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -48,8 +48,10 @@ namespace GetIntoTeachingApi.Jobs
             else
             {
                 var registrations = ClearTeachingEventRegistrations(candidate);
+                var phoneCall = ClearPhoneCall(candidate);
                 SaveCandidate(candidate);
                 SaveTeachingEventRegistrations(registrations, candidate);
+                SavePhoneCall(phoneCall, candidate);
 
                 _logger.LogInformation("UpsertCandidateJob - Succeeded");
             }
@@ -62,12 +64,22 @@ namespace GetIntoTeachingApi.Jobs
 
         private IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)
         {
-            // Due to reasons unknown the candidate registrations relationship can't be deep-inserted
+            // Due to reasons unknown the event registrations relationship can't be deep-inserted
             // in the same way we do for other relationships - we need to explicitly save them against
             // the candidate instead.
             var teachingEventRegistrations = new List<TeachingEventRegistration>(candidate.TeachingEventRegistrations);
             candidate.TeachingEventRegistrations.Clear();
             return teachingEventRegistrations;
+        }
+
+        private PhoneCall ClearPhoneCall(Candidate candidate)
+        {
+            // Due to reasons unknown the phone call relationship can't be deep-inserted
+            // in the same way we do for other relationships - we need to explicitly save them against
+            // the candidate instead.
+            var phoneCall = candidate.PhoneCall;
+            candidate.PhoneCall = null;
+            return phoneCall;
         }
 
         private void SaveTeachingEventRegistrations(IEnumerable<TeachingEventRegistration> registrations, Candidate candidate)
@@ -77,6 +89,17 @@ namespace GetIntoTeachingApi.Jobs
                 registration.CandidateId = (Guid)candidate.Id;
                 _crm.Save(registration);
             }
+        }
+
+        private void SavePhoneCall(PhoneCall phoneCall, Candidate candidate)
+        {
+            if (phoneCall == null)
+            {
+                return;
+            }
+
+            phoneCall.CandidateId = candidate.Id.ToString();
+            _crm.Save(phoneCall);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApi.Models
     {
         public enum Channel
         {
-            CallbackRequest = 222750000,
+            CallbackRequest = 222750003,
         }
 
         public enum Destination

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -19,6 +19,8 @@ namespace GetIntoTeachingApi.Models
             International = 222750001,
         }
 
+        [EntityField("dfe_tocontactguid")]
+        public string CandidateId { get; set; }
         [EntityField("dfe_channelcreation", typeof(OptionSetValue))]
         public int? ChannelId { get; set; }
         [EntityField("dfe_destination", typeof(OptionSetValue))]

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -61,6 +61,21 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
+        public void Run_WithPhoneCallOnSuccess_SavesPhoneCall()
+        {
+            var candidateId = Guid.NewGuid();
+            var phoneCall = new PhoneCall();
+            _candidate.PhoneCall = phoneCall;
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+            _mockCrm.Setup(mock => mock.Save(_candidate)).Callback(() => _candidate.Id = candidateId);
+
+            _job.Run(_candidate, null);
+
+            _mockCrm.Verify(mock => mock.Save(phoneCall), Times.Once);
+            phoneCall.CandidateId.Should().Be(candidateId.ToString());
+        }
+
+        [Fact]
         public void Run_OnFailure_EmailsCandidate()
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -20,6 +20,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("DestinationId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_destination" && a.Type == typeof(OptionSetValue));
 
+            type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_tocontactguid");
             type.GetProperty("ScheduledAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "scheduledstart");
             type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "phonenumber");
             type.GetProperty("Subject").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "subject");


### PR DESCRIPTION
- Update PhoneCall channel

The CRM team have requested a new channel id for callbacks.

- Persist PhoneCall in separate transaction

For an unknown reason the CRM team require a `dfe_contactguid` attribute to be set on the `PhoneCall` entity in order for it to correctly link to a `contact` record in Dynamics; this means we need to save the `PhoneCall` in a separate transaction (after persisting the `Candidate` so that we have their `id`).