### PR TITLE
Log request/response with payloads

### DIFF
--- a/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CrmETagAttribute.cs
@@ -9,7 +9,7 @@ using Hangfire;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace GetIntoTeachingApi.Filters
+namespace GetIntoTeachingApi.Attributes
 {
     public class CrmETagAttribute : Attribute, IActionFilter
     {

--- a/GetIntoTeachingApi/Attributes/LogRequestsAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/LogRequestsAttribute.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class LogRequestsAttribute : Attribute, IActionFilter
+    {
+        private readonly ILogger<LogRequestsAttribute> _logger;
+
+        public LogRequestsAttribute()
+        {
+            var factory = LoggerFactory.Create(builder => builder.AddConsole());
+            _logger = factory.CreateLogger<LogRequestsAttribute>();
+        }
+
+        public LogRequestsAttribute(ILogger<LogRequestsAttribute> logger)
+        {
+            _logger = logger;
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var descriptor = (ControllerActionDescriptor)context.ActionDescriptor;
+
+            var messages = context.ActionArguments.Select(a => LogMessageForObject(a.Value));
+            var message = LogMessage("Request", descriptor, messages);
+            _logger.LogInformation(message);
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.Result is ObjectResult result)
+            {
+                var descriptor = (ControllerActionDescriptor)context.ActionDescriptor;
+                var messages = new List<string> { LogMessageForObject(result.Value) };
+                var message = LogMessage("Response", descriptor, messages);
+                _logger.LogInformation(message);
+            }
+        }
+
+        private static string LogMessage(string type, ControllerActionDescriptor descriptor, IEnumerable<string> messages)
+        {
+            var actionName = descriptor.ActionName;
+            var controllerName = descriptor.ControllerName;
+            var payload = string.Join("\n", messages.Where(m => !string.IsNullOrEmpty(m)));
+
+            return $"{type} {controllerName}:{actionName} - {payload}";
+        }
+
+        private static string LogMessageForObject(object obj)
+        {
+            var type = obj.GetType().GetGenericArguments().FirstOrDefault();
+
+            if (type == null)
+            {
+                type = obj.GetType();
+            }
+
+            if (type.GetCustomAttribute<LoggableAttribute>() == null)
+            {
+                return null;
+            }
+
+            return JsonConvert.SerializeObject(
+                obj,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new FilterSensitiveDataContractResolver(),
+                });
+        }
+
+        private class FilterSensitiveDataContractResolver : DefaultContractResolver
+        {
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                var property = base.CreateProperty(member, memberSerialization);
+
+                property.ShouldSerialize = instance =>
+                    instance.GetType().GetCustomAttribute<LoggableAttribute>() != null &&
+                    member.GetCustomAttribute<SensitiveDataAttribute>() == null &&
+                    member.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() == null;
+
+                return property;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Attributes/LoggableAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/LoggableAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class LoggableAttribute : Attribute
+    {
+    }
+}

--- a/GetIntoTeachingApi/Attributes/SensitiveDataAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/SensitiveDataAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class SensitiveDataAttribute : Attribute
+    {
+    }
+}

--- a/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
+++ b/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -9,6 +10,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/callback_booking_quotas")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class CallbackBookingQuotasController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -9,6 +10,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/candidates")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class CandidatesController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -11,6 +12,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/mailing_list")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class MailingListController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/operations")]
     [ApiController]
