### PR TITLE
Setting Timeout on API Statuscake

### DIFF
--- a/terraform/statuscake/resources.tf
+++ b/terraform/statuscake/resources.tf
@@ -10,4 +10,5 @@ resource statuscake_test alert {
   custom_header = each.value.custom_header
   status_codes  = each.value.status_codes
   test_tags     = [ "GIT" , "BETA" ]
+  timeout       = each.value.timeout
 }

--- a/terraform/statuscake/test.env.tfvars
+++ b/terraform/statuscake/test.env.tfvars
@@ -6,6 +6,7 @@ ftt = {
     check_rate    = 60
     contact_group = [185037]
     trigger_rate  = 0
+    timeout       = 60
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }
@@ -16,6 +17,7 @@ ptt = {
     check_rate    = 60
     contact_group = [185037]
     trigger_rate  = 0
+    timeout       = 60
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }

--- a/terraform/statuscake/test.env.tfvars
+++ b/terraform/statuscake/test.env.tfvars
@@ -1,5 +1,5 @@
 alerts =  {
-ftt = {
+GIT_API_TEST_HEALTHCHECK = {
     website_name = "Get Teacher Training API (Test Space)"
     website_url   = "https://get-into-teaching-api-test.london.cloudapps.digital/api/operations/health_check"
     test_type     = "HTTP"
@@ -10,7 +10,7 @@ ftt = {
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }
-ptt = {
+GIT_API_PROD_HEALTHCHECK = {
     website_name = "Get Teacher Training API (Production Space)"
     website_url   = "https://get-into-teaching-api-prod.london.cloudapps.digital/api/operations/health_check"
     test_type     = "HTTP"


### PR DESCRIPTION
Statuscake is warning that the API is down, when it is more likely that the Healthcheck can take longer than the timeout, which is set to 40 seconds.
This can be overridden so moving it to 60 seconds