### PR TITLE
Workaround for exception in Prometheus.HttpMetrics.HttpRequestDurationMiddleware

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -13,6 +13,7 @@ using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -71,6 +72,13 @@ namespace GetIntoTeachingApi
             services.AddControllers().AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();
+            });
+
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                // Workaround for https://github.com/dotnet/aspnetcore/issues/8302
+                // caused by Prometheus.HttpMetrics.HttpRequestDurationMiddleware
+                options.AllowSynchronousIO = true;
             });
 
             services.AddSwaggerGen(c =>


### PR DESCRIPTION
It appears to be fixed in a later version of .NET Core but the version we are using occasionally throws an `InvalidOperationException` due to performing a synchronous operation.

This updates Kestrel config to allow sync operations.