### PR TITLE
Trim white space from JSON string attributes

### DIFF
--- a/GetIntoTeachingApi/ModelBinders/TrimStringModelBinder.cs
+++ b/GetIntoTeachingApi/ModelBinders/TrimStringModelBinder.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace GetIntoTeachingApi.ModelBinders
+{
+    public class TrimStringModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var modelName = bindingContext.ModelName;
+
+            // Try to fetch the value of the argument by name
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                return Task.CompletedTask;
+            }
+
+            bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+
+            var value = valueProviderResult.FirstValue;
+
+            bindingContext.Result = ModelBindingResult.Success(value?.Trim());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/GetIntoTeachingApi/ModelBinders/TrimStringModelBinderProvider.cs
+++ b/GetIntoTeachingApi/ModelBinders/TrimStringModelBinderProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace GetIntoTeachingApi.ModelBinders
+{
+    public class TrimStringModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.Metadata.ModelType == typeof(string))
+            {
+                return new TrimStringModelBinder();
+            }
+
+            return null;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -5,6 +5,7 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Auth;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.ModelBinders;
 using GetIntoTeachingApi.OperationFilters;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -69,7 +70,11 @@ namespace GetIntoTeachingApi
             services.AddAuthentication("SharedSecretHandler")
                 .AddScheme<SharedSecretSchemeOptions, SharedSecretHandler>("SharedSecretHandler", op => { });
 
-            services.AddControllers().AddFluentValidation(c =>
+            services.AddControllers(o =>
+            {
+                o.ModelBinderProviders.Insert(0, new TrimStringModelBinderProvider());
+            })
+            .AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();
             });

--- a/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderProviderTests.cs
+++ b/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderProviderTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.ModelBinders;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Moq;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.ModelBinders
+{
+    public class TrimStringModelBinderProviderTests
+    {
+        private readonly TrimStringModelBinderProvider _provider;
+
+        public TrimStringModelBinderProviderTests()
+        {
+            _provider = new TrimStringModelBinderProvider();
+        }
+
+        [Fact]
+        public void GetBinder_ModelTypeString_ReturnsTrimStringModelBinder()
+        {
+            var mockContext = new Mock<ModelBinderProviderContext>();
+            var mockMetadata = new Mock<ModelMetadata>(ModelMetadataIdentity.ForType(typeof(string)));
+            mockContext.Setup(m => m.Metadata).Returns(mockMetadata.Object);
+
+            var binder = _provider.GetBinder(mockContext.Object);
+
+            binder.Should().BeOfType(typeof(TrimStringModelBinder));
+        }
+
+        [Fact]
+        public void GetBinder_ModelTypeNotString_ReturnsNull()
+        {
+            var mockContext = new Mock<ModelBinderProviderContext>();
+            var mockMetadata = new Mock<ModelMetadata>(ModelMetadataIdentity.ForType(typeof(double)));
+            mockContext.Setup(m => m.Metadata).Returns(mockMetadata.Object);
+
+            _provider.GetBinder(mockContext.Object).Should().BeNull();
+        }
+
+        [Fact]
+        public void GetBinder_ContextIsNull_ThrowsArgumentNullException()
+        {
+            _provider.Invoking(p => p.GetBinder(null)).Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderTests.cs
+++ b/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderTests.cs
@@ -1,0 +1,59 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.ModelBinders;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.ModelBinders
+{
+    public class TrimStringModelBinderTests
+    {
+        private readonly TrimStringModelBinder _binder;
+        private readonly Mock<ModelBindingContext> _mockContext;
+        private readonly Mock<IValueProvider> _mockValueProvider;
+
+        public TrimStringModelBinderTests()
+        {
+            _binder = new TrimStringModelBinder();
+            _mockContext = new Mock<ModelBindingContext>();
+            _mockValueProvider = new Mock<IValueProvider>();
+
+            _mockContext.Setup(m => m.ModelName).Returns("key");
+            _mockContext.Setup(m => m.ValueProvider).Returns(_mockValueProvider.Object);
+        }
+
+        [Fact]
+        public void BindModelAsync_WithNullContext_ThrowsArgumentNullException()
+        {
+            _binder.Awaiting(b => b.BindModelAsync(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void BindModelAsync_WhenValueProviderResultIsNone_CompletesTask()
+        {
+            _mockValueProvider.Setup(m => m.GetValue("key")).Returns(ValueProviderResult.None);
+
+            var task = _binder.BindModelAsync(_mockContext.Object);
+
+            task.Wait();
+            task.Should().Be(Task.CompletedTask);
+        }
+
+        [Fact]
+        public void BindModelAsync_WhenValueIsString_TrimsStringAndCompletesTask()
+        {
+            var modelState = new ModelStateDictionary();
+            var valueProviderResult = new ValueProviderResult("  value  ");
+            _mockValueProvider.Setup(m => m.GetValue("key")).Returns(valueProviderResult);
+            _mockContext.Setup(m => m.ModelState).Returns(modelState);
+
+            var task = _binder.BindModelAsync(_mockContext.Object);
+
+            task.Wait();
+            task.Should().Be(Task.CompletedTask);
+            _mockContext.VerifySet(m => m.Result = ModelBindingResult.Success("value"));
+        }
+    }
+}


### PR DESCRIPTION
When a HTTP request comes in to ASP.NET Web API the payload is bound to a request model; when this happens we hook into the operation and ensure any string attributes are trimmed.

When we read/write JSON string attributes there aren't any instances where having trailing/leading white space would be useful or intentional.

Accepting white space on the start/end of strings is currently causing issues with the postcode validator, as the regex is strict in this respect, yet it shouldn't matter if a user enters a postcode with white space around it.

Initially I attempted doing this with a custom `JsonConverter`, but that only applied to POST request body payloads and not GET query parameters. By using a model binder we should be covered for any content-type.