### PR TITLE
Switch to docker-compose for development

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,10 +24,13 @@ jobs:
       run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
 
     - name: Install dependencies
-      run: sudo dotnet restore && sudo apt-get update && sudo apt-get install -y libsqlite3-mod-spatialite
+      run: sudo dotnet restore
 
     - name: Build
       run: sudo dotnet build --configuration Release --no-restore /warnaserror
+
+    - name: Spin Up Stack
+      run: docker-compose up -d
 
     - name: Test
       run: sudo dotnet test --no-restore --verbosity normal

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,7 +24,10 @@ jobs:
         run:  dotnet tool install --global dotnet-sonarscanner --version 4.8.0
 
       - name: Install dependencies
-        run:  sudo dotnet restore && sudo apt-get update && sudo apt-get install -y libsqlite3-mod-spatialite
+        run:  sudo dotnet restore
+
+      - name: Spin Up Stack
+        run: docker-compose up -d
 
       - name: SonarCloud
         env:

--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -25,9 +25,9 @@ namespace GetIntoTeachingApi.Database
         public static string HangfireConnectionString(IEnv env) =>
             $"{GenerateConnectionString(env, env.HangfireInstanceName)};SearchPath=hangfire";
 
-        public static void ConfigPostgres(IEnv env, DbContextOptionsBuilder builder)
+        public static void ConfigPostgres(string connetionString, DbContextOptionsBuilder builder)
         {
-            builder.UseNpgsql(DatabaseConnectionString(env), x => x.UseNetTopologySuite());
+            builder.UseNpgsql(connetionString, x => x.UseNetTopologySuite());
         }
 
         public static void ConfigSqLite(DbContextOptionsBuilder builder, SqliteConnection keepAliveConnection)
@@ -36,10 +36,10 @@ namespace GetIntoTeachingApi.Database
             builder.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite());
         }
 
-        public void Configure(IEnv env)
+        public void Configure(int instanceIndex = 0)
         {
             var migrationsAreSupported = _dbContext.Database.ProviderName != "Microsoft.EntityFrameworkCore.Sqlite";
-            var firstInstance = env.InstanceIndex == 0;
+            var firstInstance = instanceIndex == 0;
 
             if (migrationsAreSupported && firstInstance)
             {

--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Utils;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Npgsql;
@@ -30,24 +29,13 @@ namespace GetIntoTeachingApi.Database
             builder.UseNpgsql(connetionString, x => x.UseNetTopologySuite());
         }
 
-        public static void ConfigSqLite(DbContextOptionsBuilder builder, SqliteConnection keepAliveConnection)
-        {
-            keepAliveConnection.Open();
-            builder.UseSqlite(keepAliveConnection, x => x.UseNetTopologySuite());
-        }
-
         public void Configure(int instanceIndex = 0)
         {
-            var migrationsAreSupported = _dbContext.Database.ProviderName != "Microsoft.EntityFrameworkCore.Sqlite";
             var firstInstance = instanceIndex == 0;
 
-            if (migrationsAreSupported && firstInstance)
+            if (firstInstance)
             {
                 _dbContext.Database.Migrate();
-            }
-            else
-            {
-                _dbContext.Database.EnsureCreated();
             }
         }
 

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -18,16 +18,6 @@ namespace GetIntoTeachingApi.Database
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            switch (Database.ProviderName)
-            {
-                case "Microsoft.EntityFrameworkCore.Sqlite":
-                    modelBuilder.Entity<Location>().Property(m => m.Coordinate)
-                        .HasSrid(DbConfiguration.Wgs84Srid);
-                    modelBuilder.Entity<TeachingEventBuilding>().Property(m => m.Coordinate)
-                        .HasSrid(DbConfiguration.Wgs84Srid);
-                    break;
-            }
-
             modelBuilder.Entity<TeachingEvent>().HasOne(c => c.Building).WithMany(b => b.TeachingEvents)
                 .HasForeignKey(e => e.BuildingId).OnDelete(DeleteBehavior.SetNull);
             modelBuilder.Entity<TypeEntity>().HasKey(t => new { t.Id, t.EntityName, t.AttributeName });

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
@@ -23,8 +23,9 @@ namespace GetIntoTeachingApi.Database
         public GetIntoTeachingDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
+            var connectionString = DbConfiguration.DatabaseConnectionString(_env);
 
-            DbConfiguration.ConfigPostgres(_env, optionsBuilder);
+            DbConfiguration.ConfigPostgres(connectionString, optionsBuilder);
 
             return new GetIntoTeachingDbContext(optionsBuilder.Options);
         }

