### PR TITLE
Increase rate limits from 30 to 60 rpm

### DIFF
--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -19,27 +19,27 @@
       {
         "Endpoint": "POST:/api/candidates/access_tokens",
         "Period": "1m",
-        "Limit": 30
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/teacher_training_adviser/candidates",
         "Period": "1m",
-        "Limit": 30
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/mailing_list/members",
         "Period": "1m",
-        "Limit": 30
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/teaching_events/attendees",
         "Period": "1m",
-        "Limit": 30
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/teacher_training_adviser/candidates",
         "Period": "1m",
-        "Limit": 30
+        "Limit": 60
       }
     ]
   }

--- a/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
@@ -21,10 +21,10 @@ namespace GetIntoTeachingApiTests.Integration
         }
 
         [Theory]
-        [InlineData("/api/candidates/access_tokens", 30)]
-        [InlineData("/api/mailing_list/members", 30)]
-        [InlineData("/api/teaching_events/attendees", 30)]
-        [InlineData("/api/teacher_training_adviser/candidates", 30)]
+        [InlineData("/api/candidates/access_tokens", 60)]
+        [InlineData("/api/mailing_list/members", 60)]
+        [InlineData("/api/teaching_events/attendees", 60)]
+        [InlineData("/api/teacher_training_adviser/candidates", 60)]
         public async void Path_ExceedingRateLimit_ReturnsStatus429TooManyRequests(string path, int limit)
         {
             HttpResponseMessage response = null;

--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -28,7 +28,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1603898445768,
+  "iteration": 1604487342784,
   "links": [],
   "panels": [
     {
@@ -850,7 +850,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cpu_percent",
+          "expr": "cpu_percent{space=\"$Space\"}",
+          "interval": "",
           "legendFormat": "{{service}}",
           "refId": "A"
         }
@@ -924,7 +925,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -946,6 +947,7 @@
       "targets": [
         {
           "expr": "dotnet_total_memory_bytes",
+          "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1040,7 +1042,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "connections",
+          "expr": "connections{space=\"$Space\"}",
+          "interval": "",
           "legendFormat": "{{service}}",
           "refId": "A"
         }
@@ -1834,6 +1837,7 @@
       "targets": [
         {
           "expr": "sum(increase(http_request_duration_seconds_bucket[$__interval])) by (le) ",
+          "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2124,7 +2128,7 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 30,
+          "value": 60,
           "yaxis": "left"
         },
         {
@@ -2132,7 +2136,7 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 15,
+          "value": 30,
           "yaxis": "left"
         }
       ],
@@ -2159,7 +2163,7 @@
           "format": "short",
           "label": "",
           "logBase": 1,
-          "max": "35",
+          "max": "65",
           "min": "0",
           "show": true
         },
@@ -2813,11 +2817,44 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "get-into-teaching-production",
+          "value": "get-into-teaching-production"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Space",
+        "options": [
+          {
+            "selected": true,
+            "text": "get-into-teaching-production",
+            "value": "get-into-teaching-production"
+          },
+          {
+            "selected": false,
+            "text": "get-into-teaching-test",
+            "value": "get-into-teaching-test"
+          },
+          {
+            "selected": false,
+            "text": "get-into-teaching",
+            "value": "get-into-teaching"
+          }
+        ],
+        "query": "get-into-teaching-production,get-into-teaching-test,get-into-teaching",
+        "skipUrlSync": false,
+        "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
- Up rate limits from 30 to 60 requests/minute

We're seeing spikes up to around 15rpm so this should give us plenty of breathing room for when we increase the rollout distribution.

- Restrict infrastructure metrics by space

To avoid over requesting data this scopes the infrastructure metrics by space.

Increases the threshold indicators on the rate limiting indicators to 30 (warning) and 60 (critical) as we are seeing spikes up to ~15 requests/minute at busy periods, so the rate limiting will be altered in a follow up commit.