+    [LogRequests]
     public class OperationsController : ControllerBase
     {
         private readonly IStore _store;

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using GetIntoTeachingApi.Filters;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -11,6 +11,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/privacy_policies")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class PrivacyPoliciesController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -11,6 +12,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
 {
     [Route("api/teacher_training_adviser/candidates")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class CandidatesController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using GetIntoTeachingApi.Filters;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/teaching_events")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class TeachingEventsController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using GetIntoTeachingApi.Filters;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/types")]
     [ApiController]
+    [LogRequests]
     [Authorize]
     public class TypesController : ControllerBase
     {

--- a/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
+++ b/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
@@ -5,6 +5,7 @@ using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     [Entity("dfe_callbackbookingquota")]
     public class CallbackBookingQuota : BaseModel
     {

--- a/GetIntoTeachingApi/Models/HealthCheckResponse.cs
+++ b/GetIntoTeachingApi/Models/HealthCheckResponse.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class HealthCheckResponse
     {
         public const string StatusOk = "ok";

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class MailingListAddMember
     {
         public Guid? CandidateId { get; set; }
@@ -18,10 +20,15 @@ namespace GetIntoTeachingApi.Models
         [SwaggerSchema(WriteOnly = true)]
         public int? ChannelId { get; set; }
 
+        [SensitiveData]
         public string Email { get; set; }
+        [SensitiveData]
         public string FirstName { get; set; }
+        [SensitiveData]
         public string LastName { get; set; }
+        [SensitiveData]
         public string AddressPostcode { get; set; }
+        [SensitiveData]
         public string Telephone { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToEvents { get; set; }

--- a/GetIntoTeachingApi/Models/MappingInfo.cs
+++ b/GetIntoTeachingApi/Models/MappingInfo.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class MappingInfo
     {
         private readonly Type _type;

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class TeacherTrainingAdviserSignUp
     {
         public Guid? CandidateId { get; set; }
@@ -25,17 +27,26 @@ namespace GetIntoTeachingApi.Models
         public int? PlanningToRetakeGcseMathsAndEnglishId { get; set; }
         public int? PlanningToRetakeGcseScienceId { get; set; }
 
+        [SensitiveData]
         public string Email { get; set; }
+        [SensitiveData]
         public string FirstName { get; set; }
+        [SensitiveData]
         public string LastName { get; set; }
         [SwaggerSchema(Format = "date")]
+        [SensitiveData]
         public DateTime? DateOfBirth { get; set; }
+        [SensitiveData]
         public string TeacherId { get; set; }
         public string DegreeSubject { get; set; }
+        [SensitiveData]
         public string Telephone { get; set; }
+        [SensitiveData]
         public string AddressLine1 { get; set; }
+        [SensitiveData]
         public string AddressLine2 { get; set; }
         public string AddressCity { get; set; }
+        [SensitiveData]
         public string AddressPostcode { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public DateTime? PhoneCallScheduledAt { get; set; }

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -7,6 +7,7 @@ using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     [Entity("msevtmgt_event")]
     public class TeachingEvent : BaseModel
     {

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class TeachingEventAddAttendee
     {
         public Guid? CandidateId { get; set; }
@@ -19,10 +21,15 @@ namespace GetIntoTeachingApi.Models
         public int? ConsiderationJourneyStageId { get; set; }
         public int? DegreeStatusId { get; set; }
 
+        [SensitiveData]
         public string Email { get; set; }
+        [SensitiveData]
         public string FirstName { get; set; }
+        [SensitiveData]
         public string LastName { get; set; }
+        [SensitiveData]
         public string AddressPostcode { get; set; }
+        [SensitiveData]
         public string Telephone { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool SubscribeToEvents => AddressPostcode != null && SubscribeToMailingList;

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -8,6 +8,7 @@ using NetTopologySuite.Geometries;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     [Entity("msevtmgt_building")]
     public class TeachingEventBuilding : BaseModel
     {

--- a/GetIntoTeachingApi/Models/TeachingEventSearchRequest.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventSearchRequest.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using GetIntoTeachingApi.Attributes;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class TeachingEventSearchRequest : ICloneable
     {
         [SwaggerSchema("Postcode to center search around.")]

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
 using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [Loggable]
     public class TypeEntity
     {
         public static readonly Guid UnitedKingdomCountryId = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2");

--- a/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/CrmETagAttributeTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using FluentAssertions;
-using GetIntoTeachingApi.Filters;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;

--- a/GetIntoTeachingApiTests/Attributes/LogRequestsAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/LogRequestsAttributeTests.cs
@@ -1,0 +1,175 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Filters
+{
+    public class LogRequestsAttributeTests
+    {
+        private readonly LogRequestsAttribute _filter;
+        private readonly ActionExecutingContext _actionExecutingContext;
+        private readonly ActionExecutedContext _actionExecutedContext;
+        private readonly Mock<ILogger<LogRequestsAttribute>> _mockLogger;
+
+        public LogRequestsAttributeTests()
+        {
+            var actionContext = new ActionContext(
+                Mock.Of<HttpContext>(),
+                Mock.Of<RouteData>(),
+                Mock.Of<ActionDescriptor>(),
+                new ModelStateDictionary()
+            )
+            {
+                ActionDescriptor = new ControllerActionDescriptor()
+                {
+                    ActionName = "Action",
+                    ControllerName = "Controller"
+                }
+            };
+
+            _actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                Mock.Of<Controller>()
+            );
+
+            _actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                Mock.Of<Controller>()
+            );
+
+            _mockLogger = new Mock<ILogger<LogRequestsAttribute>>();
+
+            _filter = new LogRequestsAttribute(_mockLogger.Object);
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithLoggable_LogsTheRequestWithPayload()
+        {
+            _actionExecutingContext.ActionArguments.Add("person", new StubLoggable());
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Request Controller:Action - {\"Name\":\"Ross\"}");
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithMultipleArgumentsOfLoggable_LogsTheRequestWithPayloads()
+        {
+            _actionExecutingContext.ActionArguments.Add("person1", new StubLoggable("Ross"));
+            _actionExecutingContext.ActionArguments.Add("person2", new StubLoggable("James"));
+            _actionExecutingContext.ActionArguments.Add("person3", new StubUnloggable());
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Request Controller:Action - {\"Name\":\"Ross\"}\n{\"Name\":\"James\"}");
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithArrayOfLoggable_LogsTheRequestWithPayload()
+        {
+            var people = new List<StubLoggable>() { new StubLoggable("Ross"), new StubLoggable("James") };
+            _actionExecutingContext.ActionArguments.Add("people", people);
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Request Controller:Action - [{\"Name\":\"Ross\"},{\"Name\":\"James\"}]");
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithUnloggable_LogsTheRequestWithoutPayload()
+        {
+            _actionExecutingContext.ActionArguments.Add("person", new StubUnloggable());
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Request Controller:Action - ");
+        }
+
+        [Fact]
+        public void OnActionExecuting_WithPrimitive_LogsTheRequestWithoutPayload()
+        {
+            _actionExecutingContext.ActionArguments.Add("password", 12345);
+
+            _filter.OnActionExecuting(_actionExecutingContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Request Controller:Action - ");
+        }
+
+        [Fact]
+        public void OnActionExecuted_WithLoggable_LogsTheResponseWithPayload()
+        {
+            _actionExecutedContext.Result = new OkObjectResult(new StubLoggable());
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Response Controller:Action - {\"Name\":\"Ross\"}");
+        }
+
+        [Fact]
+        public void OnActionExecuted_WithArrayOfLoggable_LogsTheResponseWithPayload()
+        {
+            var people = new List<StubLoggable>() { new StubLoggable("Ross"), new StubLoggable("James") };
+            _actionExecutedContext.Result = new OkObjectResult(people);
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Response Controller:Action - [{\"Name\":\"Ross\"},{\"Name\":\"James\"}]");
+        }
+
+        [Fact]
+        public void OnActionExecuted_WithUnloggable_LogsTheRequestWithoutPayload()
+        {
+            _actionExecutedContext.Result = new OkObjectResult(new StubUnloggable());
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Response Controller:Action - ");
+        }
+
+        [Fact]
+        public void OnActionExecuted_WithPrimitive_LogsTheRequestWithoutPayload()
+        {
+            _actionExecutedContext.Result = new OkObjectResult(12345);
+
+            _filter.OnActionExecuted(_actionExecutedContext);
+
+            _mockLogger.VerifyInformationWasCalledExactly("Response Controller:Action - ");
+        }
+
+        [Loggable]
+        private class StubLoggable
+        {
+            public string Name { get; set; } = "Ross";
+            [SensitiveData]
+            public string Password { get; set; } = "sensitive";
+            [JsonIgnore]
+            public string Ignored { get; set; } = "ignored";
+
+            public StubLoggable() { }
+
+            public StubLoggable(string name)
+            {
+                Name = name;
+            }
+        }
+
+        private class StubUnloggable
+        {
+            public string Name { get; set; } = "Ross";
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using System;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -25,6 +26,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(CallbackBookingQuotasController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(CallbackBookingQuotasController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using GetIntoTeachingApi.Services;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -29,6 +30,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(CandidatesController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -11,6 +11,7 @@ using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -35,6 +36,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(MailingListController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(MailingListController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -8,6 +8,7 @@ using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Moq;
 using Xunit;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -88,6 +89,12 @@ namespace GetIntoTeachingApiTests.Controllers
             health.Notify.Should().Be(notifyStatus);
             health.Hangfire.Should().Be(hangfireStatus);
             health.Status.Should().Be(expectedStatus);
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(OperationsController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -5,10 +5,10 @@ using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using System;
-using GetIntoTeachingApi.Filters;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -27,6 +27,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(PrivacyPoliciesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(PrivacyPoliciesController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -11,6 +11,7 @@ using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 {
@@ -35,6 +36,12 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         public void Authorize_IsPresent()
         {
             typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(CandidatesController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 using GetIntoTeachingApi.Controllers;
-using GetIntoTeachingApi.Filters;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using Moq;
@@ -14,6 +13,7 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
 using MoreLinq;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -40,6 +40,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(TeachingEventsController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(TeachingEventsController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -7,11 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using System;
 using System.Reflection;
-using GetIntoTeachingApi.Filters;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using MoreLinq;
 using Xunit;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -30,6 +30,12 @@ namespace GetIntoTeachingApiTests.Controllers
         public void Authorize_IsPresent()
         {
             typeof(TypesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+        }
+
+        [Fact]
+        public void LogRequests_IsPresent()
+        {
+            typeof(TypesController).Should().BeDecoratedWith<LogRequestsAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
+++ b/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
@@ -11,15 +11,36 @@ namespace GetIntoTeachingApiTests.Helpers
             return VerifyCalled(logger, LogLevel.Information, expectedMessage);
         }
 
+        public static Mock<ILogger<T>> VerifyInformationWasCalledExactly<T>(this Mock<ILogger<T>> logger, string expectedMessage)
+        {
+            return VerifyCalledExactly(logger, LogLevel.Information, expectedMessage);
+        }
+
         public static Mock<ILogger<T>> VerifyWarningWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
         {
             return VerifyCalled(logger, LogLevel.Warning, expectedMessage);
         }
 
+        private static Mock<ILogger<T>> VerifyCalledExactly<T>(this Mock<ILogger<T>> logger, LogLevel expectedLogLevel, string expectedMessage)
+        {
+            bool state(object v, Type t) => v.ToString() == expectedMessage;
+
+            VerifyCalled(logger, expectedLogLevel, state);
+
+            return logger;
+        }
+
         private static Mock<ILogger<T>> VerifyCalled<T>(this Mock<ILogger<T>> logger, LogLevel expectedLogLevel, string expectedMessage)
         {
-            Func<object, Type, bool> state = (v, t) => v.ToString().Contains(expectedMessage);
+            bool state(object v, Type t) => v.ToString().Contains(expectedMessage);
 
+            VerifyCalled(logger, expectedLogLevel, state);
+
+            return logger;
+        }
+
+        private static void VerifyCalled<T>(this Mock<ILogger<T>> logger, LogLevel expectedLogLevel, Func<object, Type, bool> state)
+        {
             logger.Verify(
                 mock => mock.Log(
                     It.Is<LogLevel>(logLevel => logLevel == expectedLogLevel),
@@ -29,8 +50,6 @@ namespace GetIntoTeachingApiTests.Helpers
                     It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
                 )
             );
-
-            return logger;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CallbackBookingQuotaTests.cs
+++ b/GetIntoTeachingApiTests/Models/CallbackBookingQuotaTests.cs
@@ -8,6 +8,12 @@ namespace GetIntoTeachingApiTests.Models
     public class CallbackBookingQuotaTests
     {
         [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(CallbackBookingQuota).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
+        [Fact]
         public void EntityAttributes()
         {
             var type = typeof(CallbackBookingQuota);

--- a/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
@@ -3,6 +3,7 @@ using GetIntoTeachingApi.Models;
 using System;
 using Microsoft.Xrm.Sdk;
 using Xunit;
+using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Models
 {

--- a/GetIntoTeachingApiTests/Models/HealthCheckResponseTests.cs
+++ b/GetIntoTeachingApiTests/Models/HealthCheckResponseTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using Xunit;
 
@@ -6,6 +7,12 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class HealthCheckResponseTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(HealthCheckResponse).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
         [Theory]
         [InlineData(true, true, true, true, "healthy")]
         [InlineData(true, true, false, true, "degraded")]

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,20 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class MailingListAddMemberTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            var type = typeof(MailingListAddMember);
+
+            type.Should().BeDecoratedWith<LoggableAttribute>();
+
+            type.GetProperty("Email").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("FirstName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("LastName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("Telephone").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("AddressPostcode").Should().BeDecoratedWith<SensitiveDataAttribute>();
+        }
+
         [Fact]
         public void Constructor_WithCandidate_MapsCorrectly()
         {

--- a/GetIntoTeachingApiTests/Models/MappingInfoTests.cs
+++ b/GetIntoTeachingApiTests/Models/MappingInfoTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApiTests.Mocks;
 using Xunit;
@@ -14,6 +15,12 @@ namespace GetIntoTeachingApiTests.Models
         public MappingInfoTests()
         {
             _mappingInfo = new MappingInfo(typeof(MockModel));
+        }
+
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(MappingInfo).Should().BeDecoratedWith<LoggableAttribute>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,24 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TeacherTrainingAdviserSignUpTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            var type = typeof(TeacherTrainingAdviserSignUp);
+
+            type.Should().BeDecoratedWith<LoggableAttribute>();
+
+            type.GetProperty("Email").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("FirstName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("LastName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("DateOfBirth").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("TeacherId").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("Telephone").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("AddressLine1").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("AddressLine2").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("AddressPostcode").Should().BeDecoratedWith<SensitiveDataAttribute>();
+        }
+
         [Fact]
         public void Constructor_WithCandidate_MapsCorrectly()
         {

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,20 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TeachingEventAddAttendeeTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            var type = typeof(TeachingEventAddAttendee);
+
+            type.Should().BeDecoratedWith<LoggableAttribute>();
+
+            type.GetProperty("Email").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("FirstName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("LastName").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("Telephone").Should().BeDecoratedWith<SensitiveDataAttribute>();
+            type.GetProperty("AddressPostcode").Should().BeDecoratedWith<SensitiveDataAttribute>();
+        }
+
         [Fact]
         public void Constructor_WithCandidate_MapsCorrectly()
         {

--- a/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
@@ -8,6 +8,12 @@ namespace GetIntoTeachingApiTests.Models
     public class TeachingEventBuildingTests
     {
         [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(TeachingEventBuilding).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
+        [Fact]
         public void EntityAttributes()
         {
             var type = typeof(TeachingEventBuilding);

--- a/GetIntoTeachingApiTests/Models/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventSearchRequestTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using Xunit;
 
@@ -6,6 +7,12 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TeachingEventSearchRequestTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(TeachingEventSearchRequest).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
         [Theory]
         [InlineData(1, 1.6093)]
         [InlineData(-1, -1.6093)]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -9,6 +9,12 @@ namespace GetIntoTeachingApiTests.Models
     public class TeachingEventTests
     {
         [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(TeachingEvent).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
+        [Fact]
         public void EntityAttributes()
         {
             var type = typeof(TeachingEvent);

--- a/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
+++ b/GetIntoTeachingApiTests/Models/TypeEntityTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
@@ -10,6 +11,12 @@ namespace GetIntoTeachingApiTests.Models
 {
     public class TypeEntityTests
     {
+        [Fact]
+        public void Loggable_IsPresent()
+        {
+            typeof(TypeEntity).Should().BeDecoratedWith<LoggableAttribute>();
+        }
+
         [Fact]
         public void EntityAttributes()
         {
@@ -22,8 +29,10 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithEntity()
         {
-            var entity = new Entity();
-            entity.Id = Guid.NewGuid();
+            var entity = new Entity
+            {
+                Id = Guid.NewGuid()
+            };
             entity["dfe_name"] = "name";
 
             var typeEntity = new TypeEntity(entity, "entityName");


### PR DESCRIPTION
- Add filter to log request/response paylaods

We want to be able to see request/response payloads to help us when debugging requests in production.

Add `LogRequests` attribute that will log request/response information per-controller and enable for every controller.

Add `LoggableAttribute` to opt-in models that should be logged.

Add `SensitiveDataAttribute` to opt-out any sensitive attributes from being logged.

- Make request/response models loggable

Add the `Loggable` attribute to request/response models.

Add the `SensitiveData` attribute to any attributes within the models that we want to omit from the logs.