### PR TITLE
Add alert rules for any 429s and high 404s

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -7,3 +7,39 @@ groups:
         severity: page
       annotations:
         summary: Development High CPU
+  - name: App
+    rules:
+    - alert: TooManyRequests
+      expr: sum(increase(app_requests_total{path=~".+",status=~"2.."}[1m])) > 0
+      labels:
+        severity: page
+      annotations:
+        summary: Alert when any user hits a rate limit.
+    - alert: HighNotFound
+      expr: sum(increase(app_requests_total{path=~".+",status=~"404"}[10m])) > 15
+      labels:
+        severity: page
+      annotations:
+        summary: Alert when any user hits a rate limit.
+  - name: TTA
+    rules:
+    - alert: TooManyRequests
+      expr: sum(increase(tta_requests_total{path=~".+",status=~"2.."}[1m])) > 0
+      labels:
+        severity: page
+      annotations:
+        summary: Alert when any user hits a rate limit.
+    - alert: HighNotFound
+      expr: sum(increase(tta_requests_total{path=~".+",status=~"404"}[10m])) > 15
+      labels:
+        severity: page
+      annotations:
+        summary: Alert when any user hits a rate limit.
+  - name: API
+    rules:
+    - alert: TooManyRequests
+      expr: sum(increase(http_requests_received_total{controller=~".+",action=~".+",code=~"429"}[1m])) > 0
+      labels:
+        severity: page
+      annotations:
+        summary: Alert when any client hits a rate limit.


### PR DESCRIPTION
As a first attempt at getting some metric alerting in place, this should inform us when a client or end user receives a 429 response (too many requests) or if there are high numbers of 404s being triggered in the app/tta services.