### PR TITLE
Add AlreadySubscribedToTeacherTrainingAdviser to response models

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -25,6 +25,8 @@ namespace GetIntoTeachingApi.Models
         public bool AlreadySubscribedToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToMailingList { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public bool AlreadySubscribedToTeacherTrainingAdviser { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -61,6 +63,7 @@ namespace GetIntoTeachingApi.Models
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviserSubscription == true;
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -32,6 +32,8 @@ namespace GetIntoTeachingApi.Models
         public bool AlreadySubscribedToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToMailingList { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public bool AlreadySubscribedToTeacherTrainingAdviser { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -68,6 +70,7 @@ namespace GetIntoTeachingApi.Models
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviserSubscription == true;
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -38,6 +38,7 @@ namespace GetIntoTeachingApiTests.Models
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
+                HasTeacherTrainingAdviserSubscription = true,
             };
 
             var response = new MailingListAddMember(candidate);
@@ -56,6 +57,7 @@ namespace GetIntoTeachingApiTests.Models
 
             response.AlreadySubscribedToEvents.Should().BeTrue();
             response.AlreadySubscribedToMailingList.Should().BeFalse();
+            response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -38,6 +38,7 @@ namespace GetIntoTeachingApiTests.Models
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
+                HasTeacherTrainingAdviserSubscription = true,
             };
 
             var response = new TeachingEventAddAttendee(candidate);
@@ -56,6 +57,7 @@ namespace GetIntoTeachingApiTests.Models
 
             response.AlreadySubscribedToEvents.Should().BeTrue();
             response.AlreadySubscribedToMailingList.Should().BeFalse();
+            response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
We need to be able to stop the user signing up for the mailing list or event emails if they already have a TTA; this exposes the necessary values as part of the responses.