### PR TITLE
Use correct coordinate system in GeocodeClientAdapter

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -1,9 +1,11 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using GeocodeSharp.Google;
+using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Extensions.Logging;
+using NetTopologySuite;
 using NetTopologySuite.Geometries;
 
 namespace GetIntoTeachingApi.Adapters
@@ -44,7 +46,9 @@ namespace GetIntoTeachingApi.Adapters
             _metrics.GoogleApiCalls.WithLabels(postcode, "success").Inc();
 
             var location = result.Geometry.Location;
-            return new Point(new Coordinate(location.Longitude, location.Latitude));
+            var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);
+
+            return geometryFactory.CreatePoint(new Coordinate(location.Longitude, location.Latitude));
         }
     }
 }


### PR DESCRIPTION
When we were creating the coordinates in response to the Google location result we weren't specifying a coordinate system. This meant that the coordinates would use the default system (or no system, I'm not sure which) and when we came to compare them in the radius search with a coordinate in the Wgs84 coordinate system it would raise an exception.

Updates to use the `NtsGeometryServices` factory to create the coordinate in the correct system.

Fixes new occurrences of this Sentry issue:

https://sentry.io/organizations/dfe-bat/issues/2044744917/?project=5276954&query=is%3Aunresolved

We will still get a few errors like this in production from any postcodes that have been geocoded by Google already (there's only a small number, probably half a dozen). When this happens we can find out the postcode from the logs and delete it from the Postgres cache:

https://kibana.logit.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',key:cf.app,negate:!f,params:(query:get-into-teaching-api-prod),type:phrase),query:(match_phrase:(cf.app:get-into-teaching-api-prod)))),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:SearchIndexedByType),sort:!())