### PR TITLE
Simplify PhoneCall mapping

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -277,9 +277,6 @@ namespace GetIntoTeachingApi.Models
 
             switch (propertyName)
             {
-                case "PhoneCall":
-                    value.PopulateWithCandidate(this);
-                    return true;
                 case "PrivacyPolicy" when Id != null:
                     return crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId);
                 default:

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -47,11 +47,5 @@ namespace GetIntoTeachingApi.Models
             : base(entity, crm)
         {
         }
-
-        public void PopulateWithCandidate(Candidate candidate)
-        {
-            Telephone = candidate.Telephone;
-            Subject = $"Scheduled phone call requested by {candidate.FullName}";
-        }
     }
 }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -197,6 +197,7 @@ namespace GetIntoTeachingApi.Models
                     DestinationId = DestinationForTelephone(Telephone),
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.CallbackRequest,
+                    Subject = $"Scheduled phone call requested by {candidate.FullName}",
                 };
             }
         }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -229,32 +229,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void ToEntity_WithPhoneCall_PopulatesFromCandidate()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var candidate = new Candidate()
-            {
-                FirstName = "John",
-                LastName = "Doe",
-                Telephone = "123456789",
-                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.UtcNow }
-            };
-
-            var phoneCallEntity = new Entity("phonecall");
-
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(new Entity("contact"));
-            mockCrm.Setup(m => m.MappableEntity("phonecall", null, context)).Returns(phoneCallEntity);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            phoneCallEntity.GetAttributeValue<string>("phonenumber").Should().Be(candidate.Telephone);
-            phoneCallEntity.GetAttributeValue<string>("subject").Should().Be("Scheduled phone call requested by John Doe");
-        }
-
-        [Fact]
         public void ToEntity_WithNullId_SetsIsNewRegistrantToTrue()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -30,18 +30,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void PopulateWithCandidate_SetsTelephoneAndSubject()
-        {
-            var phoneCall = new PhoneCall();
-            var candidate = new Candidate() { FirstName = "John", LastName = "Doe", Telephone = "123456789" };
-
-            phoneCall.PopulateWithCandidate(candidate);
-
-            phoneCall.Telephone.Should().Be(candidate.Telephone);
-            phoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
-        }
-
-        [Fact]
         public void IsAppointment_DefaultValue_IsCorrect()
         {
             new PhoneCall().IsAppointment.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -181,6 +181,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PhoneCall.Telephone.Should().Be(request.Telephone);
             candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
             candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
+            candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
 
             candidate.PastTeachingPositions.First().Id.Should().Be(request.PastTeachingPositionId);
             candidate.PastTeachingPositions.First().SubjectTaughtId.Should().Be(request.SubjectTaughtId);


### PR DESCRIPTION
Instead of doing it as a pre-map hook on the `Candidate` model we can move the logic into the request model and simplify things.