### PR TITLE
Expose ChannelId for MailingListAddMember request

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -89,6 +89,32 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
+        [Route("candidate/mailing_list_subscription_channels")]
+        [SwaggerOperation(
+    Summary = "Retrieves the list of candidate mailing list subscription channels.",
+    OperationId = "GetCandidateMailingListSubscriptionChannels",
+    Tags = new[] { "Types" })]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public async Task<IActionResult> GetCandidateMailingListSubscriptionChannels()
+        {
+            return Ok(await _store.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel").ToListAsync());
+        }
+
+        [HttpGet]
+        [CrmETag]
+        [Route("candidate/event_subscription_channels")]
+        [SwaggerOperation(
+  Summary = "Retrieves the list of candidate event subscription channels.",
+  OperationId = "GetCandidateEventSubscriptionChannels",
+  Tags = new[] { "Types" })]
+        [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
+        public async Task<IActionResult> GetCandidateEventSubscriptionChannels()
+        {
+            return Ok(await _store.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel").ToListAsync());
+        }
+
+        [HttpGet]
+        [CrmETag]
         [Route("candidate/gcse_status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate GCSE status.",

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -15,6 +15,8 @@ namespace GetIntoTeachingApi.Models
 
         public int? ConsiderationJourneyStageId { get; set; }
         public int? DegreeStatusId { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
+        public int? ChannelId { get; set; }
 
         public string Email { get; set; }
         public string FirstName { get; set; }
@@ -78,7 +80,7 @@ namespace GetIntoTeachingApi.Models
                 LastName = LastName,
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
-                ChannelId = CandidateId == null ? (int?)Candidate.Channel.MailingList : null,
+                ChannelId = CandidateId == null ? ChannelId ?? (int?)Candidate.Channel.MailingList : null,
                 OptOutOfSms = false,
                 DoNotBulkEmail = false,
                 DoNotEmail = false,
@@ -108,7 +110,7 @@ namespace GetIntoTeachingApi.Models
         private void ConfigureSubscriptions(Candidate candidate)
         {
             candidate.HasMailingListSubscription = true;
-            candidate.MailingListSubscriptionChannelId = (int)Candidate.SubscriptionChannel.MailingList;
+            candidate.MailingListSubscriptionChannelId = ChannelId ?? (int)Candidate.SubscriptionChannel.MailingList;
             candidate.MailingListSubscriptionStartAt = DateTime.UtcNow;
             candidate.MailingListSubscriptionDoNotEmail = false;
             candidate.MailingListSubscriptionDoNotBulkEmail = false;
@@ -117,7 +119,7 @@ namespace GetIntoTeachingApi.Models
             candidate.MailingListSubscriptionDoNotSendMm = false;
 
             candidate.HasEventsSubscription = true;
-            candidate.EventsSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Events;
+            candidate.EventsSubscriptionChannelId = ChannelId ?? (int)Candidate.SubscriptionChannel.Events;
             candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
             candidate.EventsSubscriptionDoNotBulkEmail = false;

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -107,6 +107,14 @@ namespace GetIntoTeachingApi.Models.Validators
                 .Must(id => AdviserRequirementIds().Contains(id.ToString()))
                 .Unless(candidate => candidate.AdviserRequirementId == null)
                 .WithMessage("Must be a valid candidate adviser requirement.");
+            RuleFor(candidate => candidate.EventsSubscriptionChannelId)
+                .Must(id => EventSubscriptionChannelIds().Contains(id.ToString()))
+                .Unless(candidate => candidate.EventsSubscriptionChannelId == null)
+                .WithMessage("Must be a valid event subscription channel.");
+            RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
+                .Must(id => MailingListSubscriptionChannelIds().Contains(id.ToString()))
+                .Unless(candidate => candidate.MailingListSubscriptionChannelId == null)
+                .WithMessage("Must be a valid mailing list subscription channel.");
         }
 
         private IEnumerable<string> PreferredTeachingSubjectIds()
@@ -132,6 +140,16 @@ namespace GetIntoTeachingApi.Models.Validators
         private IEnumerable<string> ChannelIds()
         {
             return _store.GetPickListItems("contact", "dfe_channelcreation").Select(channel => channel.Id);
+        }
+
+        private IEnumerable<string> MailingListSubscriptionChannelIds()
+        {
+            return _store.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel").Select(channel => channel.Id);
+        }
+
+        private IEnumerable<string> EventSubscriptionChannelIds()
+        {
+            return _store.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel").Select(channel => channel.Id);
         }
 
         private IEnumerable<string> GcseStatusIds()

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -194,6 +194,8 @@ namespace GetIntoTeachingApi.Services
             await SyncTypes(crm.GetPickListItems("contact", "dfe_candidatestatus"));
             await SyncTypes(crm.GetPickListItems("contact", "dfe_iscandidateeligibleforadviser"));
             await SyncTypes(crm.GetPickListItems("contact", "dfe_isadvisorrequiredos"));
+            await SyncTypes(crm.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel"));
+            await SyncTypes(crm.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel"));
             await SyncTypes(crm.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus"));
             await SyncTypes(crm.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade"));
             await SyncTypes(crm.GetPickListItems("dfe_candidatequalification", "dfe_type"));

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -103,6 +103,30 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public async void GetCandidateMailingListSubscriptionChannels_ReturnsAllChannels()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel")).Returns(mockEntities.AsAsyncQueryable());
+
+            var response = await _controller.GetCandidateMailingListSubscriptionChannels();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
+        [Fact]
+        public async void GetCandidateEventSubscriptionChannels_ReturnsAllChannels()
+        {
+            var mockEntities = MockTypeEntities();
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel")).Returns(mockEntities.AsAsyncQueryable());
+
+            var response = await _controller.GetCandidateEventSubscriptionChannels();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockEntities);
+        }
+
+        [Fact]
         public async void GetCandidateGcseStatus_ReturnsAllStatus()
         {
             var mockEntities = MockTypeEntities();

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -150,5 +150,15 @@ namespace GetIntoTeachingApiTests.Models
 
             request.Candidate.ChannelId.Should().BeNull();
         }
+
+        [Fact]
+        public void Candidate_WhenChannelIsProvided_SetsOnAllModels()
+        {
+            var request = new MailingListAddMember() { ChannelId = 123 };
+
+            request.Candidate.ChannelId.Should().Be(123);
+            request.Candidate.MailingListSubscriptionChannelId.Should().Be(123);
+            request.Candidate.EventsSubscriptionChannelId.Should().Be(123);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -45,6 +45,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
             _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_websitehasgcseenglish"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
             _mockStore
@@ -95,6 +101,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 PreferredEducationPhaseId = int.Parse(mockPickListItem.Id),
                 InitialTeacherTrainingYearId = int.Parse(mockPickListItem.Id),
                 ChannelId = int.Parse(mockPickListItem.Id),
+                MailingListSubscriptionChannelId = int.Parse(mockPickListItem.Id),
+                EventsSubscriptionChannelId = int.Parse(mockPickListItem.Id),
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
             };
 
@@ -442,6 +450,18 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_AssignmentStatusIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AssignmentStatusId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_MailingListSubscriptionChannelIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MailingListSubscriptionChannelId, 123);
+        }
+
+        [Fact]
+        public void Validate_EventSubscriptionChannelIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.EventsSubscriptionChannelId, 123);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -287,6 +287,8 @@ namespace GetIntoTeachingApiTests.Services
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_candidatestatus"));
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_iscandidateeligibleforadviser"));
             mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_isadvisorrequiredos"));
+            mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel"));
+            mockCrm.Verify(m => m.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade"));
             mockCrm.Verify(m => m.GetPickListItems("dfe_candidatequalification", "dfe_type"));


### PR DESCRIPTION
Expose ChannelId for MailingListAddMember request

We want to be able to specify the channel from the front-end for on-campus events (via a QR code and unique URL containing the channel id). This updates the `MailingListAddMember` model to allow the `ChannelId` to be specified and uses it for the candidate/mailing list/event subscription channels.

Add validation to the `Candidate` model to ensure the channel ids are valid according to the CRM.