### PR TITLE
Default education phase to secondary for returners

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -158,11 +158,20 @@ namespace GetIntoTeachingApi.Models
             AddPastTeachingPosition(candidate);
             SetAdviserEligibility(candidate);
             SetType(candidate);
+            DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
             ConfigureSubscription(candidate);
             ConfigureConsent(candidate);
 
             return candidate;
+        }
+
+        private void DefaultPreferredEducationPhase(Candidate candidate)
+        {
+            if (candidate.IsReturningToTeaching())
+            {
+                candidate.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
+            }
         }
 
         private void DefaultPreferredTeachingSubjectId(Candidate candidate)

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -428,6 +428,14 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_ReturningToTeaching_PreferredEducationPhaseIdDefaultsToSecondary()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+
+            request.Candidate.PreferredEducationPhaseId.Should().Be((int)Candidate.PreferredEducationPhase.Secondary);
+        }
+
+        [Fact]
         public void Candidate_SubjectTaughtIdIsNotNull_PreferredEducationPhaseIdDefaultsToSecondary()
         {
             var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };


### PR DESCRIPTION
We don't ask returners for their preferred education phase as part of the TTA sign up, instead defaulting it in the client-side to secondary. This is not ideal in the scenario where the candidate goes down the returner path then backs out and goes down the new candidate path; we end up pre-selecting secondary for their education phase even though they didn't explicitly select it.

Defaulting it in the API avoids this issue (we no longer have to set it in the client).