--- a/GetIntoTeachingApi/Fixtures/ukpostcodes.dev.csv
+++ b/GetIntoTeachingApi/Fixtures/ukpostcodes.dev.csv
@@ -1,3 +1,0 @@
-﻿id,postcode,latitude,longitude
-1,KY11 9YU,56.02748,-3.35870
-2,WC1B 3LS,51.51727,-0.12847

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -44,14 +44,4 @@
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<Folder Include="Fixtures\" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Update="Fixtures\ukpostcodes.dev.csv">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
-
 </Project>

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -19,8 +19,6 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="3.1.4" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -122,11 +122,6 @@ namespace GetIntoTeachingApi.Jobs
 
         private async Task<string> RetrieveCsv(string ukPostcodeCsvUrl)
         {
-            if (Env.IsDevelopment)
-            {
-                return "./Fixtures/ukpostcodes.dev.csv";
-            }
-
             var zipPath = GetTempPath();
             var csvPath = GetTempPath();
             var net = new System.Net.WebClient();
@@ -152,10 +147,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private void DeleteCsv(string csvPath)
         {
-            if (!Env.IsDevelopment)
-            {
-                File.Delete(csvPath);
-            }
+            File.Delete(csvPath);
         }
     }
 }

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApi
             // Configure the database.
             var dbConfiguration = scope.ServiceProvider.GetRequiredService<DbConfiguration>();
             var env = scope.ServiceProvider.GetRequiredService<IEnv>();
-            dbConfiguration.Configure(env);
+            dbConfiguration.Configure(env.InstanceIndex);
 
             await webHost.RunAsync();
         }

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -23,7 +23,11 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DATABASE_INSTANCE_NAME": "gis",
+        "HANGFIRE_INSTANCE_NAME": "gis",
+        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}]}",
+        "SHARED_SECRET": "abc123"
       }
     }
   }

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -27,7 +27,13 @@
         "DATABASE_INSTANCE_NAME": "gis",
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}]}",
-        "SHARED_SECRET": "abc123"
+        "SHARED_SECRET": "abc123",
+        "TOTP_SECRET_KEY": "def456",
+        "CRM_CLIENT_SECRET": "3Q_bZ0epYn8oB._QtLYshtPUX5M8~Zhe-~",
+        "CRM_CLIENT_ID": "965b7a3a-dc0a-4f4f-b75c-14ad6dbc57f2",
+        "CRM_SERVICE_URL": "https://gitis-dev.api.crm4.dynamics.com",
+        "CRM_TENANT_ID": "fad277c9-c60a-4da1-b5f3-b3b8b34a82f9",
+        "NOTIFY_API_KEY": "dev_api_key-d9fdd2e0-6c6b-4fc6-93c1-509db81d8bc6-ad1df893-0a8a-430c-94bb-60b2c1dd3ee6"
       }
     }
   }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -61,12 +60,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<IEnv>(env);
 
