### PR TITLE
Track how long UpsertCandidateJobs spend in the queue

### DIFF
--- a/GetIntoTeachingApi/Adapters/IPerformContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IPerformContextAdapter.cs
@@ -1,9 +1,11 @@
-﻿using Hangfire.Server;
+﻿using System;
+using Hangfire.Server;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public interface IPerformContextAdapter
     {
         int GetRetryCount(PerformContext context);
+        DateTime GetJobCreatedAt(PerformContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/PerformContextAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/PerformContextAdapter.cs
@@ -1,4 +1,5 @@
-﻿using Hangfire.Server;
+﻿using System;
+using Hangfire.Server;
 
 namespace GetIntoTeachingApi.Adapters
 {
@@ -7,6 +8,11 @@ namespace GetIntoTeachingApi.Adapters
         public int GetRetryCount(PerformContext context)
         {
             return context.GetJobParameter<int>("RetryCount");
+        }
+
+        public DateTime GetJobCreatedAt(PerformContext context)
+        {
+            return context.BackgroundJob.CreatedAt;
         }
     }
 }

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -7,6 +7,7 @@ namespace GetIntoTeachingApi.Services
         Histogram CrmSyncDuration { get; }
         Histogram LocationSyncDuration { get; }
         Histogram LocationBatchDuration { get; }
+        Histogram HangfireJobQueueDuration { get; }
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }
         Counter CacheLookups { get; }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -10,6 +10,11 @@ namespace GetIntoTeachingApi.Services
             .CreateHistogram("api_location_sync_duration_seconds", "Histogram of location sync durations.");
         private static readonly Histogram _locationBatchDuration = Metrics
             .CreateHistogram("api_location_batch_duration_seconds", "Histogram of location batch processing durations.");
+        private static readonly Histogram _hangfireJobQueueDuration = Metrics
+            .CreateHistogram("api_hangfire_job_queue_duration_seconds", "Histogram of the time jobs spend in the queue.", new HistogramConfiguration
+            {
+                LabelNames = new[] { "job" },
+            });
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
@@ -26,6 +31,7 @@ namespace GetIntoTeachingApi.Services
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
         public Histogram LocationBatchDuration => _locationBatchDuration;
+        public Histogram HangfireJobQueueDuration => _hangfireJobQueueDuration;
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;
         public Counter CacheLookups => _cacheLookups;

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -33,6 +33,13 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void HangfireJobQueueDuration_ReturnsMetric()
+        {
+            _metrics.HangfireJobQueueDuration.Name.Should().Be("api_hangfire_job_queue_duration_seconds");
+            _metrics.HangfireJobQueueDuration.LabelNames.Should().BeEquivalentTo(new[] { "job" });
+        }
+
+        [Fact]
         public void HangfireJobs_ReturnsMetric()
         {
             _metrics.HangfireJobs.Name.Should().Be("api_hangfire_jobs");


### PR DESCRIPTION
Add a Histogram metric to track the job duration for `UpsertCandidateJob` so that we can get a feel for how long they are remaining in the queue for before being sent to the API or dropped.