### PR TITLE
Correct API rate limit alert rule

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -86,7 +86,7 @@ groups:
         annotations:
           summary: Alert when the Google API returns a non-success response.
       - alert: ClientApproachingRateLimit
-        expr: 'sum(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"CreateAccessToken|AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 30'
+        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"CreateAccessToken|AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 30'
         labels:
           severity: medium
         annotations:


### PR DESCRIPTION
The rate limit was applying to the `sum` of all possible rate limited endpoints, so it would fire if we had 10 TTA sign ups and 20 mailing list sign ups, when it should only fire if any one of the rate limited endpoints exceeds 30rpm.

Change `sum` to `max` corrects the behaviour.