### PR TITLE
Opt-out of DoNotBulkEmail on event sign up

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -117,7 +117,7 @@ namespace GetIntoTeachingApi.Models
         private void ConfigureConsent(Candidate candidate)
         {
             candidate.OptOutOfSms = false;
-            candidate.DoNotBulkEmail = !SubscribeToEvents && !SubscribeToMailingList;
+            candidate.DoNotBulkEmail = false;
             candidate.DoNotBulkPostalMail = !SubscribeToMailingList;
             candidate.DoNotEmail = false;
             candidate.DoNotPostalMail = !SubscribeToMailingList;

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -196,7 +196,6 @@ namespace GetIntoTeachingApiTests.Models
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = null };
 
-            request.Candidate.DoNotBulkEmail.Should().BeTrue();
             request.Candidate.DoNotSendMm.Should().BeTrue();
         }
 


### PR DESCRIPTION
When signing up for an event subscription we should be setting the contact-level `DoNotBulkEmail` preference to `false`.