### PR TITLE
Add source to csv locations

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApi.Adapters
 
         public async Task<Point> GeocodePostcodeAsync(string postcode)
         {
-            var response = await _client.GeocodeAddress(postcode);
+            var response = await _client.GeocodeAddress($"postcode {postcode}");
 
             _logger.LogInformation($"Google API Status: {response.StatusText}");
 

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
+using Hangfire;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -87,6 +89,18 @@ namespace GetIntoTeachingApi.Controllers
             System.Text.StringBuilder builder = null;
 
             builder.Append("throw error");
+        }
+
+        [HttpGet]
+        [Route("trigger_location_sync")]
+        [SwaggerOperation(
+            Summary = "Manually triggers a location sync job",
+            OperationId = "TriggerLocationSync",
+            Tags = new[] { "Operations" })]
+        [ProducesResponseType(typeof(void), 200)]
+        public void TriggerLocationSync()
+        {
+            RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -7,6 +7,7 @@ using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -92,6 +93,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [Authorize]
         [Route("trigger_location_sync")]
         [SwaggerOperation(
             Summary = "Manually triggers a location sync job",

--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
@@ -10,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Prometheus;
-using Location = GetIntoTeachingApi.Models.Location;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -56,7 +56,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private static Location CreateLocation(dynamic location)
         {
-            return new Location(location.Postcode, location.Latitude, location.Longitude);
+            return new Location(location.Postcode, location.Latitude, location.Longitude, Source.CSV);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -51,6 +51,12 @@ namespace GetIntoTeachingApi.Models
         {
             Coordinate = coordinate;
         }
+
+        public Location(string postcode, double latitude, double longitude, Source source)
+           : this(postcode, latitude, longitude)
+        {
+            Source = source;
+        }
     }
 
     public enum Source

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -10,6 +10,8 @@ using Moq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
 using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -102,6 +104,13 @@ namespace GetIntoTeachingApiTests.Controllers
         public void LogRequests_IsPresent()
         {
             typeof(OperationsController).Should().BeDecoratedWith<LogRequestsAttribute>();
+        }
+
+        [Fact]
+        public void TriggerLocationSync_Authorize_IsPresent()
+        {
+            MethodInfo triggerLocationSync = typeof(OperationsController).GetMethod("TriggerLocationSync");
+            triggerLocationSync.Should().BeDecoratedWith<AuthorizeAttribute>();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
@@ -23,7 +24,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly IMetricService _metrics;
         private readonly Mock<ILogger<LocationBatchJob>> _mockLogger;
 
-        public LocationBatchJobTests(DatabaseFixture databaseFixture): base(databaseFixture)
+        public LocationBatchJobTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
             _mockLogger = new Mock<ILogger<LocationBatchJob>>();
             _metrics = new MetricService();
@@ -45,9 +46,10 @@ namespace GetIntoTeachingApiTests.Jobs
             await _job.RunAsync(JsonConvert.SerializeObject(batch));
             await _job.RunAsync(JsonConvert.SerializeObject(batch));
 
-            DbContext.Locations.Count().Should().Be(batch.Count());
+            DbContext.Locations.Count().Should().Be(batch.Count);
             DbContext.Locations.ToList().All(l =>
                 batch.Any(b => BatchLocationMatchesExistingLocation(b, l))).Should().BeTrue();
+            DbContext.Locations.All(l => l.Source == Source.CSV);
 
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Started");
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Succeeded");


### PR DESCRIPTION
Some locations from Google Geocoding were being set in the database with the wrong SRID. This PR adds a source to the locations that are imported from FreeMapTools, and an endpoint to manually trigger a location batch job.