### PR TITLE
Cache responses from Google Geocoding API

### DIFF
--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -7,8 +7,6 @@ using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using NetTopologySuite;
-using NetTopologySuite.Geometries;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Prometheus;
@@ -58,10 +56,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private static Location CreateLocation(dynamic location)
         {
-            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
-            var coordinate = geometryFactory.CreatePoint(new Coordinate(location.Longitude, location.Latitude));
-
-            return new Location() { Postcode = location.Postcode, Coordinate = coordinate };
+            return new Location(location.Postcode, location.Latitude, location.Longitude);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.RegularExpressions;
+using GetIntoTeachingApi.Database;
+using NetTopologySuite;
 using NetTopologySuite.Geometries;
 
 namespace GetIntoTeachingApi.Models
@@ -18,6 +20,29 @@ namespace GetIntoTeachingApi.Models
         public static string SanitizePostcode(string postcode)
         {
             return Regex.Replace(postcode, @"\s+", string.Empty).ToLower();
+        }
+
+        public Location()
+        {
+        }
+
+        public Location(string postcode)
+            : this()
+        {
+            Postcode = SanitizePostcode(postcode);
+        }
+
+        public Location(string postcode, double latitude, double longitude)
+            : this(postcode)
+        {
+            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
+            Coordinate = geometryFactory.CreatePoint(new Coordinate(longitude, latitude));
+        }
+
+        public Location(string postcode, Point coordinate)
+            : this(postcode)
+        {
+            Coordinate = coordinate;
         }
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -250,7 +250,21 @@ namespace GetIntoTeachingApi.Services
                 return coordinate;
             }
 
-            return await _geocodeClient.GeocodePostcodeAsync(sanitizedPostcode);
+            coordinate = await _geocodeClient.GeocodePostcodeAsync(sanitizedPostcode);
+
+            if (coordinate != null)
+            {
+                await CacheLocation(postcode, coordinate);
+            }
+
+            return coordinate;
+        }
+
+        private async Task CacheLocation(string postcode, Point coordinate)
+        {
+            var location = new Location(postcode, coordinate);
+            await _dbContext.Locations.AddAsync(location);
+            await _dbContext.SaveChangesAsync();
         }
 
         private async Task<Point> GeocodePostcodeWithLocalLookup(string sanitizedPostcode)

--- a/GetIntoTeachingApiTests/Models/LocationTests.cs
+++ b/GetIntoTeachingApiTests/Models/LocationTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using FluentAssertions;
+using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Models;
+using NetTopologySuite;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
@@ -13,6 +15,36 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(Location);
 
             type.GetProperty("Postcode").Should().BeDecoratedWith<KeyAttribute>();
+        }
+
+        [Fact]
+        public void Constructor_WithPostcode()
+        {
+            var location = new Location("KY11 9YU");
+
+            location.Postcode.Should().Be("ky119yu");
+        }
+
+        [Fact]
+        public void Constructor_WithLatitudeLongitude()
+        {
+            var location = new Location("KY11 9YU", 1, 2);
+
+            location.Postcode.Should().Be("ky119yu");
+
+            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
+            var expectedCoordinate = geometryFactory.CreatePoint(new NetTopologySuite.Geometries.Coordinate(2, 1));
+            location.Coordinate.Should().Be(expectedCoordinate);
+        }
+
+        [Fact]
+        public void Constructor_WithCoordinate()
+        {
+            var coordinate = new NetTopologySuite.Geometries.Point(new NetTopologySuite.Geometries.Coordinate(1, 2));
+            var location = new Location("KY11 9YU", coordinate);
+
+            location.Postcode.Should().Be("ky119yu");
+            location.Coordinate.Should().Be(coordinate);
         }
 
         [Theory]


### PR DESCRIPTION
When we can't find a postcode geolocation from our local cache we go off to the Google Geocoding API. We're finding that many teaching events share the same postcode, so we're requesting it multiple times from Google during a sync, which both slows the sync down and costs us money. Instead, this commit persists the location to our cache so that subsequent lookups don't  need to hit Google's API.