### PR TITLE
Update postcode regex to match app

### DIFF
--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -10,9 +10,9 @@ namespace GetIntoTeachingApi.Models
     public class Location
     {
         public static readonly Regex OutwardOrFullPostcodeRegex = new Regex(
-            $"^({OutwardPostcodePattern}|{FullPostcodePattern})$", RegexOptions.IgnoreCase);
+            $@"\A({OutwardPostcodePattern})\Z|\A({FullPostcodePattern})\z", RegexOptions.IgnoreCase);
         public static readonly Regex PostcodeRegex = new Regex(
-            $"^({FullPostcodePattern})$", RegexOptions.IgnoreCase);
+            $@"\A({FullPostcodePattern})\Z", RegexOptions.IgnoreCase);
 
         private const string OutwardPostcodePattern = @"[A-Z][A-HJ-Y]?\d[A-Z\d]?";
         private const string InwardPostcodePattern = @"\d[A-Z]{2}|GIR ?0A{2}";

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -100,6 +100,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("AZ1VS1", true)]
         [InlineData("KY11", false)]
         [InlineData("KY999", true)]
+        [InlineData("TE57 ING", true)]
         public void Validate_PostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
         {
             if (hasError)


### PR DESCRIPTION
\A...\z matches the beginning and strict end of the string and is therefore less ambiguous than ^...$, which has the potential to match when there is extra text after a newline.