### PR TITLE
Place distributed lock on CRM sync operation

### DIFF
--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
+using Hangfire;
 using Microsoft.Extensions.Logging;
 using Prometheus;
 
@@ -27,6 +28,7 @@ namespace GetIntoTeachingApi.Jobs
             _metrics = metrics;
         }
 
+        [DisableConcurrentExecution(timeoutInSeconds: 10 * 60)]
         public async Task RunAsync()
         {
             using (_metrics.CrmSyncDuration.NewTimer())

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -3,6 +3,7 @@ using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
+using Hangfire;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -24,6 +25,14 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockStore = new Mock<IStore>();
             _metrics = new MetricService();
             _job = new CrmSyncJob(new Env(), _mockCrm.Object, _mockStore.Object, _mockLogger.Object, _metrics);
+        }
+
+        [Fact]
+        public void DisableConcurrentExecutionAttribute()
+        {
+            var type = typeof(CrmSyncJob);
+
+            type.GetMethod("RunAsync").Should().BeDecoratedWith<DisableConcurrentExecutionAttribute>();
         }
 
         [Fact]


### PR DESCRIPTION
We're seeing errors on deployment but only when running multiple instances.

This commit places a distributed lock on the sync operation to try and diagnose if this method being ran in parallel by multiple instances results in the error (a sync is performed when the instance starts).