### PR TITLE
Add legacy support for HasTeacherTrainingAdviser check

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -11,6 +11,8 @@ namespace GetIntoTeachingApi.Models
     [Entity("contact")]
     public class Candidate : BaseModel
     {
+        public static readonly Guid AdviserBusinessUnitId = new Guid("1A61F629-F502-E911-A972-000D3A23443B");
+
         public enum Status
         {
             Active,
@@ -90,6 +92,8 @@ namespace GetIntoTeachingApi.Models
         public Guid? PreferredTeachingSubjectId { get; set; }
         [EntityField("dfe_country", typeof(EntityReference), "dfe_country")]
         public Guid? CountryId { get; set; }
+        [EntityField("owningbusinessunit", typeof(EntityReference), "businessunit")]
+        public Guid? OwningBusinessUnitId { get; set; }
         [EntityField("dfe_preferrededucationphase01", typeof(OptionSetValue))]
         public int? PreferredEducationPhaseId { get; set; }
         [EntityField("dfe_ittyear", typeof(OptionSetValue))]
@@ -239,6 +243,11 @@ namespace GetIntoTeachingApi.Models
         public Candidate(Entity entity, ICrmService crm)
             : base(entity, crm)
         {
+        }
+
+        public bool HasTeacherTrainingAdviser()
+        {
+            return HasTeacherTrainingAdviserSubscription == true || OwningBusinessUnitId == AdviserBusinessUnitId;
         }
 
         public bool IsReturningToTeaching()

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApi.Models
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
-            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviserSubscription == true;
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -86,7 +86,7 @@ namespace GetIntoTeachingApi.Models
             AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
 
-            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviserSubscription == true;
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
 
             var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
 

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -70,7 +70,7 @@ namespace GetIntoTeachingApi.Models
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
-            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviserSubscription == true;
+            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -26,6 +26,9 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("CountryId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_country" && a.Type == typeof(EntityReference) &&
                      a.Reference == "dfe_country");
+            type.GetProperty("OwningBusinessUnitId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "owningbusinessunit" && a.Type == typeof(EntityReference) &&
+                     a.Reference == "businessunit");
 
             type.GetProperty("PreferredEducationPhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_preferrededucationphase01" && a.Type == typeof(OptionSetValue));
@@ -129,6 +132,33 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("PrivacyPolicy").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_contact_dfe_candidateprivacypolicy_Candidate" &&
                      a.Type == typeof(CandidatePrivacyPolicy));
+        }
+
+        [Theory]
+        [InlineData(true, null, true)]
+        [InlineData(null, "1A61F629-F502-E911-A972-000D3A23443B", true)]
+        [InlineData(true, "1A61F629-F502-E911-A972-000D3A23443B", true)]
+        [InlineData(false, "1A61F629-F502-E911-A972-000D3A23443B", true)]
+        [InlineData(true, "2A61F629-F502-E911-A972-000D3A23443C", true)]
+        [InlineData(false, null, false)]
+        [InlineData(false, "2A61F629-F502-E911-A972-000D3A23443C", false)]
+        [InlineData(null, "2A61F629-F502-E911-A972-000D3A23443C", false)]
+        [InlineData(null, null, false)]
+        public void HasTeacherTrainingAdviser_WithSubscription_ReturnsCorrectly(bool? hasSubscription, string owningBusinessUnitId, bool expectedOutcome)
+        {
+            Guid? id = null;
+            
+            if (owningBusinessUnitId != null)
+            {
+                id = new Guid(owningBusinessUnitId);
+            }
+
+            var candidate = new Candidate() { 
+                HasTeacherTrainingAdviserSubscription = hasSubscription, 
+                OwningBusinessUnitId = id,
+            };
+
+            candidate.HasTeacherTrainingAdviser().Should().Be(expectedOutcome);
         }
 
         [Fact]


### PR DESCRIPTION
If a candidate has already been assigned a teacher training adviser as part of the current/legacy system we don't want them to be able to sign up for a TTA again. We determine this by ensuring that their `contact.owningbusinessunit` is not `1A61F629-F502-E911-A972-000D3A23443B` (a TTA).