### PR TITLE
Product Release Workflow to Permit TAG

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,7 +1,13 @@
 ---  
 name: Release to Production
 on: 
+   repository_dispatch:
    workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Release Tag'
+        required: true
+        default: 'master'
 
 env:
   DOCKERHUB_REPOSITORY:     dfedigital/get-into-teaching-api
@@ -21,6 +27,8 @@ jobs:
 
        - name: Checkout
          uses: actions/checkout@v2
+         with: 
+            ref: "${{ github.event.inputs.tags }}"
    
        - name: Get Short SHA
          id: sha
@@ -71,38 +79,38 @@ jobs:
              TF_VAR_GOOGLE_API_KEY:    "${{ secrets.PROD_GOOGLE_API_KEY      }}"
              TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
 
-   
-       - name: Terraform Apply
-         run: |
-             cd terraform/paas && pwd
-             terraform apply -auto-approve plan
-         env:
-             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
-             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
-             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
-   
-       - name:  Smoke Test
-         run: |
-             tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
-
-       - name: Create Sentry release
-         if: success()
-         uses: getsentry/action-release@v1.0.0
-         env:
-           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-         with:
-           environment: production
-
-       - name: Slack Notification
-         if: failure()
-         uses: rtCamp/action-slack-notify@master
-         env:
-           SLACK_CHANNEL: getintoteaching_tech
-           SLACK_COLOR: '#3278BD'
-           SLACK_ICON: https://github.com/rtCamp.png?size=48
-           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
-           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                
+ #      - name: Terraform Apply
+ #        run: |
+ #            cd terraform/paas && pwd
+ #            terraform apply -auto-approve plan
+ #        env:
+ #            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+ #            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
+ #            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
+ #  
+ #      - name:  Smoke Test
+ #        run: |
+ #            tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
+ #
+ #      - name: Create Sentry release
+ #        if: success()
+ #        uses: getsentry/action-release@v1.0.0
+ #        env:
+ #          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+ #          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+ #          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+ #        with:
+ #          environment: production
+ #
+ #      - name: Slack Notification
+ #        if: failure()
+ #        uses: rtCamp/action-slack-notify@master
+ #        env:
+ #          SLACK_CHANNEL: getintoteaching_tech
+ #          SLACK_COLOR: '#3278BD'
+ #          SLACK_ICON: https://github.com/rtCamp.png?size=48
+ #          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+ #          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+ #          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -89,37 +89,38 @@ jobs:
              TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
 
                 
-#      - name: Terraform Apply
-#        run: |
-#            cd terraform/paas && pwd
-#            terraform apply -auto-approve plan
-#        env:
-#            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
-#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
-#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
-#  
-#      - name:  Smoke Test
-#        run: |
-#            tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
-#
-#      - name: Create Sentry release
-#        if: success()
-#        uses: getsentry/action-release@v1.0.0
-#        env:
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-#          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-#        with:
-#          environment: production
-#
-#      - name: Slack Notification
-#        if: failure()
-#        uses: rtCamp/action-slack-notify@master
-#        env:
-#          SLACK_CHANNEL: getintoteaching_tech
-#          SLACK_COLOR: '#3278BD'
-#          SLACK_ICON: https://github.com/rtCamp.png?size=48
-#          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
-#          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+       - name: Terraform Apply
+         run: |
+             cd terraform/paas && pwd
+             terraform apply -auto-approve plan
+         env:
+             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
+             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
+   
+       - name:  Smoke Test
+         run: |
+             tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
+ 
+       - name: Create Sentry release
+         if: success()
+         uses: getsentry/action-release@v1.0.0
+         env:
+           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+           VERSION: ${{ steps.sha.outputs.short}}
+         with:
+           environment: production
+ 
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
+         env:
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: 'Carrying out job ${{github.job}}'
+           SLACK_TITLE: 'Production Deploy Failure'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,7 +32,7 @@ jobs:
    
        - name: Get Short SHA
          id: sha
-         run: echo ::set-output name=short::$(git rev-parse --short $GITHUB_SHA)
+         run: echo ::set-output name=short::$(git rev-parse --short HEAD )
    
        - name: Install Terraform CloudFoundry Provider
          run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,7 +7,6 @@ on:
       tags:
         description: 'Release Tag'
         required: true
-        default: 'master'
 
 env:
   DOCKERHUB_REPOSITORY:     dfedigital/get-into-teaching-api
@@ -24,6 +23,16 @@ jobs:
         shell: bash
 
     steps:
