### PR TITLE
Allow GET requests to be cached privately for 5m

### DIFF
--- a/GetIntoTeachingApi/Attributes/PrivateShortTermResponseCacheAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/PrivateShortTermResponseCacheAttribute.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    public class PrivateShortTermResponseCacheAttribute : ResponseCacheAttribute
+    {
+        public PrivateShortTermResponseCacheAttribute()
+        {
+            Location = ResponseCacheLocation.Client;
+            Duration = 300;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/privacy_policies")]
     [ApiController]
     [LogRequests]
+    [PrivateShortTermResponseCache]
     [Authorize]
     public class PrivacyPoliciesController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -41,6 +41,7 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
+        [PrivateShortTermResponseCache]
         [Route("search_indexed_by_type")]
         [SwaggerOperation(
             Summary = "Searches for teaching events, returning grouped by type.",
@@ -69,6 +70,7 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
+        [PrivateShortTermResponseCache]
         [Route("upcoming_indexed_by_type")]
         [SwaggerOperation(
             Summary = "Retrieves upcoming teaching events grouped by type.",
@@ -84,6 +86,7 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
+        [PrivateShortTermResponseCache]
         [Route("{readableId}")]
         [SwaggerOperation(
             Summary = "Retrieves an event.",

--- a/GetIntoTeachingApi/Controllers/TypesController.cs
+++ b/GetIntoTeachingApi/Controllers/TypesController.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/types")]
     [ApiController]
     [LogRequests]
+    [PrivateShortTermResponseCache]
     [Authorize]
     public class TypesController : ControllerBase
     {

--- a/GetIntoTeachingApiTests/Attributes/PrivateShortTermResponseCacheAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/PrivateShortTermResponseCacheAttributeTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Attributes
+{
+    public class PrivateShortTermResponseCacheAttributeTests
+    {
+        [Fact]
+        public void Constructor_CorrectlySetsCacheControl()
+        {
+            var cache = new PrivateShortTermResponseCacheAttribute();
+
+            cache.Location.Should().Be(ResponseCacheLocation.Client);
+            cache.Duration.Should().Be(300);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PrivacyPoliciesControllerTests.cs
@@ -36,6 +36,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void PrivateShortTermResponseCache_IsPresent()
+        {
+            typeof(PrivacyPoliciesController).Should().BeDecoratedWith<PrivateShortTermResponseCacheAttribute>();
+        }
+
+        [Fact]
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -64,6 +64,15 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void CrmETagPrivateShortTermResponseCache_IsPresent()
+        {
+            JobStorage.Current = new Mock<JobStorage>().Object;
+            var methods = new[] { "Get", "SearchIndexedByType", "UpcomingIndexedByType" };
+
+            methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<PrivateShortTermResponseCacheAttribute>());
+        }
+
+        [Fact]
         public void AddAttendee_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new TeachingEventAddAttendee() { EventId = Guid.NewGuid(), FirstName = null };

--- a/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TypesControllerTests.cs
@@ -41,6 +41,12 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void PrivateShortTermResponseCache_IsPresent()
+        {
+            typeof(TypesController).Should().BeDecoratedWith<PrivateShortTermResponseCacheAttribute>();
+        }
+
+        [Fact]
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;


### PR DESCRIPTION
At the moment we monkey-patch the Ruby API client library to cache GET request responses for 5 minutes. It was done this way originally as ASP.NET Core was preventing us from setting `Cache-Control` headers on authenticated requests.
This no longer seems to be the case and the core team appear to be actively working towards a less opinionated caching implementation.

Add a custom attribute for short term (5m), private response caching that is safe to use on most GET responses (essentially every action that has a `CrmETag` attribute). 

It is applied to:

- All /types endpoints
- All /privacy_policies endpoints
- GET /teaching_events endpoints (search and upcoming)