### PR TITLE
Rate limit vulnerable endpoints by client 

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -5,6 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AspNetCoreRateLimit" Version="3.0.5" />
 		<PackageReference Include="CsvHelper" Version="15.0.5" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,13 +1,26 @@
+using System.Threading.Tasks;
+using AspNetCoreRateLimit;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace GetIntoTeachingApi
 {
     public static class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            var webHost = CreateHostBuilder(args).Build();
+
+            using var scope = webHost.Services.CreateScope();
+
+            // Get the ClientPolicyStore instance.
+            var clientPolicyStore = scope.ServiceProvider.GetRequiredService<IClientPolicyStore>();
+
+            // Seed client data from appsettings.
+            await clientPolicyStore.SeedAsync();
+
+            await webHost.RunAsync();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -7,5 +7,40 @@
       "Hangfire": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ClientRateLimiting": {
+    "EnableEndpointRateLimiting": true,
+    "StackBlockedRequests": false,
+    "ClientIdHeader": "Authorization",
+    "HttpStatusCode": 429,
+    "EndpointWhitelist": [ "*:/api/operations/*" ],
+    "ClientWhitelist": [],
+    "GeneralRules": [
+      {
+        "Endpoint": "POST:/api/candidates/access_tokens",
+        "Period": "1m",
+        "Limit": 30
+      },
+      {
+        "Endpoint": "POST:/api/teacher_training_adviser/candidates",
+        "Period": "1m",
+        "Limit": 30
+      },
+      {
+        "Endpoint": "POST:/api/mailing_list/members",
+        "Period": "1m",
+        "Limit": 30
+      },
+      {
+        "Endpoint": "POST:/api/teaching_events/attendees",
+        "Period": "1m",
+        "Limit": 30
+      },
+      {
+        "Endpoint": "POST:/api/teacher_training_adviser/candidates",
+        "Period": "1m",
+        "Limit": 30
+      }
+    ]
+  }
 }

