### PR TITLE
Switch readable id to new field

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApi.Models
         public int TypeId { get; set; }
         [EntityField("dfe_eventstatus", typeof(OptionSetValue))]
         public int StatusId { get; set; }
-        [EntityField("msevtmgt_readableeventid")]
+        [EntityField("dfe_websiteeventpartialurl")]
         public string ReadableId { get; set; }
         [EntityField("dfe_eventwebfeedid")]
         [SwaggerSchema("If set, the API will accept new attendees for " +

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -173,8 +173,9 @@ namespace GetIntoTeachingApi.Services
             var futureDatedCondition = new ConditionExpression("msevtmgt_eventenddate", ConditionOperator.GreaterThan, DateTime.UtcNow);
             var types = Enum.GetValues(typeof(TeachingEvent.EventType)).Cast<int>().ToArray();
             var typeCondition = new ConditionExpression("dfe_event_type", ConditionOperator.In, types);
+            var readableIdCondition = new ConditionExpression("dfe_websiteeventpartialurl", ConditionOperator.NotNull);
             var filter = new FilterExpression(LogicalOperator.And);
-            filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition, typeCondition });
+            filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition, typeCondition, readableIdCondition });
             query.Criteria.AddFilter(filter);
 
             var link = query.AddLink("msevtmgt_building", "msevtmgt_building", "msevtmgt_buildingid", JoinOperator.LeftOuter);

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_eventstatus" && a.Type == typeof(OptionSetValue));
 
-            type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_readableeventid");
+            type.GetProperty("ReadableId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websiteeventpartialurl");
             type.GetProperty("WebFeedId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventwebfeedid");
             type.GetProperty("IsOnline").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_isonlineevent");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -105,8 +105,10 @@ namespace GetIntoTeachingApiTests.Services
             };
             var hasTypeCondition = conditions.Where(c => c.AttributeName == "dfe_event_type" &&
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(types)).Any();
+            var hasReadabaleIdCondition = conditions.Where(c => c.AttributeName == "dfe_websiteeventpartialurl" &&
+                c.Operator == ConditionOperator.NotNull).Any();
 
-            return hasEntityName && hasStatusCondition && hasFutureDatedCondition && hasTypeCondition;
+            return hasEntityName && hasStatusCondition && hasFutureDatedCondition && hasTypeCondition && hasReadabaleIdCondition;
         }
 
         [Fact]


### PR DESCRIPTION
Instead of using the built-in Dynamics event readable id, the CRM team are going to populate a new field with a readable id that matches the current GiT website.

If the new field is not populated we do not want to show the event.