### PR TITLE
Default PreferredTeachingSubjectId to Primary

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -158,10 +158,21 @@ namespace GetIntoTeachingApi.Models
             AddPastTeachingPosition(candidate);
             SetAdviserEligibility(candidate);
             SetType(candidate);
+            DefaultPreferredTeachingSubjectId(candidate);
             ConfigureSubscription(candidate);
             ConfigureConsent(candidate);
 
             return candidate;
+        }
+
+        private void DefaultPreferredTeachingSubjectId(Candidate candidate)
+        {
+            if (candidate.PreferredEducationPhaseId != (int)Candidate.PreferredEducationPhase.Primary)
+            {
+                return;
+            }
+
+            candidate.PreferredTeachingSubjectId = TypeEntity.PrimaryTeachingSubjectId;
         }
 
         private void ConfigureGcseStatus(Candidate candidate)

--- a/GetIntoTeachingApi/Models/TypeEntity.cs
+++ b/GetIntoTeachingApi/Models/TypeEntity.cs
@@ -11,6 +11,7 @@ namespace GetIntoTeachingApi.Models
     public class TypeEntity
     {
         public static readonly Guid UnitedKingdomCountryId = new Guid("72f5c2e6-74f9-e811-a97a-000d3a2760f2");
+        public static readonly Guid PrimaryTeachingSubjectId = new Guid("b02655a1-2afa-e811-a981-000d3a276620");
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public string Id { get; set; }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -216,6 +216,19 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_EducationPhaseIsPrimary_SetsPreferredTeachingSubjectIdToPrimary()
+        {
+            var request = new TeacherTrainingAdviserSignUp()
+            {
+                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
+            };
+
+            var candidate = request.Candidate;
+
+            candidate.PreferredTeachingSubjectId.Should().Be(TypeEntity.PrimaryTeachingSubjectId);
+        }
+
+        [Fact]
         public void Candidate_ReturningToTeaching_CorrectConsent()
         {
             var request = new TeacherTrainingAdviserSignUp()


### PR DESCRIPTION
When a Candidate signs up with a `PreferredEducationPhaseId` of primary we do not ask them their preferred teaching subject (only secondary teachers will specialise in a particular teaching subject). The CRM, however, requires this field to be set and it should have the guid corresponding to `Primary`.