### PR TITLE
Changes to Subscription modelling

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -274,6 +274,15 @@ namespace GetIntoTeachingApi.Models
                 StatusIsWaitingToBeAssignedAt = DateTime.UtcNow;
             }
 
+            var changingEventSubscriptionType = !IsNewRegistrant && EventsSubscriptionTypeId != null;
+
+            if (changingEventSubscriptionType && crm.CandidateAlreadyHasLocalEventSubscriptionType((Guid)Id))
+            {
+                // Never down-grade to a 'single event' subscription type from
+                // a 'local event' subscription type.
+                EventsSubscriptionTypeId = (int)SubscriptionType.LocalEvent;
+            }
+
             return base.ShouldMap(crm);
         }
 

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -130,10 +130,10 @@ namespace GetIntoTeachingApi.Models
             candidate.EventsSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Events;
             candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
-            candidate.EventsSubscriptionDoNotBulkEmail = !SubscribeToEvents;
+            candidate.EventsSubscriptionDoNotBulkEmail = false;
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
             candidate.EventsSubscriptionDoNotPostalMail = true;
-            candidate.EventsSubscriptionDoNotSendMm = !SubscribeToEvents;
+            candidate.EventsSubscriptionDoNotSendMm = false;
 
             if (string.IsNullOrWhiteSpace(AddressPostcode))
             {

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -100,6 +100,11 @@ namespace GetIntoTeachingApi.Services
             return entity == null ? null : new Candidate(entity, this);
         }
 
+        public bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId)
+        {
+            return GetCandidate(candidateId).EventsSubscriptionTypeId == (int)Candidate.SubscriptionType.LocalEvent;
+        }
+
         public bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId)
         {
             return _service.CreateQuery("dfe_candidateprivacypolicy", Context()).FirstOrDefault(entity =>

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -17,6 +17,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<TeachingEvent> GetTeachingEvents();
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
+        bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -259,6 +259,25 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void ToEntity_WhenChangingEventSubscriptionFromSingleToLocal_RetainsLocalSubscription()
+        {
+            var mockService = new Mock<IOrganizationServiceAdapter>();
+            var context = mockService.Object.Context();
+            var mockCrm = new Mock<ICrmService>();
+            var candidate = new Candidate() { Id = Guid.NewGuid(), EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent };
+            var candidateEntity = new Entity("contact");
+            mockCrm.Setup(m => m.MappableEntity("contact", candidate.Id, context)).Returns(candidateEntity);
+            mockCrm.Setup(m => m.CandidateAlreadyHasLocalEventSubscriptionType((Guid)candidate.Id)).Returns(true);
+
+            candidate.ToEntity(mockCrm.Object, context);
+
+            candidateEntity.GetAttributeValue<bool>("dfe_newregistrant").Should().BeFalse();
+
+            candidateEntity.GetAttributeValue<OptionSetValue>("dfe_gitiseventsservicesubscriptiontype")
+                .Value.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
+        }
+
+        [Fact]
         public void ToEntity_WithNullId_SetsIsNewRegistrantToTrue()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -156,24 +156,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsFalseAndDoesNotProvideAddressPostCode_CorrectSubscription()
-        {
-            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = null };
-
-            var candidate = request.Candidate;
-
-            candidate.HasEventsSubscription.Should().BeTrue();
-            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
-            candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotSendMm.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
-            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
-        }
-
-        [Fact]
         public void Candidate_SubscribeToMailingListIsTrueAndDoesNotProvideAddressPostCode_CorrectSubscription()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, AddressPostcode = null };
@@ -192,10 +174,10 @@ namespace GetIntoTeachingApiTests.Models
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
             candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeTrue();
+            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
             candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
             candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotSendMm.Should().BeTrue();
+            candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
             candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
             candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
         }


### PR DESCRIPTION
- Always opt in to bulk emails/mm on event sign up

When a candidate signs up for an event we want to be able to both send them bulk emails and marketing material.

- Prevent event subscription being downgraded

When a candidate signs up for an event and passes their post code when opting into the mailing list, we give them a 'local event' subscription type. If they then go on to sign up for another event and don't provide their postcode we currently downgrade their subscription to a 'single event' type.

Instead, if they have provided their postcode as part of an event sign up in the past then we want to keep their subscription type as 'local event'.
