### PR TITLE
Add labels to geocode metrics

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -20,12 +20,11 @@ namespace GetIntoTeachingApi.Adapters
 
         public async Task<Point> GeocodePostcodeAsync(string postcode)
         {
-            _metrics.GoogleApiCalls.Inc();
-
             var response = await _client.GeocodeAddress(postcode);
 
             if (response.Status != GeocodeStatus.Ok)
             {
+                _metrics.GoogleApiCalls.WithLabels(postcode, "error").Inc();
                 return null;
             }
 
@@ -33,8 +32,11 @@ namespace GetIntoTeachingApi.Adapters
 
             if (result == null)
             {
+                _metrics.GoogleApiCalls.WithLabels(postcode, "fail").Inc();
                 return null;
             }
+
+            _metrics.GoogleApiCalls.WithLabels(postcode, "success").Inc();
 
             var location = result.Geometry.Location;
             return new Point(new Coordinate(location.Longitude, location.Latitude));

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -13,7 +13,10 @@ namespace GetIntoTeachingApi.Services
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
-            .CreateCounter("api_google_api_calls", "Number of Google API calls.");
+            .CreateCounter("api_google_api_calls", "Number of Google API calls.", new CounterConfiguration
+            {
+                LabelNames = new[] { "postcode", "result" },
+            });
         private static readonly Counter _cacheLookups = Metrics
             .CreateCounter("api_cache_lookups", "Number of cache lookups.", new CounterConfiguration
             {

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -42,6 +42,7 @@ namespace GetIntoTeachingApiTests.Services
         public void GoogleApiCalls_ReturnsMetric()
         {
             _metrics.GoogleApiCalls.Name.Should().Be("api_google_api_calls");
+            _metrics.GoogleApiCalls.LabelNames.Should().BeEquivalentTo(new[] { "postcode", "result" });
         }
 
         [Fact]


### PR DESCRIPTION
Add `postcode` and `result` labels to the geocoding metrics; this will enable us to track any teaching event search requests that fail because we are unable to geocode the postcode. It will also enable us to see which postcodes end up falling through the local database lookup and result in a call out to Google.