### PR TITLE
Add deployment annotation to dashboard

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -9,14 +9,26 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "Elasticseach",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Deployments",
+        "query": "\"Application started\" AND cf.app:\"get-into-teaching-api-prod\"",
+        "showIn": 0,
+        "tags": [],
+        "type": "tags"
       }
     ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1603453250555,
+  "id": 5,
+  "iteration": 1603706211365,
   "links": [],
   "panels": [
     {
@@ -1680,10 +1692,10 @@
           "refId": "A"
         },
         {
-          "expr": "sum(increase(http_requests_received_total{controller=~\".+\",action=~\".+\",code=~\"4..\"}[$__range]))",
+          "expr": "sum(increase(http_requests_received_total{controller=~\".+\",action=~\".+\",code!~\"[^4]..|404\"}[$__range]))",
           "instant": true,
           "interval": "",
-          "legendFormat": "4xx",
+          "legendFormat": "4xx (!404)",
           "refId": "B"
         },
         {
@@ -1699,6 +1711,12 @@
           "interval": "",
           "legendFormat": "3xx",
           "refId": "D"
+        },
+        {
+          "expr": "sum(increase(http_requests_received_total{controller=~\".+\",action=~\".+\",code=~\"404\"}[$__range]))",
+          "interval": "",
+          "legendFormat": "404",
+          "refId": "E"
         }
       ],
       "timeFrom": null,
@@ -1832,6 +1850,7 @@
       "targets": [
         {
           "expr": "sum(rate(http_requests_received_total[3m])) by (controller)",
+          "interval": "",
           "legendFormat": "{{controller}}",
           "refId": "A"
         }
@@ -1846,6 +1865,25 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "CallbackBookingQuotas",
+                "Candidates",
+                "MailingList",
+                "Operations",
+                "PrivacyPolicies",
+                "TeachingEvents",
+                "Types",
+                "Time"
+              ]
+            }
+          }
+        }
+      ],
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2380,7 +2418,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(245, 54, 54, 0.9)"
           ],
-          "decimals": 2,
+          "decimals": 0,
           "pattern": "/.*/",
           "thresholds": [
             "0.1",
@@ -2571,7 +2609,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
Add a deployment annotation to the dashboard, useful for linking a change in the graphs to a particular deployment.

Remove 404's from 'error' panels, as 404s are expected in a number of scenarios (unsuccessful matchback).

<img width="705" alt="Screenshot 2020-10-26 at 09 36 10" src="https://user-images.githubusercontent.com/29867726/97156519-b8405f80-176e-11eb-9ee6-32fa56421c23.png">
