### PR TITLE
port fix

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -2,6 +2,10 @@
 name: Release Monitoring ( Development )
 on: 
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Build and Deploy"]
+    types:
+      - completed
 
 env:
   CF_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry

--- a/monitoring/prometheus/prometheus.yml.tmpl
+++ b/monitoring/prometheus/prometheus.yml.tmpl
@@ -10,10 +10,20 @@ scrape_configs:
   dns_sd_configs:
     - names: 
        - ${git_app}
-       - ${git_api}
+      type: 'A'
+      port: 3000
+- job_name: TTA
+  dns_sd_configs:
+    - names: 
        - ${git_tta}
       type: 'A'
-      port: ${port}
+      port: 3000
+- job_name: API
+  dns_sd_configs:
+    - names: 
+       - ${git_api}
+      type: 'A'
+      port: 8080
 
 alerting:
   alertmanagers:

--- a/terraform/monitoring/network.tf
+++ b/terraform/monitoring/network.tf
@@ -3,19 +3,19 @@ resource "cloudfoundry_network_policy" "my-policy" {
   policy {
     destination_app = data.cloudfoundry_app.app.id
     source_app      = module.prometheus.app_id
-    port            = var.port
+    port            = 3000
   }
 
   policy {
     destination_app = data.cloudfoundry_app.tta.id
     source_app      = module.prometheus.app_id
-    port            = var.port
+    port            = 3000
   }
 
   policy {
     destination_app = data.cloudfoundry_app.api.id
     source_app      = module.prometheus.app_id
-    port            = var.port
+    port            = 8080
   }
 }
 

--- a/terraform/monitoring/prometheus.tf
+++ b/terraform/monitoring/prometheus.tf
@@ -5,7 +5,6 @@ locals {
     git_app    = "${data.cloudfoundry_route.app_internal.hostname}.${data.cloudfoundry_domain.internal.name}"
     git_api    = "${data.cloudfoundry_route.api_internal.hostname}.${data.cloudfoundry_domain.internal.name}"
     git_tta    = "${data.cloudfoundry_route.tta_internal.hostname}.${data.cloudfoundry_domain.internal.name}"
-    port       = var.port
   }
 }
 

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -28,9 +28,6 @@ variable "domain" {
   default = "london.cloudapps.digital"
 }
 
-variable "port" {
-  default = "8080"
-}
 
 variable "tta_application_name" {}
 variable "app_application_name" {}


### PR DESCRIPTION
The TTA and APP present metrics internally on port 3000
Where as the API presents them on 8080
so resolved that and metrics should now scrape