### PR TITLE
Add CSP violations dashboard

### DIFF
--- a/monitoring/grafana/dashboards/csp_violations.json
+++ b/monitoring/grafana/dashboards/csp_violations.json
@@ -1,0 +1,935 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "iteration": 1603439685425,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [],
+      "repeat": "metric",
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "app_csp_violations_total",
+          "value": "app_csp_violations_total"
+        }
+      },
+      "title": "$metric",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 20,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.2.2",
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "app_csp_violations_total",
+          "value": "app_csp_violations_total"
+        }
+      },
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (violated_directive)",
+          "interval": "",
+          "legendFormat": "{{violated_directive}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations By Directive",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "basic",
+            "filterable": false
+          },
+          "decimals": 0,
+          "displayName": "Total",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(115, 191, 105, 0)",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "blocked_uri"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Blocked URI"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 6,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.2",
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "app_csp_violations_total",
+          "value": "app_csp_violations_total"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (blocked_uri) > 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations by Blocked URI",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "blocked_uri",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "basic",
+            "filterable": false
+          },
+          "decimals": 0,
+          "displayName": "Total",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(115, 191, 105, 0)",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "document_uri"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Document URI"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 15,
+        "y": 1
+      },
+      "id": 9,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.2",
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "app_csp_violations_total",
+          "value": "app_csp_violations_total"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (document_uri) > 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations by Document URI",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "document_uri",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 24,
+      "panels": [],
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "tta_csp_violations_total",
+          "value": "tta_csp_violations_total"
+        }
+      },
+      "title": "$metric",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 20,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 25,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.2.2",
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 4,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "tta_csp_violations_total",
+          "value": "tta_csp_violations_total"
+        }
+      },
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (violated_directive)",
+          "interval": "",
+          "legendFormat": "{{violated_directive}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations By Directive",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "basic",
+            "filterable": false
+          },
+          "decimals": 0,
+          "displayName": "Total",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(115, 191, 105, 0)",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "blocked_uri"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Blocked URI"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 6,
+        "y": 22
+      },
+      "id": 26,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.2",
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 6,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "tta_csp_violations_total",
+          "value": "tta_csp_violations_total"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (blocked_uri) > 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations by Blocked URI",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "blocked_uri",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "basic",
+            "filterable": false
+          },
+          "decimals": 0,
+          "displayName": "Total",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(115, 191, 105, 0)",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "document_uri"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Document URI"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 15,
+        "y": 22
+      },
+      "id": 27,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.2",
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 9,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "metric": {
+          "selected": false,
+          "text": "tta_csp_violations_total",
+          "value": "tta_csp_violations_total"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase($metric[$__range])) by (document_uri) > 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total CSP Violations by Document URI",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "document_uri",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 22,
+      "panels": [],
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-teacher-training-adviser-service-prod",
+          "value": "get-teacher-training-adviser-service-prod"
+        }
+      },
+      "title": "$cf_app",
+      "type": "row"
+    },
+    {
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 23,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "7.2.2",
+      "repeatIteration": 1603439685425,
+      "repeatPanelId": 15,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-teacher-training-adviser-service-prod",
+          "value": "get-teacher-training-adviser-service-prod"
+        }
+      },
+      "targets": [
+        {
+          "bucketAggs": [],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "meta": {},
+              "pipelineVariables": [
+                {
+                  "name": "var1",
+                  "pipelineAgg": "select metric"
+                }
+              ],
+              "settings": {
+                "size": 500
+              },
+              "type": "raw_data"
+            }
+          ],
+          "query": "\"csp-report\" AND cf.app:\"$cf_app\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latest CSP Violations",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "@timestamp",
+                "payload.csp-report.effective-directive",
+                "payload.csp-report.original-policy",
+                "payload.csp-report.referrer",
+                "payload.csp-report.script-sample",
+                "payload.csp-report.status-code",
+                "payload.csp-report.violated-directive",
+                "message"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 21,
+      "panels": [],
+      "repeat": "cf_app",
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-into-teaching-app-prod",
+          "value": "get-into-teaching-app-prod"
+        }
+      },
+      "title": "$cf_app",
+      "type": "row"
+    },
+    {
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 15,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "7.2.2",
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-into-teaching-app-prod",
+          "value": "get-into-teaching-app-prod"
+        }
+      },
+      "targets": [
+        {
+          "bucketAggs": [],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "meta": {},
+              "pipelineVariables": [
+                {
+                  "name": "var1",
+                  "pipelineAgg": "select metric"
+                }
+              ],
+              "settings": {
+                "size": 500
+              },
+              "type": "raw_data"
+            }
+          ],
+          "query": "\"csp-report\" AND cf.app:\"$cf_app\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latest CSP Violations",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "@timestamp",
+                "payload.csp-report.effective-directive",
+                "payload.csp-report.original-policy",
+                "payload.csp-report.referrer",
+                "payload.csp-report.script-sample",
+                "payload.csp-report.status-code",
+                "payload.csp-report.violated-directive",
+                "message"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Metric",
+        "multi": false,
+        "name": "metric",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "app_csp_violations_total",
+            "value": "app_csp_violations_total"
+          },
+          {
+            "selected": false,
+            "text": "tta_csp_violations_total",
+            "value": "tta_csp_violations_total"
+          }
+        ],
+        "query": "app_csp_violations_total, tta_csp_violations_total",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cloud Foundry App",
+        "multi": false,
+        "name": "cf_app",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "get-into-teaching-app-prod",
+            "value": "get-into-teaching-app-prod"
+          },
+          {
+            "selected": false,
+            "text": "get-teacher-training-adviser-service-prod",
+            "value": "get-teacher-training-adviser-service-prod"
+          }
+        ],
+        "query": "get-into-teaching-app-prod, get-teacher-training-adviser-service-prod",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CSP Violations",
+  "uid": "qZjcqcpGz",
+  "version": 1
+}


### PR DESCRIPTION
A dashboard to detail the app/tta CSP violations, including:

- Total violations by directive violated
- Total violations by document URI
- Total violations by blocked URI
- Recent CSP violation log messages

![Screenshot 2020-10-23 at 09 58 14](https://user-images.githubusercontent.com/29867726/96978477-4ff74100-1516-11eb-9b40-783ec1b23555.png)