--- a/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Integration
+{
+    public class RateLimitingTests
+    {
+        private readonly HttpClient _client;
+
+        public RateLimitingTests()
+        {
+            var factory = new WebApplicationFactory<Startup>();
+            _client = factory.CreateClient();
+
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Token 1");
+        }
+
+        [Theory]
+        [InlineData("/api/candidates/access_tokens", 30)]
+        [InlineData("/api/mailing_list/members", 30)]
+        [InlineData("/api/teaching_events/attendees", 30)]
+        [InlineData("/api/teacher_training_adviser/candidates", 30)]
+        public async void Path_ExceedingRateLimit_ReturnsStatus429TooManyRequests(string path, int limit)
+        {
+            HttpResponseMessage response = null;
+
+            for (var count = 0; count < limit + 1; count++)
+            {
+                response = await _client.PostAsync(path, new StringContent("{}"));
+            }
+
+            response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Token 2");
+
+            response = await _client.PostAsync(path, new StringContent("{}"));
+
+            response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ We run Entity Framework Core in order to persist models/data to a Postgres datab
 
 Migrations are applied from code when the application starts (see `DbConfiguration.cs`). You can add a migration by modifying the models and running `Add-Migration MyNewMigration` from the package manager console. As we run SQLite in development and Postgres in production we need to tell EF Core which provider to use at design-time; the `GetIntoTeachingDbContextFactory` takes care of this.
 
+### Rate Limiting
+
+We use [AspNetCoreRateLimit](https://github.com/stefanprodan/AspNetCoreRateLimit) to rate limit clients based on their access token (the value passed in the `Authorization` header). Currently both our clients share the same access token, but we envisage splitting that up in the future.
+
+It is the responsibility of the API client to rate limit on a per-user basis to ensure the global rate limiting of their access token is not exceeded.
+
+We apply the same rate limits irrespective of client at the moment, but going forward we could offer per-client rate limiting using the library.
+
+The rate limit counters are currently stored in memory, but we will change this going forward to use Redis so that they are shared between instances.
+
 ### Deployment
 
 Deployment is via Terraform and the key will be stored in Azure.

--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1603706211365,
+  "id": 2,
+  "iteration": 1603898445768,
   "links": [],
   "panels": [
     {
@@ -1749,7 +1749,7 @@
       },
       "fontSize": "100%",
       "gridPos": {
-        "h": 10,
+        "h": 12,
         "w": 12,
         "x": 0,
         "y": 69
@@ -1796,6 +1796,483 @@
       "type": "table-old"
     },
     {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnBu",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 20,
+      "legend": {
+        "show": true
+      },
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "expr": "sum(increase(http_request_duration_seconds_bucket[$__interval])) by (le) ",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Response Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "ms",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "aliasColors": {
+        "deleted": "red",
+        "failed": "dark-red",
+        "processing": "purple",
+        "retry": "yellow",
+        "succeeded": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 81
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(api_hangfire_jobs{state=~\"succeeded|deleted|failed|enqueued|processing|retry|scheduled\"}[10m]) ",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Hangfire Jobs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 81
+      },
+      "hiddenSeries": false,
+      "id": 60,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "/candidates/access_tokens",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "1m",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/candidates/access_tokens\" AND access.method:\"POST\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "/teaching_events/attendees",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/teaching_events/attendees\" AND access.method:\"POST\"",
+          "refId": "B",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "/mailing_list/members",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/mailing_list/members\" AND access.method:\"POST\"",
+          "refId": "C",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "/teacher_training_adviser/candidates",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/teacher_training_adviser/candidates\" AND access.method:\"POST\"",
+          "refId": "D",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 30,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 15,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rate Limited Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": "35",
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "50",
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(http_request_duration_seconds_count[1m]))",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Requests/s",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1815,7 +2292,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 69
+        "y": 91
       },
       "hiddenSeries": false,
       "id": 54,
@@ -1916,177 +2393,13 @@
       }
     },
     {
-      "cards": {
-        "cardPadding": null,
-        "cardRound": null
-      },
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateGnBu",
-        "exponent": 0.5,
-        "max": null,
-        "min": null,
-        "mode": "spectrum"
-      },
-      "dataFormat": "timeseries",
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 0,
-        "y": 79
-      },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 20,
-      "legend": {
-        "show": true
-      },
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "expr": "sum(increase(http_request_duration_seconds_bucket[$__interval])) by (le) ",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Response Time",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "xBucketNumber": null,
-      "xBucketSize": null,
-      "yAxis": {
-        "decimals": null,
-        "format": "ms",
-        "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true,
-        "splitFactor": null
-      },
-      "yBucketBound": "auto",
-      "yBucketNumber": null,
-      "yBucketSize": null
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 12,
-        "y": 79
-      },
-      "hiddenSeries": false,
-      "id": 18,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.2.2",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(http_request_duration_seconds_count[1m]))",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Requests/s",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "reqps",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 101
       },
       "id": 34,
       "panels": [],
@@ -2094,118 +2407,13 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "deleted": "red",
-        "failed": "dark-red",
-        "processing": "purple",
-        "retry": "yellow",
-        "succeeded": "green"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 92
-      },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.2.2",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "increase(api_hangfire_jobs{state=~\"succeeded|deleted|failed|enqueued|processing|retry|scheduled\"}[10m]) ",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{state}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Hangfire Jobs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 102
       },
       "id": 42,
       "panels": [],
@@ -2253,7 +2461,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 105
+        "y": 103
       },
       "id": 27,
       "interval": null,
@@ -2328,7 +2536,7 @@
         "h": 10,
         "w": 4,
         "x": 4,
-        "y": 105
+        "y": 103
       },
       "id": 55,
       "interval": null,
@@ -2399,7 +2607,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 105
+        "y": 103
       },
       "id": 57,
       "pageSize": null,
@@ -2462,7 +2670,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 105
+        "y": 103
       },
       "hiddenSeries": false,
       "id": 58,


### PR DESCRIPTION
- Enforce rate limiting to vulnerable endpoints

Rate limits endpoints that could be exploited:

```
POST /candidates/access_tokens
POST /mailing_list/members
POST /teaching_events/attendees
POST /teacher_training_adviser/candidates
```

Set to 30 requests/min which is well above the current traffic (peaking at ~2rpm). This should have enough buffer in it for when we go up to 40% rollout.

The /operations endpoints are excluded from rate limiting.

- Add graph to monitor rate limited requests

Adds a graph to display the requests/minute for each of the rate limited endpoints. The panel also has thresholds for 15rpm (warning) and 30rpm (critical) so that we can see when traffic is approaching the rate limits and needs to be adjusted.

<img width="692" alt="Screenshot 2020-10-28 at 15 27 05" src="https://user-images.githubusercontent.com/29867726/97458460-a14a6a80-1932-11eb-8248-261fd5a32a65.png">