+
+       - name: Check Tag is a Release
+         run: |
+               rval=$(curl -s -X GET https://api.github.com/repos/DFE-Digital/get-into-teaching-content/releases/tags/${{ github.event.inputs.tags }} | jq -r ".message")
+               if [ "${rval}" = "Not Found" ]
+               then
+                   echo "Tag ${{ github.event.inputs.tags }} cannot be found in releases"
+                   exit 1
+               fi
+               exit 0
 
        - name: Checkout
          uses: actions/checkout@v2
@@ -80,37 +89,37 @@ jobs:
              TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
 
                 
-       - name: Terraform Apply
-         run: |
-             cd terraform/paas && pwd
-             terraform apply -auto-approve plan
-         env:
-             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
-             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
-             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
-   
-       - name:  Smoke Test
-         run: |
-             tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
- 
-       - name: Create Sentry release
-         if: success()
-         uses: getsentry/action-release@v1.0.0
-         env:
-           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-         with:
-           environment: production
- 
-       - name: Slack Notification
-         if: failure()
-         uses: rtCamp/action-slack-notify@master
-         env:
-           SLACK_CHANNEL: getintoteaching_tech
-           SLACK_COLOR: '#3278BD'
-           SLACK_ICON: https://github.com/rtCamp.png?size=48
-           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
-           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Terraform Apply
+#        run: |
+#            cd terraform/paas && pwd
+#            terraform apply -auto-approve plan
+#        env:
+#            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
+#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
+#  
+#      - name:  Smoke Test
+#        run: |
+#            tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
+#
+#      - name: Create Sentry release
+#        if: success()
+#        uses: getsentry/action-release@v1.0.0
+#        env:
+#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+#          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+#        with:
+#          environment: production
+#
+#      - name: Slack Notification
+#        if: failure()
+#        uses: rtCamp/action-slack-notify@master
+#        env:
+#          SLACK_CHANNEL: getintoteaching_tech
+#          SLACK_COLOR: '#3278BD'
+#          SLACK_ICON: https://github.com/rtCamp.png?size=48
+#          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+#          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -80,37 +80,37 @@ jobs:
              TF_VAR_SENTRY_URL:        "${{ secrets.SENTRY_URL }}"
 
                 
- #      - name: Terraform Apply
- #        run: |
- #            cd terraform/paas && pwd
- #            terraform apply -auto-approve plan
- #        env:
- #            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
- #            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
- #            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
- #  
- #      - name:  Smoke Test
- #        run: |
- #            tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
- #
- #      - name: Create Sentry release
- #        if: success()
- #        uses: getsentry/action-release@v1.0.0
- #        env:
- #          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
- #          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
- #          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
- #        with:
- #          environment: production
- #
- #      - name: Slack Notification
- #        if: failure()
- #        uses: rtCamp/action-slack-notify@master
- #        env:
- #          SLACK_CHANNEL: getintoteaching_tech
- #          SLACK_COLOR: '#3278BD'
- #          SLACK_ICON: https://github.com/rtCamp.png?size=48
- #          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
- #          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
- #          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+       - name: Terraform Apply
+         run: |
+             cd terraform/paas && pwd
+             terraform apply -auto-approve plan
+         env:
+             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME   }}"
+             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD   }}"
+   
+       - name:  Smoke Test
+         run: |
+             tests/confidence/healthcheck.sh "get-into-teaching-api-prod"  "${{ steps.sha.outputs.short}}" 
+ 
+       - name: Create Sentry release
+         if: success()
+         uses: getsentry/action-release@v1.0.0
+         env:
+           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+         with:
+           environment: production
+ 
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
+         env:
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
 
        - name: Check Tag is a Release
          run: |
-               rval=$(curl -s -X GET https://api.github.com/repos/DFE-Digital/get-into-teaching-content/releases/tags/${{ github.event.inputs.tags }} | jq -r ".message")
+               rval=$(curl -s -X GET https://api.github.com/repos/DFE-Digital/get-into-teaching-api/releases/tags/${{ github.event.inputs.tags }} | jq -r ".message")
                if [ "${rval}" = "Not Found" ]
                then
                    echo "Tag ${{ github.event.inputs.tags }} cannot be found in releases"


### PR DESCRIPTION
When you release to production it will ask for a TAG, this tag should be the Tag for the Release you want to send to Production.
This will then send the version of the Docker Image and Terraform to Production rather than the current master.

