### PR TITLE
Remove approximate distance filtering

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -34,6 +34,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [CrmETag]
         [Route("search")]
         [SwaggerOperation(
             Summary = "Searches for teaching events.",

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -15,11 +15,6 @@ namespace GetIntoTeachingApi.Services
 {
     public class Store : IStore
     {
-        private const double EarthCircumferenceInKm = 40075.017;
-
-        // We get a 16km error when approximating the distance between postcodes for
-        // John O'Groats and Lands End.
-        private const double ErrorMarginInKm = 25;
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;
 
@@ -128,10 +123,6 @@ namespace GetIntoTeachingApi.Services
 
             // Exclude events we don't have a location for.
             teachingEvents = teachingEvents.Where(te => te.Building != null && te.Building.Coordinate != null);
-
-            // Approximate distance filtering in the database, with a suitable error margin (treats distance as an arc degree).
-            teachingEvents = teachingEvents.Where(te => EarthCircumferenceInKm *
-                te.Building.Coordinate.Distance(origin) / 360 < request.RadiusInKm() + ErrorMarginInKm);
 
             var inMemoryTeachingEvents = await teachingEvents.ToListAsync();
 

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -9,7 +9,6 @@ using GetIntoTeachingApi.Models;
 using Moq;
 using Microsoft.AspNetCore.Mvc;
 using GetIntoTeachingApi.Services;
-using GetIntoTeachingApiTests.Helpers;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
@@ -47,7 +46,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new [] { "Get" };
+            var methods = new [] { "Get", "Search" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }


### PR DESCRIPTION
- Remove approximate distance filtering

The logic here isn't correct; it's not filtering accurately - removing for now so that the search will be accurate and we can investigate and re-introduce later (there aren't many events in the system in general so there shouldn't be a noticeable performance hit for doing this in-memory).

- Re-introduce etag cache on Teaching Event search

The cache wasn't the culprit of the buggy behaviour that was being investigated, so it should be safe to re-enable.