### PR TITLE
Prevent scheduled callbacks for overseas candidates

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -284,13 +284,11 @@ namespace GetIntoTeachingApi.Models
                 return false;
             }
 
-            switch (propertyName)
+            return propertyName switch
             {
-                case "PrivacyPolicy" when Id != null:
-                    return crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId);
-                default:
-                    return true;
-            }
+                "PrivacyPolicy" when Id != null => crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId),
+                _ => true,
+            };
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
 using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
@@ -7,6 +8,8 @@ namespace GetIntoTeachingApi.Models
 {
     public class TypeEntity
     {
+        public static readonly Guid UnitedKingdomCountryId = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2");
+
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public string Id { get; set; }
         public string Value { get; set; }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using GetIntoTeachingApi.Services;
@@ -18,12 +17,11 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.CountryId).NotNull();
             RuleFor(request => request.PreferredEducationPhaseId).NotNull();
 
-            var unitedKingdomCountryGuid = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2");
-            RuleFor(request => request.AddressLine1).NotEmpty().Unless(request => request.CountryId != unitedKingdomCountryGuid)
+            RuleFor(request => request.AddressLine1).NotEmpty().Unless(request => request.CountryId != TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set candidate in the UK.");
-            RuleFor(request => request.AddressCity).NotEmpty().Unless(request => request.CountryId != unitedKingdomCountryGuid)
+            RuleFor(request => request.AddressCity).NotEmpty().Unless(request => request.CountryId != TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set candidate in the UK.");
-            RuleFor(request => request.AddressPostcode).NotEmpty().Unless(request => request.CountryId != unitedKingdomCountryGuid)
+            RuleFor(request => request.AddressPostcode).NotEmpty().Unless(request => request.CountryId != TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set candidate in the UK.");
 
             RuleFor(request => request.Telephone).NotEmpty()
@@ -31,8 +29,11 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be set to schedule a callback.");
 
             RuleFor(request => request.PhoneCallScheduledAt).NotNull()
-                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent && request.CountryId == TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set for candidate with UK equivalent degree.");
+            RuleFor(request => request.PhoneCallScheduledAt).Null()
+                .When(request => request.CountryId != TypeEntity.UnitedKingdomCountryId)
+                .WithMessage("Cannot be set for overseas candidates.");
 
             RuleFor(request => request.InitialTeacherTrainingYearId).NotNull()
                 .Unless(request => request.Candidate.IsReturningToTeaching())

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -28,6 +28,10 @@ namespace GetIntoTeachingApi.Models.Validators
                 .When(request => request.PhoneCallScheduledAt != null)
                 .WithMessage("Must be set to schedule a callback.");
 
+            RuleFor(request => request.Telephone).NotEmpty()
+                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .WithMessage("Must be set for candidates with an equivalent degree.");
+
             RuleFor(request => request.PhoneCallScheduledAt).NotNull()
                 .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent && request.CountryId == TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set for candidate with UK equivalent degree.");

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 SubjectTaughtId = Guid.NewGuid(),
                 PastTeachingPositionId = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.NewGuid(),
-                CountryId = Guid.NewGuid(),
+                CountryId = TypeEntity.UnitedKingdomCountryId,
                 UkDegreeGradeId = 1,
                 DegreeStatusId = 2,
                 InitialTeacherTrainingYearId = 3,
@@ -123,7 +123,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                CountryId = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2"),
+                CountryId = TypeEntity.UnitedKingdomCountryId,
                 AddressLine1 = null,
                 AddressCity = null,
                 AddressPostcode = null,
@@ -159,7 +159,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                CountryId = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2"),
+                CountryId = TypeEntity.UnitedKingdomCountryId,
                 AddressLine1 = "Line 1",
                 AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
@@ -201,11 +201,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_DegreeTypeIsEquivalentAndPhoneCallScheduledAtIsNull_HasError()
+        public void Validate_DegreeTypeIsEquivalentAndCountryIsUkAndPhoneCallScheduledAtIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                CountryId = TypeEntity.UnitedKingdomCountryId,
                 PhoneCallScheduledAt = null,
             };
 
@@ -215,11 +216,26 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_DegreeTypeIsEquivalentAndPhoneCallScheduledAtIsNotNull_HasNoError()
+        public void Validate_CountryIsNotUkAndPhoneCallScheduledAtIsNotNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                CountryId = Guid.NewGuid(),
+                PhoneCallScheduledAt = DateTime.UtcNow,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Cannot be set for overseas candidates.");
+        }
+
+        [Fact]
+        public void Validate_DegreeTypeIsEquivalentAndCountryIsUkAndPhoneCallScheduledAtIsNotNull_HasNorror()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                CountryId = TypeEntity.UnitedKingdomCountryId,
                 PhoneCallScheduledAt = DateTime.UtcNow,
             };
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -187,6 +187,20 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_DegreeTypeIdIsEquivalentAndTelephoneIsNull_HasError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                Telephone = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("Telephone").WithErrorMessage("Must be set for candidates with an equivalent degree.");
+        }
+
+        [Fact]
         public void Validate_PhoneCallScheduledAtIsPresentAndTelephoneIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp


### PR DESCRIPTION
TPUK do not currently have the provision to make outbound overseas telephone calls. The adviser service is being updated to remove the callback booking step from the wizard and this change will make sure the validation allows overseas candidates to register with an equivalent degree and no scheduled callback.