### PR TITLE
Increase rate limit thresholds

### DIFF
--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -19,22 +19,22 @@
       {
         "Endpoint": "POST:/api/candidates/access_tokens",
         "Period": "1m",
-        "Limit": 60
+        "Limit": 250
       },
       {
         "Endpoint": "POST:/api/teacher_training_adviser/candidates",
         "Period": "1m",
-        "Limit": 60
+        "Limit": 100
       },
       {
         "Endpoint": "POST:/api/mailing_list/members",
         "Period": "1m",
-        "Limit": 60
+        "Limit": 100
       },
       {
         "Endpoint": "POST:/api/teaching_events/attendees",
         "Period": "1m",
-        "Limit": 60
+        "Limit": 100
       }
     ]
   }

--- a/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
@@ -21,10 +21,10 @@ namespace GetIntoTeachingApiTests.Integration
         }
 
         [Theory]
-        [InlineData("/api/candidates/access_tokens", 60)]
-        [InlineData("/api/mailing_list/members", 60)]
-        [InlineData("/api/teaching_events/attendees", 60)]
-        [InlineData("/api/teacher_training_adviser/candidates", 60)]
+        [InlineData("/api/candidates/access_tokens", 250)]
+        [InlineData("/api/mailing_list/members", 100)]
+        [InlineData("/api/teaching_events/attendees", 100)]
+        [InlineData("/api/teacher_training_adviser/candidates", 100)]
         public async void Path_ExceedingRateLimit_ReturnsStatus429TooManyRequests(string path, int limit)
         {
             HttpResponseMessage response = null;

--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -28,7 +28,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1605023849506,
+  "iteration": 1605104949695,
   "links": [],
   "panels": [
     {
@@ -2256,7 +2256,7 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 60,
+          "value": 100,
           "yaxis": "left"
         },
         {
@@ -2264,7 +2264,15 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 30,
+          "value": 50,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 250,
           "yaxis": "left"
         }
       ],
@@ -2291,7 +2299,7 @@
           "format": "short",
           "label": "",
           "logBase": 1,
-          "max": "65",
+          "max": "300",
           "min": "0",
           "show": true
         },

--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -83,11 +83,17 @@ groups:
         annotations:
           summary: Alert when the Google API returns a non-success response.
       - alert: ClientApproachingRateLimit
-        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"CreateAccessToken|AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 30'
+        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 50'
         labels:
           severity: medium
         annotations:
-          summary: Alert when a client is approaching the rate limit threshold (30rpm out of an available 60rpm).
+          summary: Alert when a client is approaching the rate limit threshold (50rpm out of an available 100rpm).
+      - alert: ClientApproachingRateLimit (CreateAccessToken)
+        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates",action=~"CreateAccessToken",code=~".+"}[1m])) by (controller, action) > 175'
+        labels:
+          severity: medium
+        annotations:
+          summary: Alert when a client is approaching the rate limit threshold (175rpm out of an available 250rpm).
       - alert: HighCpu
         expr: 'max(cpu_percent) > 70'
         labels:


### PR DESCRIPTION
- Increase rate limit thresholds

We saw a spike of match back requests nearing 60rpm, so upping it to 250rpm and increasing the other endpoints to 100rpm.

- Update thresholds to match new rate limits

- Split rate limit alert rules

We now have two rules, one to cover the majority of sign up requests and one for the match back endpoint, which receives more requests.