### PR TITLE
Run migrations earlier

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -36,13 +37,18 @@ namespace GetIntoTeachingApi.Database
             builder.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite());
         }
 
-        public void Configure()
+        public async Task ConfigureAsync()
         {
             var migrationsAreSupported = _dbContext.Database.ProviderName != "Microsoft.EntityFrameworkCore.Sqlite";
 
             if (migrationsAreSupported)
             {
-                _dbContext.Database.Migrate();
+                var pendingMigrations = await _dbContext.Database.GetPendingMigrationsAsync();
+
+                if (pendingMigrations.Any())
+                {
+                    _dbContext.Database.Migrate();
+                }
             }
             else
             {

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using AspNetCoreRateLimit;
+using GetIntoTeachingApi.Database;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,6 +20,10 @@ namespace GetIntoTeachingApi
 
             // Seed client data from appsettings.
             await clientPolicyStore.SeedAsync();
+
+            // Configure the database.
+            var dbConfiguration = scope.ServiceProvider.GetRequiredService<DbConfiguration>();
+            await dbConfiguration.ConfigureAsync();
 
             await webHost.RunAsync();
         }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -212,10 +212,6 @@ The GIT API aims to provide:
                 (x) => x.RunAsync("https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip"),
                 Cron.Weekly());
 
-            // Configure the database.
-            var dbConfiguration = serviceScope.ServiceProvider.GetService<DbConfiguration>();
-            dbConfiguration.Configure();
-
             // Don't seed test environment.
             if (!env.IsTest)
             {

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -18,7 +18,8 @@ namespace GetIntoTeachingApiTests.Helpers
             DbConfiguration.ConfigSqLite(builder, _keepAliveConnection);
 
             DbContext = new GetIntoTeachingDbContext(builder.Options);
-            new DbConfiguration(DbContext).Configure();
+            var dbConfiguration = new DbConfiguration(DbContext);
+            dbConfiguration.ConfigureAsync().Wait();
         }
 
         public void Dispose() => _keepAliveConnection.Dispose();


### PR DESCRIPTION
We are getting permission errors occasionally on deployment due to migrations running on multiple instances. To reduce of the chance of this happening this commit will run migrations earlier (hopefully before the application has fully 'started' so before the second instance gets spun up) and also check to ensure pending migrations exist before attempting to run them.