### PR TITLE
Increase Instances to 2

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -6,3 +6,4 @@ paas_api_application_name="get-into-teaching-api-prod"
 paas_api_route_name="get-into-teaching-api-prod"
 paas_logging_endpoint_port="syslog-tls://89d7be0f-ddcd-437e-ad3c-c8125d0bad00-ls.logit.io:18190"
 ASPNETCORE_ENVIRONMENT="Production"
+application_instances=2


### PR DESCRIPTION
Increase the number of production instances to two, to try and prevent gliching down time when AWS does tricks