### PR TITLE
Use fallback booking quotas when CRM is unavailable

### DIFF
--- a/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
+++ b/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
@@ -14,11 +14,11 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize]
     public class CallbackBookingQuotasController : ControllerBase
     {
-        private readonly ICrmService _crm;
+        private readonly ICallbackBookingService _callbackBookingService;
 
-        public CallbackBookingQuotasController(ICrmService crm)
+        public CallbackBookingQuotasController(ICallbackBookingService callbackBookingService)
         {
-            _crm = crm;
+            _callbackBookingService = callbackBookingService;
         }
 
         [HttpGet]
@@ -30,7 +30,7 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IEnumerable<CallbackBookingQuota>), 200)]
         public IActionResult GetAll()
         {
-            var quotas = _crm.GetCallbackBookingQuotas();
+            var quotas = _callbackBookingService.GetCallbackBookingQuotas();
             return Ok(quotas);
         }
     }

--- a/GetIntoTeachingApi/Services/CallbackBookingService.cs
+++ b/GetIntoTeachingApi/Services/CallbackBookingService.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Models;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CallbackBookingService : ICallbackBookingService
+    {
+        public static readonly int FallbackBookingQuotaWeekdays = 5;
+        public static readonly TimeSpan FallbackBookingQuotaInterval = TimeSpan.FromMinutes(30);
+        public static readonly TimeSpan FallbackBookingQuotaFirstTimeSpan = new TimeSpan(9, 0, 0);
+        public static readonly TimeSpan FallbackBookingQuotaLastTimeSpan = new TimeSpan(16, 30, 0);
+        private readonly ICrmService _crm;
+        private readonly ILogger<CallbackBookingService> _logger;
+
+        public CallbackBookingService(ICrmService crm, ILogger<CallbackBookingService> logger)
+        {
+            _crm = crm;
+            _logger = logger;
+        }
+
+        public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
+        {
+            IEnumerable<CallbackBookingQuota> quotas = null;
+
+            try
+            {
+                 quotas = _crm.GetCallbackBookingQuotas();
+            }
+            catch
+            {
+                _logger.LogError("GetCallbackBookingQuotas: failed to reach CRM");
+            }
+
+            if (quotas == null || !quotas.Any())
+            {
+                _logger.LogWarning("GetCallbackBookingQuotas: returning fallback quotas");
+
+                quotas = FallbackBookingQuotas();
+            }
+
+            return quotas;
+        }
+
+        private static bool IsWeekend(DateTime date)
+        {
+            var weekendDaysOfWeek = new List<DayOfWeek> { DayOfWeek.Saturday, DayOfWeek.Sunday };
+
+            return weekendDaysOfWeek.Contains(date.DayOfWeek);
+        }
+
+        private static IEnumerable<CallbackBookingQuota> GenerateFallbackQuotasOnDay(DateTime day)
+        {
+            var quotas = new List<CallbackBookingQuota>();
+            var startAt = day.Date + FallbackBookingQuotaFirstTimeSpan;
+
+            while (startAt.TimeOfDay <= FallbackBookingQuotaLastTimeSpan)
+            {
+                var endAt = startAt + FallbackBookingQuotaInterval;
+
+                quotas.Add(CreateFallbackQuota(startAt, endAt));
+                startAt = endAt;
+            }
+
+            return quotas;
+        }
+
+        private static CallbackBookingQuota CreateFallbackQuota(DateTime startAt, DateTime endAt)
+        {
+            var localStartAt = TimeZoneInfo.ConvertTimeFromUtc(startAt, TimeZoneInfo.Local);
+            var localEndAt = TimeZoneInfo.ConvertTimeFromUtc(endAt, TimeZoneInfo.Local);
+
+            return new CallbackBookingQuota()
+            {
+                Id = Guid.NewGuid(),
+                StartAt = startAt,
+                EndAt = endAt,
+                NumberOfBookings = 0,
+                Quota = 1,
+                Day = localStartAt.ToLongDateString(),
+                TimeSlot = $"{localEndAt.ToShortTimeString()} - {localEndAt.ToShortTimeString()}",
+            };
+        }
+
+        private IEnumerable<CallbackBookingQuota> FallbackBookingQuotas()
+        {
+            var quotasByDay = new Dictionary<DateTime, IEnumerable<CallbackBookingQuota>>();
+            var day = DateTime.UtcNow.AddDays(1);
+
+            while (quotasByDay.Count < FallbackBookingQuotaWeekdays)
+            {
+                if (!IsWeekend(day))
+                {
+                    quotasByDay.Add(day, GenerateFallbackQuotasOnDay(day));
+                }
+
+                day = day.AddDays(1);
+            }
+
+            return quotasByDay.Values.SelectMany(q => q);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICallbackBookingService.cs
+++ b/GetIntoTeachingApi/Services/ICallbackBookingService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICallbackBookingService
+    {
+        IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -64,6 +64,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<INotifyService, NotifyService>();
             services.AddSingleton<IHangfireService, HangfireService>();
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
+            services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IEnv>(env);
 
             if (!env.IsTest)

--- a/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
@@ -13,13 +13,13 @@ namespace GetIntoTeachingApiTests.Controllers
 {
     public class CallbackBookingQuotasControllerTests
     {
-        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<ICallbackBookingService> _mockCallbackBookingService;
         private readonly CallbackBookingQuotasController _controller;
 
         public CallbackBookingQuotasControllerTests()
         {
-            _mockCrm = new Mock<ICrmService>();
-            _controller = new CallbackBookingQuotasController(_mockCrm.Object);
+            _mockCallbackBookingService = new Mock<ICallbackBookingService>();
+            _controller = new CallbackBookingQuotasController(_mockCallbackBookingService.Object);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void GetAll_ReturnsAllQuotas()
         {
             var mockQuotas = new[] { MockQuota(), MockQuota() };
-            _mockCrm.Setup(mock => mock.GetCallbackBookingQuotas()).Returns(mockQuotas);
+            _mockCallbackBookingService.Setup(mock => mock.GetCallbackBookingQuotas()).Returns(mockQuotas);
 
             var response = _controller.GetAll();
 

--- a/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
+++ b/GetIntoTeachingApiTests/Helpers/LoggerTestHelpers.cs
@@ -21,6 +21,11 @@ namespace GetIntoTeachingApiTests.Helpers
             return VerifyCalled(logger, LogLevel.Warning, expectedMessage);
         }
 
+        public static Mock<ILogger<T>> VerifyErrorWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
+        {
+            return VerifyCalled(logger, LogLevel.Error, expectedMessage);
+        }
+
         private static Mock<ILogger<T>> VerifyCalledExactly<T>(this Mock<ILogger<T>> logger, LogLevel expectedLogLevel, string expectedMessage)
         {
             bool state(object v, Type t) => v.ToString() == expectedMessage;

--- a/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class CallbackBookingServiceTests
+    {
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<ILogger<CallbackBookingService>> _mockLogger;
+        private readonly CallbackBookingService _service;
+
+        public CallbackBookingServiceTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _mockLogger = new Mock<ILogger<CallbackBookingService>>();
+            _service = new CallbackBookingService(_mockCrm.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void GetCallbackBookingQuotas_WhenCrmIsAvailable_ReturnsQuotasFromCrm()
+        {
+            var mockQuotas = MockQuotas();
+            _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Returns(mockQuotas);
+
+            var quotas = _service.GetCallbackBookingQuotas();
+
+            quotas.Should().BeEquivalentTo(mockQuotas);
+        }
+
+        [Fact]
+        public void GetCallbackBookingQuotas_WhenCrmIsUnavailable_ReturnsFallbackQuotas()
+        {
+            _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Throws(new Exception());
+
+            var quotas = _service.GetCallbackBookingQuotas();
+
+            VerifyFallbackQuotas(quotas);
+
+            _mockLogger.VerifyErrorWasCalled("GetCallbackBookingQuotas: failed to reach CRM");
+            _mockLogger.VerifyWarningWasCalled("GetCallbackBookingQuotas: returning fallback quotas");
+        }
+
+        [Fact]
+        public void GetCallbackBookingQuotas_WhenCrmReturnsEmpty_ReturnsFallbackQuotas()
+        {
+            _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Returns(new List<CallbackBookingQuota>());
+
+            var quotas = _service.GetCallbackBookingQuotas();
+
+            VerifyFallbackQuotas(quotas);
+
+            _mockLogger.VerifyWarningWasCalled("GetCallbackBookingQuotas: returning fallback quotas");
+        }
+
+        [Fact]
+        public void GetCallbackBookingQuotas_WhenCrmReturnsNull_ReturnsFallbackQuotas()
+        {
+            _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Returns<IEnumerable<CallbackBookingQuota>>(null);
+
+            var quotas = _service.GetCallbackBookingQuotas();
+
+            VerifyFallbackQuotas(quotas);
+
+            _mockLogger.VerifyWarningWasCalled("GetCallbackBookingQuotas: returning fallback quotas");
+        }
+
+        private static IEnumerable<CallbackBookingQuota> MockQuotas()
+        {
+            var quota1 = new CallbackBookingQuota() { Id = Guid.NewGuid() };
+
+            return new [] { quota1 };
+        }
+
+        private static void VerifyFallbackQuotas(IEnumerable<CallbackBookingQuota> quotas)
+        {
+            var timeSpanPerDay = CallbackBookingService.FallbackBookingQuotaLastTimeSpan - CallbackBookingService.FallbackBookingQuotaFirstTimeSpan;
+            var expectedQuotasPerDay = ((timeSpanPerDay / CallbackBookingService.FallbackBookingQuotaInterval) + 1);
+            var expectedQuotas = CallbackBookingService.FallbackBookingQuotaWeekdays * expectedQuotasPerDay;
+            quotas.Count().Should().Be((int)expectedQuotas);
+
+            quotas.Select(q => q.Id).Should().NotContain(id => id == null);
+            quotas.Select(q => q.IsAvailable).Should().OnlyContain(b => b == true);
+            quotas.Select(q => q).Should().OnlyContain(q => q.EndAt == q.StartAt + TimeSpan.FromMinutes(30));
+            quotas.Select(q => q).Should().OnlyContain(q => VerifyDay(q));
+            quotas.Select(q => q).Should().OnlyContain(q => VerifyTimeSlot(q));
+            quotas.First().StartAt.TimeOfDay.Should().Be(new TimeSpan(9, 0, 0));
+            quotas.Last().StartAt.TimeOfDay.Should().Be(new TimeSpan(16, 30, 0));
+
+            var dates = quotas.Select(q => q.StartAt.Date).Distinct();
+            dates.Count().Should().Be(CallbackBookingService.FallbackBookingQuotaWeekdays);
+            dates.Should().NotContain(d => d.DayOfWeek == DayOfWeek.Saturday || d.DayOfWeek == DayOfWeek.Sunday);
+        }
+
+        private static bool VerifyTimeSlot(CallbackBookingQuota quota)
+        {
+            var localEndAt = TimeZoneInfo.ConvertTimeFromUtc(quota.EndAt, TimeZoneInfo.Local);
+
+            return quota.TimeSlot == $"{localEndAt.ToShortTimeString()} - {localEndAt.ToShortTimeString()}";
+        }
+
+        private static bool VerifyDay(CallbackBookingQuota quota)
+        {
+            var localStartAt = TimeZoneInfo.ConvertTimeFromUtc(quota.StartAt, TimeZoneInfo.Local);
+
+            return quota.Day == localStartAt.ToLongDateString();
+        }
+    }
+}


### PR DESCRIPTION
We want candidates to be able to sign up for a TTA even when the CRM is offline. Currently, there is a hard dependency on the CRM for the callback booking quotas as we query these at the point of displaying them to the user (so as to have the most up-to-date information).

The issue with this is that if the CRM is offline we will display an error to the user. Instead, we want to let the user proceed and book from a pre-generated list of fallback quotas.

The fallback quotas should include the next 5 working days (not including the current day) and have times from 9am to 4:30pm available in 30 minute intervals.

If the CRM is unavailable or returns an empty set of quotas, then we want to instead display the generated list of fallback options.