### PR TITLE
Log when searching around postcode

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -8,6 +8,7 @@ using GetIntoTeachingApi.Services;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -22,17 +23,20 @@ namespace GetIntoTeachingApi.Controllers
         private readonly ICrmService _crm;
         private readonly IStore _store;
         private readonly IBackgroundJobClient _jobClient;
+        private readonly ILogger<TeachingEventsController> _logger;
 
         public TeachingEventsController(
             IStore store,
             IBackgroundJobClient jobClient,
             ICandidateAccessTokenService tokenService,
-            ICrmService crm)
+            ICrmService crm,
+            ILogger<TeachingEventsController> logger)
         {
             _store = store;
             _jobClient = jobClient;
             _crm = crm;
             _tokenService = tokenService;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -52,6 +56,11 @@ namespace GetIntoTeachingApi.Controllers
             if (!ModelState.IsValid)
             {
                 return BadRequest(this.ModelState);
+            }
+
+            if (request.Postcode != null)
+            {
+                _logger.LogInformation($"SearchIndexedByType: {request.Postcode}");
             }
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -15,6 +15,8 @@ using Microsoft.AspNetCore.Authorization;
 using MoreLinq;
 using GetIntoTeachingApi.Attributes;
 using System.Linq;
+using Microsoft.Extensions.Logging;
+using GetIntoTeachingApiTests.Helpers;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -24,6 +26,7 @@ namespace GetIntoTeachingApiTests.Controllers
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<IStore> _mockStore;
+        private readonly Mock<ILogger<TeachingEventsController>> _mockLogger;
         private readonly TeachingEventsController _controller;
         private readonly ExistingCandidateRequest _request;
 
@@ -34,7 +37,9 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockCrm = new Mock<ICrmService>();
             _mockStore = new Mock<IStore>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
-            _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object, _mockTokenService.Object, _mockCrm.Object);
+            _mockLogger = new Mock<ILogger<TeachingEventsController>>();
+            _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object,
+                _mockTokenService.Object, _mockCrm.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -112,6 +117,8 @@ namespace GetIntoTeachingApiTests.Controllers
             var result = (IDictionary<string, IEnumerable<TeachingEvent>>)ok.Value;
             result["123"].Count().Should().Be(3);
             result["456"].Count().Should().Be(1);
+
+            _mockLogger.VerifyInformationWasCalled("SearchIndexedByType: KY12 8FG");
         }
 
         [Fact]


### PR DESCRIPTION
We are seeing an odd error in Sentry whereby we can't project between two coordinates:

https://sentry.io/organizations/dfe-bat/issues/2063757538/?project=5276954&referrer=slack

The only thing I can think of that's causing this is a postcode is getting geocoded to a latitude/longitude that falls outside the coordinate system we have defined in `GeometryExtension`. This _shouldn't_ be possible as it covers the whole of the United Kingdom, but perhaps there's a bad entry in the database somewhere against a postcode that results in this error.

Adding the logging should help diagnose the issue where it happens again.

The only other place that could the cause is a postcode against a teaching event; if this is the case it's going to be harder to diagnose so I'll cross that bridge if/when we come to it.