### PR TITLE
Dependant changes merged into master

### DIFF
--- a/terraform/monitoring/modules.tf
+++ b/terraform/monitoring/modules.tf
@@ -64,7 +64,7 @@ module "grafana" {
 }
 
 module "alertmanager" {
-  source                   = "git::https://github.com/DFE-Digital/bat-platform-building-blocks.git//terraform/modules/alertmanager?ref=monitoring/alertmanager/templates"
+  source                   = "git::https://github.com/DFE-Digital/bat-platform-building-blocks.git//terraform/modules/alertmanager"
   monitoring_space_id      = data.cloudfoundry_space.space.id
   monitoring_instance_name = "${var.environment}-${var.alertmanager["name"]}"
   slack_url                =  var.alertmanager_slack_url


### PR DESCRIPTION
The dependant modules in BAT Building blocks has been merged to master, so we can now use that branch

BAT building blocks is a GIT repository we use to keep common code in for various Becoming a teacher projects. The work we have carried out developing the Monitoring for GiT is being re-used on other projects. 
