### PR TITLE
Only create event subscription if postcode is provided

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -118,7 +118,13 @@ namespace GetIntoTeachingApi.Models
             candidate.MailingListSubscriptionDoNotPostalMail = true;
             candidate.MailingListSubscriptionDoNotSendMm = false;
 
+            if (string.IsNullOrWhiteSpace(AddressPostcode))
+            {
+                return;
+            }
+
             candidate.HasEventsSubscription = true;
+            candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
             candidate.EventsSubscriptionChannelId = ChannelId ?? (int)Candidate.SubscriptionChannel.Events;
             candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
@@ -126,15 +132,6 @@ namespace GetIntoTeachingApi.Models
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
             candidate.EventsSubscriptionDoNotPostalMail = true;
             candidate.EventsSubscriptionDoNotSendMm = false;
-
-            if (string.IsNullOrWhiteSpace(AddressPostcode))
-            {
-                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
-            }
-            else
-            {
-                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
-            }
         }
 
         private void AcceptPrivacyPolicy(Candidate candidate)

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -125,14 +125,14 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_AddressPostcodeNotProvided_EventsSubscriptionTypeIsSingleEvent()
+        public void Candidate_AddressPostcodeNotProvided_EventsSubscriptionIsNotCreated()
         {
             var request = new MailingListAddMember()
             {
                 AddressPostcode = null,
             };
 
-            request.Candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
+            request.Candidate.HasEventsSubscription.Should().BeNull();
         }
 
         [Fact]
@@ -154,7 +154,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_WhenChannelIsProvided_SetsOnAllModels()
         {
-            var request = new MailingListAddMember() { ChannelId = 123 };
+            var request = new MailingListAddMember() { ChannelId = 123, AddressPostcode = "TE7 8KE" };
 
             request.Candidate.ChannelId.Should().Be(123);
             request.Candidate.MailingListSubscriptionChannelId.Should().Be(123);


### PR DESCRIPTION
When signing up for the mailing list we only want to opt the candidate into an event subscription if their postcode was provided.