### PR TITLE
Sort countries and teaching subjects alphabetically

### DIFF
--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
@@ -33,7 +34,9 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public async Task<IActionResult> GetCountries()
         {
-            return Ok(await _store.GetLookupItems("dfe_country").ToListAsync());
+            var countries = await _store.GetLookupItems("dfe_country").ToListAsync();
+
+            return Ok(countries.OrderBy(c => c.Value));
         }
 
         [HttpGet]
@@ -46,7 +49,9 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<TypeEntity>), 200)]
         public async Task<IActionResult> GetTeachingSubjects()
         {
-            return Ok(await _store.GetLookupItems("dfe_teachingsubjectlist").ToListAsync());
+            var subjects = await _store.GetLookupItems("dfe_teachingsubjectlist").ToListAsync();
+
+            return Ok(subjects.OrderBy(c => c.Value));
         }
 
         [HttpGet]

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Authorization;
 using MoreLinq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -48,7 +50,7 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public async void GetCountries_ReturnsAllCountries()
+        public async void GetCountries_ReturnsAllCountriesSortedByCountryName()
         {
             var mockEntities = MockTypeEntities();
             _mockStore.Setup(mock => mock.GetLookupItems("dfe_country")).Returns(mockEntities.AsAsyncQueryable());
@@ -56,11 +58,12 @@ namespace GetIntoTeachingApiTests.Controllers
             var response = await _controller.GetCountries();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().BeEquivalentTo(mockEntities);
+            var countries = (IEnumerable<TypeEntity>)ok.Value;
+            countries.Select(c => c.Value).Should().BeEquivalentTo(new[] { "Type 1", "Type 2", "Type 3" });
         }
 
         [Fact]
-        public async void GetTeachingSubjects_ReturnsAllSubjects()
+        public async void GetTeachingSubjects_ReturnsAllSubjectsSortedBySubjectName()
         {
             var mockEntities = MockTypeEntities();
             _mockStore.Setup(mock => mock.GetLookupItems("dfe_teachingsubjectlist")).Returns(mockEntities.AsAsyncQueryable());
@@ -68,7 +71,8 @@ namespace GetIntoTeachingApiTests.Controllers
             var response = await _controller.GetTeachingSubjects();
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().BeEquivalentTo(mockEntities);
+            var subjects = (IEnumerable<TypeEntity>)ok.Value;
+            subjects.Select(c => c.Value).Should().BeEquivalentTo(new[] { "Type 1", "Type 2", "Type 3" });
         }
 
         [Fact]
@@ -330,8 +334,9 @@ namespace GetIntoTeachingApiTests.Controllers
         {
             return new[]
             {
-                new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 1"},
                 new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 2"},
+                new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 3"},
+                new TypeEntity {Id = Guid.NewGuid().ToString(), Value = "Type 1"},
             };
         }
     }


### PR DESCRIPTION
We are likely always going to present these in alphabetical order to the user, so sorting it in the API makes sense. The other types will remain ordered by their `id`, which seems to make sense for most of the option sets in Dynamics.