-            if (env.IsTest)
-            {
-                var keepAliveConnection = new SqliteConnection("DataSource=:memory:");
-                services.AddDbContext<GetIntoTeachingDbContext>(builder => DbConfiguration.ConfigSqLite(builder, keepAliveConnection));
-            }
-            else
+            if (!env.IsTest)
             {
                 var connectionString = DbConfiguration.DatabaseConnectionString(env);
                 services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -61,14 +61,15 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<IEnv>(env);
 
-            if (env.IsDevelopment || env.IsTest)
+            if (env.IsTest)
             {
                 var keepAliveConnection = new SqliteConnection("DataSource=:memory:");
                 services.AddDbContext<GetIntoTeachingDbContext>(builder => DbConfiguration.ConfigSqLite(builder, keepAliveConnection));
             }
             else
             {
-                services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(env, b));
+                var connectionString = DbConfiguration.DatabaseConnectionString(env);
+                services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
             }
 
             services.AddAuthentication("SharedSecretHandler")
@@ -143,7 +144,7 @@ The GIT API aims to provide:
                     .UseRecommendedSerializerSettings()
                     .UseFilter(automaticRetry);
 
-                if (env.IsDevelopment || env.IsTest)
+                if (env.IsTest)
                 {
                     config.UseMemoryStorage().WithJobExpirationTimeout(JobConfiguration.ExpirationTimeout);
                 }

