### PR TITLE
Use secrets var name instead of env var name

### DIFF
--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -89,7 +89,7 @@ variable "PEN_TEST_SHARED_SECRET" {
 }
 variable "NOTIFY_API_KEY" {}
 variable "TOTP_SECRET_KEY" {}
-variable "Sentry__Dsn" {
+variable "SENTRY_DSN" {
   default = ""
 }
 variable "GOOGLE_API_KEY" {


### PR DESCRIPTION
There was an error on deployment:

```
Error: Reference to undeclared input variable

  on application.tf line 42, in resource "cloudfoundry_app" "api_application":
  42:          Sentry__Dsn            = var.SENTRY_DSN

An input variable with the name "SENTRY_DSN" has not been declared. This
variable can be declared with a variable "SENTRY_DSN" {} block.
```

It seems to indicate the variable name should have been `SENTRY_DSN` and not what we want the environment variable name to be (`Sentry__Dsn`).