### PR TITLE
Ignore leading/trailing whitespace in match-back

### DIFF
--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApi.Models
 
         private bool EmailMatchesCandidate(Entity entity)
         {
-            return entity.GetAttributeValue<string>("emailaddress1").Equals(Email, StringComparison.OrdinalIgnoreCase);
+            return entity.GetAttributeValue<string>("emailaddress1").Trim().Equals(Email, StringComparison.OrdinalIgnoreCase);
         }
 
         private string[] AdditionalAttributeValues(string firstName, string lastName, DateTime? dateOfBirth)
@@ -50,8 +50,8 @@ namespace GetIntoTeachingApi.Models
         {
             var matches = AdditionalAttributeValues(FirstName, LastName, DateOfBirth).Intersect(
                 AdditionalAttributeValues(
-                    entity.GetAttributeValue<string>("firstname"),
-                    entity.GetAttributeValue<string>("lastname"),
+                    entity.GetAttributeValue<string>("firstname")?.Trim(),
+                    entity.GetAttributeValue<string>("lastname")?.Trim(),
                     entity.GetAttributeValue<DateTime>("birthdate")), StringComparer.OrdinalIgnoreCase);
 
             return matches.Count() >= MinimumAdditionalAttributeMatches;

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -73,7 +73,10 @@ namespace GetIntoTeachingApi.Services
             var entity = _service.CreateQuery("contact", context)
                 .Where(e =>
                     e.GetAttributeValue<int>("statecode") == (int)Candidate.Status.Active &&
-                    e.GetAttributeValue<string>("emailaddress1") == request.Email) // Will perform a case-insensitive comparison
+
+                    // Will perform a case-insensitive comparison.
+                    // Contains is used to ensure we match emails with white space (request.Match does an exact match in-memory).
+                    e.GetAttributeValue<string>("emailaddress1").Contains(request.Email))
                 .OrderByDescending(e => e.GetAttributeValue<double>("dfe_duplicatescorecalculated"))
                 .ThenByDescending(e => e.GetAttributeValue<DateTime>("modifiedon"))
                 .Take(MaximumNumberOfCandidatesToMatch)

--- a/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
@@ -3,7 +3,6 @@ using GetIntoTeachingApi.Models;
 using System;
 using Microsoft.Xrm.Sdk;
 using Xunit;
-using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApiTests.Models
 {
@@ -54,6 +53,17 @@ namespace GetIntoTeachingApiTests.Models
             entity["emailaddress1"] = _request.Email;
             entity["firstname"] = _request.FirstName;
             entity["lastname"] = _request.LastName;
+
+            _request.Match(entity).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Match_WithEmailAndTwoAdditionalAttributesContainingWhitespace_ReturnsTrue()
+        {
+            var entity = new Entity();
+            entity["emailaddress1"] = $" {_request.Email} ";
+            entity["firstname"] = $" {_request.FirstName} ";
+            entity["lastname"] = $" {_request.LastName} ";
 
             _request.Match(entity).Should().BeTrue();
         }

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -271,6 +271,7 @@ namespace GetIntoTeachingApiTests.Services
         [InlineData("john@doe.com", "New John", "Doe", "New John")]
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
         [InlineData("jane@doe.com", "Jane", "Doe", "Jane")]
+        [InlineData(" jane@doe.com ", " Jane ", " Doe ", "Jane")]
         [InlineData("bob@doe.com", "Bob", "Doe", null)]
         [InlineData("inactive@doe.com", "Inactive", "Doe", null)]
         public void MatchCandidate_WithExistingCandidateRequest_MatchesOnNewestCandidateWithEmail(


### PR DESCRIPTION
The CRM contains some candidates that have leading/trailing white space around their first name, last name and email address.

Ignore white space when comparing first/last name and email address.

Match on emails containing the provided email string initially (to positively match even if the email in the CRM has white space) - we do another, exact match as part of the in-memory match-back.