### PR TITLE
Use dotenv.net for development secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ msbuild.wrn
 
 # Coverage
 TestResults
+
+# Dotenv
+.env*

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -40,6 +40,7 @@
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
+		<PackageReference Include="dotenv.net" Version="2.1.1" />
 	</ItemGroup>
 
 </Project>

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using AspNetCoreRateLimit;
+using dotenv.net;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Auth;
@@ -42,6 +43,11 @@ namespace GetIntoTeachingApi
             ConfigureRateLimiting(services);
 
             var env = new Env();
+
+            if (env.IsDevelopment)
+            {
+                DotEnv.Config(true, ".env.development");
+            }
 
             services.AddSingleton<CdsServiceClientWrapper, CdsServiceClientWrapper>();
             services.AddTransient<IOrganizationService>(sp => sp.GetService<CdsServiceClientWrapper>().CdsServiceClient.Clone());

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ On the first run it will do a long sync of UK postcode information into the Post
 
 ### Environment
 
-If you want to run the API locally end-to-end you will need to set some environment variables (you can specify these in `GetIntoTeachingApi/Properties/launchSettings.json` under `environmentVariables`):
+If you want to run the API locally end-to-end you will need to set some environment variables (you can specify these in `.env.development`):
 
 ```
 # CRM credentials
@@ -41,6 +41,8 @@ CRM_TENANT_ID=****
 # GOV.UK Notify Service credentials
 NOTIFY_API_KEY=****
 ```
+
+A number of non-secret, default development environment variables are pre-set in `GetIntoTeachingApi/Properties/launchSettings.json` (such as a development `SHARED_SECRET` of `abc123` and the `VCAP_SERVICES` setup for the Postgres instance running in Docker).
 
 Other environment variables are available (see the `IEnv` interface) but not necessary to run the bare-bones application.
 


### PR DESCRIPTION
Previously we had to manually edit the `launchSettings.json` file with the development credentials for the CRM etc. This was susceptible to being accidentally committed into git (as we can't `gitignore` the `launchSettings.json` file completely).

Instead, this commit introduces `dotnet.env` for managing development secrets in an ignored `.env.development` file.