### PR TITLE
Set CdsServiceClient timeout to 30s

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Utils;
+﻿using System;
+using GetIntoTeachingApi.Utils;
 using Microsoft.PowerPlatform.Cds.Client;
 
 namespace GetIntoTeachingApi.Adapters
@@ -10,6 +11,7 @@ namespace GetIntoTeachingApi.Adapters
         public CdsServiceClientWrapper(IEnv env)
         {
             CdsServiceClient = new CdsServiceClient(ConnectionString(env));
+            CdsServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
         }
 
         private static string ConnectionString(IEnv env)


### PR DESCRIPTION
The `CdsServiceClient` timeout by default is 2 minutes, but the healthcheck endpoint depends on the CRM and we want it to complete in less time than that if there is a problem. 