### PR TITLE
Introduce HighNotFound and TooManyRequests alerts

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -1,10 +1,39 @@
 groups:
   - name: App
     rules:
-      - alert: HighNotFound
-        expr: 'sum by (space) (app_requests_total{path=~".+",status=~"404"}) > 0'
+      - alert: TooManyRequests
+        expr: 'sum(increase(app_requests_total{path=~".+",status=~"429"}[1m])) > 0'
         labels:
-          severity: page
+          severity: high
         annotations:
           summary: Alert when any user hits a rate limit.
-          
+      - alert: HighNotFound
+        expr: 'sum(increase(app_requests_total{path=~".+",status=~"404"}[10m])) > 15'
+        labels:
+          severity: medium
+        annotations:
+          summary: Alert when any user hits a rate limit.
+  - name: TTA
+    rules:
+      - alert: TooManyRequests
+        expr: 'sum(increase(tta_requests_total{path=~".+",status=~"429"}[1m])) > 0'
+        labels:
+          severity: high
+        annotations:
+          summary: Alert when any user hits a rate limit.
+      - alert: HighNotFound
+        expr: 'sum(increase(tta_requests_total{path=~".+",status=~"404"}[10m])) > 15'
+        labels:
+          severity: medium
+        annotations:
+          summary: Alert when any user hits a rate limit.
+  - name: API
+    rules:
+      - alert: TooManyRequests
+        expr: >-
+          sum(increase(http_requests_received_total{controller=~".+",action=~".+",code=~"429"}[1m]))
+          > 0
+        labels:
+          severity: high
+        annotations:
+          summary: Alert when any client hits a rate limit.


### PR DESCRIPTION
Alert on high numbers of 404 requests (>15 in 10 minute period) and any 429 requests.