### PR TITLE
Disable caching on event search results

### DIFF
--- a/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
@@ -87,7 +87,7 @@ namespace GetIntoTeachingApi.Filters
             var recurringJob = connection.GetAllEntriesFromHash(
                 $"recurring-job:{JobConfiguration.CrmSyncJobId}");
 
-            return recurringJob?["NextExecution"];
+            return recurringJob?["LastExecution"];
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -34,7 +34,6 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
-        [CrmETag]
         [Route("search")]
         [SwaggerOperation(
             Summary = "Searches for teaching events.",

--- a/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
@@ -123,7 +123,7 @@ namespace GetIntoTeachingApiTests.Filters
         public void OnActionExecuting_AfterCrmSyncJobHasRan_RespondsWithNewETag()
         {
             const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
-            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            var jobDetails = new Dictionary<string, string>() { { "LastExecution", "2020-01-01 19:52:44" } };
             _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
                 $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
             _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns<string>(null);
@@ -141,7 +141,7 @@ namespace GetIntoTeachingApiTests.Filters
         public void OnActionExecuting_WithMatchingIfNoneMatch_Responds304NotModified()
         {
             const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
-            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            var jobDetails = new Dictionary<string, string>() { { "LastExecution", "2020-01-01 19:52:44" } };
             _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
                 $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
             _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns(eTag);
@@ -161,7 +161,7 @@ namespace GetIntoTeachingApiTests.Filters
         public void OnActionExecuting_WithDifferentIfNoneMatch_RespondsWithResultAndETag()
         {
             const string eTag = "03AC2E21CC0F0298899728A7648684A16B08DF1EA22AAD296AC916B50D6A9FE1";
-            var jobDetails = new Dictionary<string, string>() { { "NextExecution", "2020-01-01 19:52:44" } };
+            var jobDetails = new Dictionary<string, string>() { { "LastExecution", "2020-01-01 19:52:44" } };
             _mockStorageConnection.Setup(m => m.GetAllEntriesFromHash(
                 $"recurring-job:{JobConfiguration.CrmSyncJobId}")).Returns(jobDetails);
             _mockHttpContext.Setup(m => m.Request.Headers["If-None-Match"]).Returns("wrong-etag");

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -47,7 +47,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new [] { "Get", "Search" };
+            var methods = new [] { "Get" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }


### PR DESCRIPTION
- Use LastExecutionTime to clear ETag cache

At the moment we use `NextExecutionTime`; the problem with this is that it doesn't change when we manually trigger a `CrmSyncJob` to run. If we use `LastExecutionTime` then the cache will be cleared after a manual trigger as well as the scheduled job runs.

- Disable ETag caching on Teaching Event search

There is odd behaviour in the hosted environments around search results not always returning correctly. The only difference I can think of with the development environment is that caching is disabled (although I've tested with it enabled in dev and it does seem to behave).

Disable caching in hosted environments to see if that clears up the unexpected results; if it does we can investigate further and then re-enable caching.