### PR TITLE
Adjust validation to allow null preferred education phase

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -15,7 +15,10 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.DateOfBirth).NotNull();
             RuleFor(request => request.AcceptedPolicyId).NotNull();
             RuleFor(request => request.CountryId).NotNull();
-            RuleFor(request => request.PreferredEducationPhaseId).NotNull();
+
+            RuleFor(request => request.PreferredEducationPhaseId)
+                .NotNull()
+                .Unless(request => request.SubjectTaughtId != null);
 
             RuleFor(request => request.AddressLine1).NotEmpty().Unless(request => request.CountryId != TypeEntity.UnitedKingdomCountryId)
                 .WithMessage("Must be set candidate in the UK.");
@@ -111,11 +114,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.PreferredTeachingSubjectId).NotEmpty()
                 .When(request => request.Candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
                 .WithMessage("Must be set when preferred education phase is secondary.");
-
-            RuleFor(request => request.PreferredEducationPhaseId)
-                .Must(phase => phase == (int)Candidate.PreferredEducationPhase.Secondary)
-                .When(request => request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be secondary when past teaching positions are present.");
 
             RuleFor(request => request)
                 .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request) && HasOrIsPlanningOnRetakingScience(request))

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -89,9 +89,31 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_PreferredEducationPhaseIdIsNull_HasError()
+        public void Validate_PreferredEducationPhaseIdIsNull_NotReturningToTeaching_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.PreferredEducationPhaseId, null as int?);
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                PreferredEducationPhaseId = null,
+                SubjectTaughtId = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("PreferredEducationPhaseId");
+        }
+
+        [Fact]
+        public void Validate_PreferredEducationPhaseIdIsNull_ReturningToTeaching_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                PreferredEducationPhaseId = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("PreferredEducationPhaseId");
         }
 
         [Fact]
@@ -621,20 +643,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldNotHaveValidationErrorFor("PreferredTeachingSubjectId");
-        }
-
-        [Fact]
-        public void Validate_HasPastTeachingPositionsAndPreferredEducationPhaseIsPrimary_HasError()
-        {
-            var request = new TeacherTrainingAdviserSignUp
-            {
-                SubjectTaughtId = Guid.NewGuid(),
-                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
-            };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor("PreferredEducationPhaseId").WithErrorMessage("Must be secondary when past teaching positions are present.");
         }
 
         [Fact]


### PR DESCRIPTION
If the candidate is returning to teaching we default the education phase so it doesn't need to be specified; this relaxes the validation rule.