--- a/GetIntoTeachingApiTests/Helpers/DatabaseCollection.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    [CollectionDefinition("Database")]
+    public class DatabaseCollection : ICollectionFixture<DatabaseFixture>
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
@@ -1,0 +1,25 @@
+﻿using GetIntoTeachingApi.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public class DatabaseFixture
+    {
+        public string TemplateDatabaseName { get; }
+        public string ConnectionString { get; }
+        private readonly GetIntoTeachingDbContext _dbContext;
+
+        public DatabaseFixture()
+        {
+            TemplateDatabaseName = $"gis_test";
+            ConnectionString = $"Host=localhost;Database={TemplateDatabaseName};Username=docker;Password=docker";
+
+            var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
+            DbConfiguration.ConfigPostgres(ConnectionString, builder);
+            _dbContext = new GetIntoTeachingDbContext(builder.Options);
+
+            _dbContext.Database.Migrate();
+            _dbContext.Database.CloseConnection();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -7,23 +7,15 @@ namespace GetIntoTeachingApiTests.Helpers
 {
     public abstract class DatabaseTests : IDisposable
     {
-        public GetIntoTeachingDbContext DbContext { get; }
+        public GetIntoTeachingDbContext DbContext { get; set; }
 
         protected DatabaseTests(DatabaseFixture databaseFixture)
         {
             var id = Guid.NewGuid().ToString().Replace("-", "");
             var databaseName = $"gis_test_{id}";
-            var connectionString = $"Host=localhost;Database={databaseName};Username=docker;Password=docker";
 
-            using var templateConnection = new NpgsqlConnection(databaseFixture.ConnectionString);
-            templateConnection.Open();
-
-            using var command = new NpgsqlCommand($"CREATE DATABASE {databaseName} WITH TEMPLATE {databaseFixture.TemplateDatabaseName};", templateConnection);
-            command.ExecuteNonQuery();
-                
-            var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
-            DbConfiguration.ConfigPostgres(connectionString, builder);
-            DbContext = new GetIntoTeachingDbContext(builder.Options);
+            CloneTemplateDatabase(databaseFixture, databaseName);
+            SetupDbContext(databaseName);
         }
 
         public void Dispose()
@@ -36,6 +28,25 @@ namespace GetIntoTeachingApiTests.Helpers
                 // StoreTests.CheckStatusAsync_WhenUnhealthy_ReturnsError
                 // disposes of the connection prematurely as part of the test.
             }
+        }
+
+        private void SetupDbContext(string databaseName)
+        {
+            var connectionString = $"Host=localhost;Database={databaseName};Username=docker;Password=docker";
+            var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
+
+            DbConfiguration.ConfigPostgres(connectionString, builder);
+
+            DbContext = new GetIntoTeachingDbContext(builder.Options);
+        }
+
+        private static void CloneTemplateDatabase(DatabaseFixture databaseFixture, string databaseName)
+        {
+            using var templateConnection = new NpgsqlConnection(databaseFixture.ConnectionString);
+            templateConnection.Open();
+
+            using var command = new NpgsqlCommand($"CREATE DATABASE {databaseName} WITH TEMPLATE {databaseFixture.TemplateDatabaseName};", templateConnection);
+            command.ExecuteNonQuery();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -1,30 +1,41 @@
 ﻿using System;
 using GetIntoTeachingApi.Database;
-using GetIntoTeachingApi.Utils;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Moq;
+using Npgsql;
 
 namespace GetIntoTeachingApiTests.Helpers
 {
     public abstract class DatabaseTests : IDisposable
     {
-        private readonly SqliteConnection _keepAliveConnection;
-        protected readonly GetIntoTeachingDbContext DbContext;
+        public GetIntoTeachingDbContext DbContext { get; }
 
-        protected DatabaseTests()
+        protected DatabaseTests(DatabaseFixture databaseFixture)
         {
-            _keepAliveConnection = new SqliteConnection("DataSource=:memory:");
+            var id = Guid.NewGuid().ToString().Replace("-", "");
+            var databaseName = $"gis_test_{id}";
+            var connectionString = $"Host=localhost;Database={databaseName};Username=docker;Password=docker";
 
-            var envMock = new Mock<IEnv>();
+            using var templateConnection = new NpgsqlConnection(databaseFixture.ConnectionString);
+            templateConnection.Open();
+
+            using var command = new NpgsqlCommand($"CREATE DATABASE {databaseName} WITH TEMPLATE {databaseFixture.TemplateDatabaseName};", templateConnection);
+            command.ExecuteNonQuery();
+                
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
-            DbConfiguration.ConfigSqLite(builder, _keepAliveConnection);
-
+            DbConfiguration.ConfigPostgres(connectionString, builder);
             DbContext = new GetIntoTeachingDbContext(builder.Options);
-            var dbConfiguration = new DbConfiguration(DbContext);
-            dbConfiguration.Configure(envMock.Object);
         }
 
-        public void Dispose() => _keepAliveConnection.Dispose();
+        public void Dispose()
+        {
+            try
+            {
+                DbContext.Database.EnsureDeleted();
+            } catch(ObjectDisposedException)
+            {
+                // StoreTests.CheckStatusAsync_WhenUnhealthy_ReturnsError
+                // disposes of the connection prematurely as part of the test.
+            }
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Helpers/GetIntoTeachingWebApplicationFactory.cs
+++ b/GetIntoTeachingApiTests/Helpers/GetIntoTeachingWebApplicationFactory.cs
@@ -1,0 +1,28 @@
+﻿using GetIntoTeachingApi;
+using GetIntoTeachingApi.Database;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public class GetIntoTeachingWebApplicationFactory : WebApplicationFactory<Startup>
+    {
+        private readonly GetIntoTeachingDbContext _dbContext;
+
+        public GetIntoTeachingWebApplicationFactory(GetIntoTeachingDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                var connectionString = _dbContext.Database.GetDbConnection().ConnectionString;
+                services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
+            });
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
@@ -1,20 +1,20 @@
 ﻿using FluentAssertions;
-using GetIntoTeachingApi;
+using GetIntoTeachingApiTests.Helpers;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Testing;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Integration
 {
-    public class RateLimitingTests
+    [Collection("Database")]
+    public class RateLimitingTests : DatabaseTests
     {
         private readonly HttpClient _client;
 
-        public RateLimitingTests()
+        public RateLimitingTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
-            var factory = new WebApplicationFactory<Startup>();
+            var factory = new GetIntoTeachingWebApplicationFactory(DbContext);
             _client = factory.CreateClient();
 
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Token 1");

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -16,13 +16,14 @@ using Location = GetIntoTeachingApi.Models.Location;
 
 namespace GetIntoTeachingApiTests.Jobs
 {
+    [Collection("Database")]
     public class LocationBatchJobTests : DatabaseTests
     {
         private readonly LocationBatchJob _job;
         private readonly IMetricService _metrics;
         private readonly Mock<ILogger<LocationBatchJob>> _mockLogger;
 
-        public LocationBatchJobTests()
+        public LocationBatchJobTests(DatabaseFixture databaseFixture): base(databaseFixture)
         {
             _mockLogger = new Mock<ILogger<LocationBatchJob>>();
             _metrics = new MetricService();

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -74,25 +74,5 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _metrics.LocationSyncDuration.Count.Should().BeGreaterOrEqualTo(1);
         }
-
-        [Fact]
-        public async void RunAsync_InDevelopment_UsesLocalFixture()
-        {
-            _mockEnv.Setup(m => m.IsDevelopment).Returns(true);
-
-            await _job.RunAsync("http://will-be-ignored.com/test.csv");
-
-            var expectedLocationBatch = new List<dynamic>
-            {
-                new { Postcode = "ky119yu", Latitude = 56.02748, Longitude = -3.35870 },
-                new { Postcode = "wc1b3ls", Latitude = 51.51727, Longitude = -0.12847 },
-            };
-
-            _mockJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Type == typeof(LocationBatchJob) &&
-                                  job.Method.Name == "RunAsync" &&
-                                  (string)job.Args[0] == JsonConvert.SerializeObject(expectedLocationBatch)),
-                It.IsAny<EnqueuedState>()));
-        }
     }
 }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -17,13 +17,14 @@ using Location = GetIntoTeachingApi.Models.Location;
 
 namespace GetIntoTeachingApiTests.Services
 {
+    [Collection("Database")]
     public class StoreTests : DatabaseTests
     {
         private static readonly Guid FindEventGuid = new Guid("ff927e43-5650-44aa-859a-8297139b8eee");
         private readonly IStore _store;
         private readonly Mock<IGeocodeClientAdapter> _mockGeocodeClient;
 
-        public StoreTests()
+        public StoreTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
             _mockGeocodeClient = new Mock<IGeocodeClientAdapter>();
             _store = new Store(DbContext, _mockGeocodeClient.Object);

--- a/README.md
+++ b/README.md
@@ -23,51 +23,39 @@ https://api.bintray.com/nuget/gov-uk-notify/nuget
 
 Next you will need to set up the environment (see the `Environment` section below) before booting up the dependent services in Docker with `docker-compose up`.
 
-When the application runs in development it will open the Swagger documentation by default. On the first run it will do a long sync of UK postcode information into the Postgres instance running in Docker - you can monitor the progress via the Hangfire dashboard (subsequent start ups should be quicker).
+When the application runs in development it will open the Swagger documentation by default (the development shared secret is `abc123`).
+
+On the first run it will do a long sync of UK postcode information into the Postgres instance running in Docker - you can monitor the progress via the Hangfire dashboard (subsequent start ups should be quicker).
 
 ### Environment
 
 If you want to run the API locally end-to-end you will need to set some environment variables (you can specify these in `GetIntoTeachingApi/Properties/launchSettings.json` under `environmentVariables`):
 
 ```
-# Secret shared between the API and client.
-SHARED_SECRET=****
-
-# Secret used when generating Timed One Time Passwords
-TOTP_SECRET_KEY=****
-
 # CRM credentials
 CRM_SERVICE_URL=****
 CRM_CLIENT_ID=****
 CRM_CLIENT_SECRET=****
+CRM_TENANT_ID=****
 
 # GOV.UK Notify Service credentials
 NOTIFY_API_KEY=****
-
-# Postgres instance names
-DATABASE_INSTANCE_NAME=****
-HANGFIRE_INSTANCE_NAME=****
-
-# Sentry
-Sentry__Dsn=****
-
-# Google
-GOOGLE_API_KEY=****
 ```
 
-The Postgres connections (for Hangfire and our database) are setup dynamically from the `VCAP_SERVICES` environment variable provided by GOV.UK PaaS and not used in development (they are replaced by in-memory alternatives by default). If you want to connect to a Postgres instance running in PaaS, such as the test environment instance, you can do so by creating a conduit to it using Cloud Foundry:
+Other environment variables are available (see the `IEnv` interface) but not necessary to run the bare-bones application.
+
+The Postgres connections (for Hangfire and our database) are setup dynamically from the `VCAP_SERVICES` environment variable provided by GOV.UK PaaS. If you want to connect to a Postgres instance running in PaaS instead of the one in Docker - such as the test environment instance - you can do so by creating a conduit to it using Cloud Foundry:
 
 ```
 cf conduit get-into-teaching-api-dev-pg-svc
 ```
 
-You then need to add a connection string containing the details for your conduit session and point it to localhost:
+You then need to update the `VCAP_SERVICES` environment variable (in `launchSettings.json`) to reflect the connection details for your conduit session:
 
 ```
-Server=127.0.0.1;SSL Mode=Require;Trust Server Certificate=true;Port=7080;Database=rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e;User Id=******;Password=******;
-```
+{\"postgres\": [{\"instance_name\": \"rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e\",\"credentials\": {\"host\": \"127.0.0.1\",\"name\": \"rdsbroker_277c8858_eb3a_427b_99ed_0f4f4171701e\",\"username\": \"******\",\"password\": \"******\",\"port\": \"7080\"}}]}
 
-Finally, update `Startup.cs` to use your connection string instead of the builder in `DbConfiguration.cs`.
+```
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Before you build the app you will need to add a package source for the GOV.UK No
 https://api.bintray.com/nuget/gov-uk-notify/nuget
 ```
 
-If you are using a Mac OS/Linux you will also need to ensure Spatialite is installed (for Windows this is pulled in via a NuGet package).
+Next you will need to set up the environment (see the `Environment` section below) before booting up the dependent services in Docker with `docker-compose up`.
 
-When the application runs in development it will open the Swagger documentation by default.
+When the application runs in development it will open the Swagger documentation by default. On the first run it will do a long sync of UK postcode information into the Postgres instance running in Docker - you can monitor the progress via the Hangfire dashboard (subsequent start ups should be quicker).
 
 ### Environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  postgres:
+    image: kartoza/postgis:12.0
+    environment:
+      - POSTGRES_DBNAME=gis,gis_test
+    volumes:
+      - db-data:/var/lib/postgresql
+    restart: on-failure
+    healthcheck:
+        test: "exit 0"
+    ports:
+      - '5432:5432'
+
+volumes:
+  db-data:


### PR DESCRIPTION
- Run against Postgres DB in development/test

Updates the development and test environments to execute against a dockerized Postgres database instance instead of using the in-memory database.

The advantages to do this are:

- Migrations are ran in the test suite/development.
- We can load and persist all the geolocation data in development.
- Development/test more closely match production.
- It's easier to run the app on a non-Windows machine.

The test environment works by creating a new database for each test that requires one; we use the `gis_test` database that is created for us as a template (after migrations have been ran).

Whilst it would be quicker to wrap each test run in a transaction using the same database, this setup would be more complicated and using Postgres templates seems to be fast enough for now.

- Remove in-memory SQLite references

Removes the in-memory SQLite dependencies.

The rate limiting integration tests hit the `Startup` class, so the `WebApplicationFactory` also has to be tweaked to cut out the default `DbContext` and replace it with an instance that points to the database that was created for the unit test being ran.

- Spin up test stack in CI

Run `docker-compose up` as part of CI so that the test database and any other resources are available.

- Tweaks to make development setup easier

Default some of the env variables that are not sensitive/don't need to change.

Clean up `DatabaseTests`.