### PR TITLE
Added labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+---
+
+VisualCpp:
+  - GetIntoTeachingApi/**/*.rb
+
+Test:
+  - GetIntoTeachingApiTests/**/*
+
+Monitoring:
+  - monitoring/**/*
+
+DevOps:
+  - terraform/**/*
+  - .github/**/*.yml
+
+Docker:
+  - Dockerfile 
+  - docker-compose.yml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 ---
 
-VisualCpp:
-  - GetIntoTeachingApi/**/*.rb
+VisualCSharp:
+  - GetIntoTeachingApi/**/*.cs
 
 Test:
   - GetIntoTeachingApiTests/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,10 @@
+name: "Pull Request Labeler"
+on:
+   - pull_request_target
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
When A PR is created the labeler will attempt to assign it a label based upon what code has changed.  
This is useful in the DevOps environment as we are monitoring repositories as a team, identifying work the team could do if an individual is not available