### PR TITLE
Default CF_INSTANCE_INDEX to 0

### DIFF
--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -22,6 +22,19 @@ namespace GetIntoTeachingApi.Utils
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
         public string PenTestSharedSecret => Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
-        public int InstanceIndex => int.Parse(Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX"));
+        public int InstanceIndex
+        {
+            get
+            {
+                var index = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
+
+                if (string.IsNullOrWhiteSpace(index))
+                {
+                    return 0;
+                }
+
+                return int.Parse(index);
+            }
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -11,20 +11,17 @@ namespace GetIntoTeachingApiTests.Utils
     public class EnvTests : IDisposable
     {
         private readonly string _previousEnvironment;
-        private readonly string _previousCfInstanceIndex;
         private readonly IEnv _env;
 
         public EnvTests()
         {
             _env = new Env();
             _previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            _previousCfInstanceIndex = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
         }
 
         public void Dispose()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", _previousEnvironment);
-            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", _previousCfInstanceIndex);
         }
 
         [Theory]
@@ -223,6 +220,17 @@ namespace GetIntoTeachingApiTests.Utils
         {
             var previous = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
             Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", "0");
+
+            _env.InstanceIndex.Should().Be(0);
+
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", previous);
+        }
+
+        [Fact]
+        public void InstanceIndex_DefaultsToZero()
+        {
+            var previous = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", null);
 
             _env.InstanceIndex.Should().Be(0);
 


### PR DESCRIPTION
If we are running locally we always want to run the migrations. In the event that the env var is not set we would also be better off running the migrations than not, so defaulting to 0 makes sense.