### PR TITLE
Use recommended Sentry integration method

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -124,7 +124,7 @@ jobs:
              TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
              TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
              ARM_ACCESS_KEY:           "${{ secrets.DEV_ARM_ACCESS_KEY    }}"
-             TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
+             TF_VAR_SENTRY_DSN:        "${{ secrets.SENTRY_DSN }}"
    
        - name: Terraform Apply
          run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -69,7 +69,7 @@ jobs:
              TF_VAR_NOTIFY_API_KEY:    "${{ secrets.PROD_NOTIFY_API_KEY      }}"
              TF_VAR_TOTP_SECRET_KEY:   "${{ secrets.PROD_TOTP_SECRET_KEY     }}"
              TF_VAR_GOOGLE_API_KEY:    "${{ secrets.PROD_GOOGLE_API_KEY      }}"
-             TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
+             TF_VAR_SENTRY_DSN:        "${{ secrets.SENTRY_DSN }}"
 
    
        - name: Terraform Apply

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
              TF_VAR_SHARED_SECRET:     "${{ secrets.SHARED_SECRET       }}"
              TF_VAR_NOTIFY_API_KEY:    "${{ secrets.NOTIFY_API_KEY      }}"
              TF_VAR_TOTP_SECRET_KEY:   "${{ secrets.TOTP_SECRET_KEY     }}"
-             TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
+             TF_VAR_SENTRY_DSN:        "${{ secrets.SENTRY_DSN }}"
    
        - name: Terraform Apply
          run: |

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -74,5 +74,19 @@ namespace GetIntoTeachingApi.Controllers
 
             return Ok(response);
         }
+
+        [HttpGet]
+        [Route("simulate_error")]
+        [SwaggerOperation(
+            Summary = "Simulates a 500 error to test the Sentry integration.",
+            OperationId = "SimulateError",
+            Tags = new[] { "Operations" })]
+        [ProducesResponseType(typeof(HealthCheckResponse), 200)]
+        public void SimulateError()
+        {
+            System.Text.StringBuilder builder = null;
+
+            builder.Append("throw error");
+        }
     }
 }

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,8 +1,5 @@
-using GetIntoTeachingApi.Utils;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Sentry;
 
 namespace GetIntoTeachingApi
 {
@@ -10,21 +7,14 @@ namespace GetIntoTeachingApi
     {
         public static void Main(string[] args)
         {
-            var host = CreateHostBuilder(args).Build();
-            using var serviceScope = host.Services.CreateScope();
-            var services = serviceScope.ServiceProvider;
-            var env = services.GetRequiredService<IEnv>();
-
-            using (SentrySdk.Init(env.SentryUrl))
-            {
-                CreateHostBuilder(args).Build().Run();
-            }
+            CreateHostBuilder(args).Build().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    webBuilder.UseSentry();
                     webBuilder.UseStartup<Startup>();
                 });
     }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -12,7 +12,6 @@ namespace GetIntoTeachingApi.Utils
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
-        public string SentryUrl => Environment.GetEnvironmentVariable("SENTRY_URL");
         public string EnvironmentName => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -10,7 +10,6 @@
         string GitCommitSha { get; }
         string DatabaseInstanceName { get; }
         string HangfireInstanceName { get; }
-        string SentryUrl { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -9,6 +9,7 @@ using GetIntoTeachingApi.Utils;
 using Moq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
+using System;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -48,6 +49,12 @@ namespace GetIntoTeachingApiTests.Controllers
             mappings.Any(m => m.LogicalName == "contact" &&
                               m.Class == "GetIntoTeachingApi.Models.Candidate"
             ).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SimulateError_ThrowsNullReferenceException()
+        {
+            _controller.Invoking(c => c.SimulateError()).Should().Throw<NullReferenceException>();
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -109,17 +109,6 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void SentryUrl_ReturnsCorrectly()
-        {
-            var previous = Environment.GetEnvironmentVariable("SENTRY_URL");
-            Environment.SetEnvironmentVariable("SENTRY_URL", "sentry-url");
-
-            _env.SentryUrl.Should().Be("sentry-url");
-
-            Environment.SetEnvironmentVariable("SENTRY_URL", previous);
-        }
-
-        [Fact]
         public void TotpSecretKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ DATABASE_INSTANCE_NAME=****
 HANGFIRE_INSTANCE_NAME=****
 
 # Sentry
-SENTRY_URL=****
+Sentry__Dsn=****
 
 # Google
 GOOGLE_API_KEY=****

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -39,7 +39,7 @@ resource "cloudfoundry_app" "api_application" {
          TOTP_SECRET_KEY        = var.TOTP_SECRET_KEY
          SHARED_SECRET          = var.SHARED_SECRET
          PEN_TEST_SHARED_SECRET = var.PEN_TEST_SHARED_SECRET
-         SENTRY_URL             = var.SENTRY_URL
+         Sentry__Dsn            = var.SENTRY_DSN
          GOOGLE_API_KEY         = var.GOOGLE_API_KEY
          ASPNETCORE_ENVIRONMENT = var.ASPNETCORE_ENVIRONMENT
          DATABASE_INSTANCE_NAME = cloudfoundry_service_instance.postgres2.name

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -89,7 +89,7 @@ variable "PEN_TEST_SHARED_SECRET" {
 }
 variable "NOTIFY_API_KEY" {}
 variable "TOTP_SECRET_KEY" {}
-variable "SENTRY_URL" {
+variable "Sentry__Dsn" {
   default = ""
 }
 variable "GOOGLE_API_KEY" {


### PR DESCRIPTION
The Sentry C# client appears to recommend a different way of integrating it to what Sentry's wizard shows you initially; this updates to leverage `useSentry()` instead of `Sentry.Init` directly.

Also includes temporary operations endpoint to enable testing the integration in production.