### PR TITLE
Only run migrations on first instance

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -37,18 +36,14 @@ namespace GetIntoTeachingApi.Database
             builder.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite());
         }
 
-        public async Task ConfigureAsync()
+        public void Configure(IEnv env)
         {
             var migrationsAreSupported = _dbContext.Database.ProviderName != "Microsoft.EntityFrameworkCore.Sqlite";
+            var firstInstance = env.InstanceIndex == 0;
 
-            if (migrationsAreSupported)
+            if (migrationsAreSupported && firstInstance)
             {
-                var pendingMigrations = await _dbContext.Database.GetPendingMigrationsAsync();
-
-                if (pendingMigrations.Any())
-                {
-                    _dbContext.Database.Migrate();
-                }
+                _dbContext.Database.Migrate();
             }
             else
             {

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using AspNetCoreRateLimit;
 using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Utils;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -23,7 +24,8 @@ namespace GetIntoTeachingApi
 
             // Configure the database.
             var dbConfiguration = scope.ServiceProvider.GetRequiredService<DbConfiguration>();
-            await dbConfiguration.ConfigureAsync();
+            var env = scope.ServiceProvider.GetRequiredService<IEnv>();
+            dbConfiguration.Configure(env);
 
             await webHost.RunAsync();
         }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -22,5 +22,6 @@ namespace GetIntoTeachingApi.Utils
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
         public string PenTestSharedSecret => Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+        public int InstanceIndex => int.Parse(Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX"));
     }
 }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -20,5 +20,6 @@
         string SharedSecret { get; }
         string PenTestSharedSecret { get; }
         string GoogleApiKey { get; }
+        int InstanceIndex { get; }
     }
 }

--- a/GetIntoTeachingApiTests/Database/DbConfigurationTests.cs
+++ b/GetIntoTeachingApiTests/Database/DbConfigurationTests.cs
@@ -2,7 +2,6 @@
 using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Utils;
-using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Utils;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 
 namespace GetIntoTeachingApiTests.Helpers
 {
@@ -14,12 +16,13 @@ namespace GetIntoTeachingApiTests.Helpers
         {
             _keepAliveConnection = new SqliteConnection("DataSource=:memory:");
 
+            var envMock = new Mock<IEnv>();
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
             DbConfiguration.ConfigSqLite(builder, _keepAliveConnection);
 
             DbContext = new GetIntoTeachingDbContext(builder.Options);
             var dbConfiguration = new DbConfiguration(DbContext);
-            dbConfiguration.ConfigureAsync().Wait();
+            dbConfiguration.Configure(envMock.Object);
         }
 
         public void Dispose() => _keepAliveConnection.Dispose();

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -217,5 +217,16 @@ namespace GetIntoTeachingApiTests.Utils
 
             Environment.SetEnvironmentVariable("GOOGLE_API_KEY", previous);
         }
+
+        [Fact]
+        public void InstanceIndex_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", "0");
+
+            _env.InstanceIndex.Should().Be(0);
+
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", previous);
+        }
     }
 }


### PR DESCRIPTION
We are getting conflicts because two instances are trying to run the migrations at the same time.

Restrict to instance 0 running the migrations, which should be the first instance spun up in a deployment.