### PR TITLE
Increment CallbackBookingQuota NumberOfBookings when creating PhoneCall

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -52,6 +52,7 @@ namespace GetIntoTeachingApi.Jobs
                 SaveCandidate(candidate);
                 SaveTeachingEventRegistrations(registrations, candidate);
                 SavePhoneCall(phoneCall, candidate);
+                IncrementCallbackBookingQuotaNumberOfBookings(phoneCall);
 
                 _logger.LogInformation("UpsertCandidateJob - Succeeded");
             }
@@ -89,6 +90,25 @@ namespace GetIntoTeachingApi.Jobs
                 registration.CandidateId = (Guid)candidate.Id;
                 _crm.Save(registration);
             }
+        }
+
+        private void IncrementCallbackBookingQuotaNumberOfBookings(PhoneCall phoneCall)
+        {
+            if (phoneCall == null)
+            {
+                return;
+            }
+
+            var quota = _crm.GetCallbackBookingQuota(phoneCall.ScheduledAt);
+
+            if (quota == null || !quota.IsAvailable)
+            {
+                return;
+            }
+
+            quota.NumberOfBookings += 1;
+
+            _crm.Save(quota);
         }
 
         private void SavePhoneCall(PhoneCall phoneCall, Candidate candidate)

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -45,7 +45,15 @@ namespace GetIntoTeachingApi.Services
                 .OrderBy((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime"))
                 .Select((entity) => new CallbackBookingQuota(entity, this))
                 .ToList()
-                .Where((quota) => quota.NumberOfBookings < quota.Quota); // Doing this in the Dynamics query throws an exception, though I'm not sure why.
+                .Where((quota) => quota.IsAvailable); // Doing this in the Dynamics query throws an exception, though I'm not sure why.
+        }
+
+        public CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt)
+        {
+            return _service.CreateQuery("dfe_callbackbookingquota", Context())
+                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") == scheduledAt)
+                .Select((entity) => new CallbackBookingQuota(entity, this))
+                .FirstOrDefault();
         }
 
         public IEnumerable<PrivacyPolicy> GetPrivacyPolicies()

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApi.Services
         Candidate GetCandidate(Guid id);
         IEnumerable<TeachingEvent> GetTeachingEvents();
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
+        CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -124,6 +124,20 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void GetCallbackBookingQuota_ReturnsQuotaMatchingScheduledAt()
+        {
+            var queryableQuotas = MockCallbackBookingQuotas();
+            _mockService.Setup(mock => mock.CreateQuery("dfe_callbackbookingquota", _context))
+                .Returns(queryableQuotas);
+            var quota = queryableQuotas.ToArray()[3];
+            var startAt = quota.GetAttributeValue<DateTime>("dfe_starttime");
+
+            var result = _crm.GetCallbackBookingQuota(startAt);
+
+            result.StartAt.Should().Be(startAt);
+        }
+
+        [Fact]
         public void GetPrivacyPolicies_Returns3MostRecentActiveWebPrivacyPolicies()
         {
             var queryablePrivacyPolicies = MockPrivacyPolicies();


### PR DESCRIPTION
When we create a `PhoneCall` entity we need to find the applicable `CallbackBookingQuota` (if one exists) and increment the `NumberOfBookings` so that the quota will no longer be available once full.