### PR TITLE
Add endpoint to get upcoming events by type

### DIFF
--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -18,5 +18,6 @@ namespace GetIntoTeachingApi.Services
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
+        IQueryable<TeachingEvent> GetUpcomingTeachingEvents();
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -110,6 +110,14 @@ namespace GetIntoTeachingApi.Services
             return await _dbContext.TeachingEvents.Include(e => e.Building).FirstOrDefaultAsync(e => e.ReadableId == readableId);
         }
 
+        public IQueryable<TeachingEvent> GetUpcomingTeachingEvents()
+        {
+            return _dbContext.TeachingEvents
+                .Include(e => e.Building)
+                .OrderBy(e => e.StartAt)
+                .Where(e => e.StartAt >= DateTime.UtcNow);
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -361,7 +361,7 @@ namespace GetIntoTeachingApiTests.Services
             var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(
-                new string[] { "Event 2", "Event 4", "Event 1", "Event 3", "Event 5", "Event 6", "Event 7" },
+                new string[] { "Event 7", "Event 2", "Event 4", "Event 1", "Event 3", "Event 5", "Event 6" },
                 options => options.WithStrictOrdering());
         }
 
@@ -420,7 +420,7 @@ namespace GetIntoTeachingApiTests.Services
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4" },
+            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2" },
                 options => options.WithStrictOrdering());
         }
 
@@ -432,7 +432,7 @@ namespace GetIntoTeachingApiTests.Services
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 3", "Event 5", "Event 6", "Event 7" },
+            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 3", "Event 5", "Event 6" },
                 options => options.WithStrictOrdering());
         }
 
@@ -444,7 +444,7 @@ namespace GetIntoTeachingApiTests.Services
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 4", "Event 1" },
+            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 7", "Event 2", "Event 4", "Event 1" },
                 options => options.WithStrictOrdering());
         }
 
@@ -466,6 +466,18 @@ namespace GetIntoTeachingApiTests.Services
 
             result.ReadableId.Should().Be(events.First().ReadableId);
             result.Building.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetUpcomingTeachingEventsByTypeAsync_ReturnsUpcomingEventsGroupedByType()
+        {
+            await SeedMockTeachingEventsAsync();
+
+            var result = _store.GetUpcomingTeachingEvents();
+
+            var dates = result.Select(e => e.StartAt);
+            dates.Should().BeEquivalentTo(dates.OrderBy(d => d), options => options.WithStrictOrdering());
+            dates.Should().OnlyContain(d => d >= DateTime.UtcNow);
         }
 
         private static IEnumerable<TeachingEvent> MockTeachingEvents()
@@ -522,7 +534,7 @@ namespace GetIntoTeachingApiTests.Services
                 ReadableId = "4",
                 Name = "Event 4",
                 StartAt = DateTime.UtcNow.AddDays(3),
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeId = (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
                 Building = new TeachingEventBuilding()
                 {
                     Id = Guid.NewGuid(),
@@ -559,7 +571,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "7",
                 Name = "Event 7",
-                StartAt = DateTime.UtcNow.AddYears(1),
+                StartAt = DateTime.UtcNow.AddYears(-1),
                 TypeId = (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
                 Building = new TeachingEventBuilding()
                 {


### PR DESCRIPTION
- Add endpoint to get upcoming events by type

When a user lands on the events index page in the website we want to be able to show them the next 3 events that are upcoming for each type. This improves the user experience when we are approaching the end of the month and there are no
longer any events within the current month to display.

Adds a new endpoint `/api/teaching_events/upcoming_indexed_by_type` that will return the upcoming teaching events grouped by their type.

The return type is `Dictionary<string, IEnumerable<TeachingEvent>>` due to `System.Text.Json` not yet supporting non-string Dictionary keys (it would be preferable to use an `int` here).

Adds a `/api/teaching_events/search_indexed_by_type` for consistency, with a view to removing the current `/search` endpoint once deprecated in the front end.

```
{
  "222750001": [
    {
      "typeId": 222750001,
      "id": "1d3d055a-84dd-ea11-a813-000d3a44afcc",
      ...
    },
    {
      "typeId": 222750001,
      "id": "293d055a-84dd-ea11-a813-000d3a44afcc",
      ...
    }
  ],
  "222750008": [
    {
      "typeId": 222750008,
      "id": "f5a82568-f402-eb11-a812-000d3a44af3f",
      ...
    },
    ...
  ]
}
```