### PR TITLE
Add ScribbleId to TeachingEvent

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -50,6 +50,8 @@ namespace GetIntoTeachingApi.Models
         public string Description { get; set; }
         [EntityField("dfe_videolink")]
         public string VideoUrl { get; set; }
+        [EntityField("dfe_scribbleurl")]
+        public string ScribbleId { get; set; }
         [EntityField("dfe_providerwebsite")]
         public string ProviderWebsiteUrl { get; set; }
         [EntityField("dfe_providertargetaudience_ml")]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -33,6 +33,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
             type.GetProperty("Summary").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventsummary_ml");
             type.GetProperty("VideoUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_videolink");
+            type.GetProperty("ScribbleId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_scribbleurl");
             type.GetProperty("ProviderWebsiteUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerwebsite");
             type.GetProperty("ProviderTargetAudience").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providertargetaudience_ml");
             type.GetProperty("ProviderOrganiser").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerorganiser");


### PR DESCRIPTION
Some teaching events have a scribble document that is used for registration; this exposes the scribble id so that we can embed the scribble document in the client website.