### PR TITLE
Attempt to run migrations from CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,10 @@ RUN dotnet publish -c release -o /app --no-restore
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 # Upgrade the distrubution to clear CVE warning
-# and install .net core SDK
 RUN apt-get update -y && \
 	apt-get dist-upgrade -y && \
-	apt-get install --no-install-recommends wget=1.20.1-1.1 -y && \
-	wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-	dpkg -i packages-microsoft-prod.deb && \
-	apt-get install -y --no-install-recommends apt-transport-https=1.8.2.1 && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends dotnet-sdk-3.1=3.1.403-1 && \
     apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
-
-# Install dotnet-ef for running migrations
-RUN dotnet tool install --global dotnet-ef
 
 WORKDIR /app
 COPY --from=build /app ./

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,12 @@
-dotnet ef database update
+# See https://www.benday.com/2017/03/17/deploy-entity-framework-core-migrations-from-a-dll/
+EfMigrationsNamespace=GetIntoTeachingApi
+EfMigrationsDllName=GetIntoTeachingApi.dll
+EfMigrationsDllDepsJson=GetIntoTeachingApi.deps.json
+DllDir=$PWD
+EfMigrationsDllDepsJsonPath=$PWD/bin/$BuildFlavor/netcoreapp1.0/$EfMigrationsDllDepsJson
+PathToNuGetPackages=$HOME/.nuget/packages
+PathToEfDll=$PathToNuGetPackages/microsoft.entityframeworkcore.tools.dotnet/3.1.9/tools/netcoreapp1.0/ef.dll
+
+dotnet exec --depsfile ./$EfMigrationsDllDepsJson --additionalprobingpath $PathToNuGetPackages $PathToEfDll database update --assembly ./$EfMigrationsDllName --startup-assembly ./$EfMigrationsDllName --project-dir . --content-root $DllDir --data-dir $DllDir --verbose --root-namespace $EfMigrationsNamespace
+
 dotnet GetIntoTeachingApi.dll


### PR DESCRIPTION
The `dotnet ef database update` command only works when we have access to the source code; in CI we only have access to the published app DLL. In order to run the migrations we have to use `dotnet exec` directly, which is what `dotnet ef` calls under the hood.