### PR TITLE
Accept X-Client-IP header on all requests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,7 +44,7 @@ jobs:
                 GetIntoTeachingApi/Migrations/*.cs,\
                 GetIntoTeachingApi/Adapters/*.cs,\
                 GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs,\
-                GetIntoTeachingApi/OperationFilters/AuthOperationFilter.cs,\
+                GetIntoTeachingApi/OperationFilters/*.cs,\
                 GetIntoTeachingApi/Startup.cs,\
                 GetIntoTeachingApi/Program.cs\
             " \

--- a/GetIntoTeachingApi/OperationFilters/ClientIpOperationFilter.cs
+++ b/GetIntoTeachingApi/OperationFilters/ClientIpOperationFilter.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GetIntoTeachingApi.OperationFilters
+{
+    public class ClientIpOperationFilter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var parameter = new OpenApiParameter()
+            {
+                Name = "X-Client-IP",
+                In = ParameterLocation.Header,
+                Description = "IP address of the end user or client " +
+                "application used for rate limiting. Will fall into a globally " +
+                "rate limited bucket if not specified.",
+                Required = false,
+            };
+
+            operation.Parameters.Add(parameter);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -120,6 +120,7 @@ The GIT API aims to provide:
                 });
 
                 c.OperationFilter<AuthOperationFilter>();
+                c.OperationFilter<ClientIpOperationFilter>();
                 c.EnableAnnotations();
                 c.AddFluentValidationRules();
             });


### PR DESCRIPTION
Update the Swagger configuration to accept an `X-Client-IP` header on all requests. The auto-generated library will allow this to be specified per-API request, for example:

```
result = api_instance.get_callback_booking_quotas(x_client_ip: "1.2.3.4")
```

Going forward this IP address will be used to rate limit requests to the API, in addition to the API key of the client (we can create custom IP/Client ID resolvers in the [ASPNetCoreRateLimit](https://github.com/stefanprodan/AspNetCoreRateLimit) package).

If the IP address is unspecified the requests will fall into the rate limiting bucket based solely on the client ID (API key in use).

Can be set to the end user IP address to allow per-user rate limiting in the API. This is how we will be rate limiting individual users when they request a PIN code email (so that they cannot abuse the GOV.UK Notify service to send spam emails).