### PR TITLE
Disable rate limiting in Staging environments

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -157,10 +157,13 @@ The GIT API aims to provide:
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment hostEnv)
         {
-            app.UseClientRateLimiting();
-
             using var serviceScope = app.ApplicationServices.CreateScope();
             var env = serviceScope.ServiceProvider.GetService<IEnv>();
+
+            if (!env.IsStaging)
+            {
+                app.UseClientRateLimiting();
+            }
 
             if (hostEnv.IsDevelopment())
             {


### PR DESCRIPTION
The API uses the staging environment for all production-like environments; we don't want to enforce rate limiting in these environments so that the integration tests can successfully run.