### PR TITLE
Run EF Core migrations from CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,25 @@ RUN dotnet publish -c release -o /app --no-restore
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 # Upgrade the distrubution to clear CVE warning
-RUN apt-get update -y && apt-get dist-upgrade  -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+# and install .net core SDK
+RUN apt-get update -y && \
+	apt-get dist-upgrade -y && \
+	apt-get install --no-install-recommends wget=1.20.1-1.1 -y && \
+	wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+	dpkg -i packages-microsoft-prod.deb && \
+	apt-get install -y --no-install-recommends apt-transport-https=1.8.2.1 && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends dotnet-sdk-3.1=3.1.403-1 && \
+    apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# Install dotnet-ef for running migrations
+RUN dotnet tool install --global dotnet-ef
 
 WORKDIR /app
 COPY --from=build /app ./
-ENTRYPOINT ["dotnet", "GetIntoTeachingApi.dll"]
+COPY entrypoint.sh ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
 ENV ASPNETCORE_URLS=http://+:8080
 ARG GIT_COMMIT_SHA
 ENV GIT_COMMIT_SHA ${GIT_COMMIT_SHA}

--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -40,11 +40,7 @@ namespace GetIntoTeachingApi.Database
         {
             var migrationsAreSupported = _dbContext.Database.ProviderName != "Microsoft.EntityFrameworkCore.Sqlite";
 
-            if (migrationsAreSupported)
-            {
-                _dbContext.Database.Migrate();
-            }
-            else
+            if (!migrationsAreSupported)
             {
                 _dbContext.Database.EnsureCreated();
             }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+dotnet ef database update
+dotnet GetIntoTeachingApi.dll


### PR DESCRIPTION
EF Core advise against running the migrations at runtime in case two instances attempt to execute them at the same time. They recommend exporting the migrations to SQL and running them manually, which is overkill for what we need so a happy medium is to run the via the CLI before the instance starts.