### PR TITLE
Correct postcodes with unknown sources

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApi.Adapters
 
         public async Task<Point> GeocodePostcodeAsync(string postcode)
         {
-            var response = await _client.GeocodeAddress(postcode);
+            var response = await _client.GeocodeAddress($"postcode {postcode}");
 
             _logger.LogInformation($"Google API Status: {response.StatusText}");
 

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -10,6 +10,7 @@ using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using static GetIntoTeachingApi.Utils.Constants;
 
 namespace GetIntoTeachingApi.Controllers
 {
@@ -23,19 +24,22 @@ namespace GetIntoTeachingApi.Controllers
         private readonly INotifyService _notifyService;
         private readonly IHangfireService _hangfire;
         private readonly IEnv _env;
+        private readonly IBackgroundJobClient _jobClient;
 
         public OperationsController(
             ICrmService crm,
             IStore store,
             INotifyService notifyService,
             IHangfireService hangfire,
-            IEnv env)
+            IEnv env,
+            IBackgroundJobClient jobClient)
         {
             _store = store;
             _crm = crm;
             _notifyService = notifyService;
             _hangfire = hangfire;
             _env = env;
+            _jobClient = jobClient;
         }
 
         [HttpGet]
@@ -102,7 +106,7 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(void), 200)]
         public void TriggerLocationSync()
         {
-            RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
+            _jobClient.Enqueue<LocationSyncJob>(job => job.RunAsync(FreeMapToolsUrl));
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
+using Hangfire;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -87,6 +89,18 @@ namespace GetIntoTeachingApi.Controllers
             System.Text.StringBuilder builder = null;
 
             builder.Append("throw error");
+        }
+
+        [HttpGet]
+        [Route("trigger_location_sync")]
+        [SwaggerOperation(
+            Summary = "Manually triggers a location sync job",
+            OperationId = "TriggerLocationSync",
+            Tags = new[] { "Operations" })]
+        [ProducesResponseType(typeof(void), 200)]
+        public void TriggerLocationSync()
+        {
+            RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -10,7 +10,6 @@ using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using static GetIntoTeachingApi.Utils.Constants;
 
 namespace GetIntoTeachingApi.Controllers
 {
@@ -106,7 +105,7 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(void), 200)]
         public void TriggerLocationSync()
         {
-            _jobClient.Enqueue<LocationSyncJob>(job => job.RunAsync(FreeMapToolsUrl));
+            _jobClient.Enqueue<LocationSyncJob>(job => job.RunAsync(LocationSyncJob.FreeMapToolsUrl));
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -7,6 +7,7 @@ using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -92,6 +93,7 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [Authorize]
         [Route("trigger_location_sync")]
         [SwaggerOperation(
             Summary = "Manually triggers a location sync job",

--- a/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationBatchJob.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Database;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
@@ -10,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Prometheus;
-using Location = GetIntoTeachingApi.Models.Location;
 
 namespace GetIntoTeachingApi.Jobs
 {
@@ -56,7 +56,7 @@ namespace GetIntoTeachingApi.Jobs
 
         private static Location CreateLocation(dynamic location)
         {
-            return new Location(location.Postcode, location.Latitude, location.Longitude);
+            return new Location(location.Postcode, location.Latitude, location.Longitude, Source.CSV);
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApi.Jobs
     public class LocationSyncJob : BaseJob
     {
         public const string UkPostcodeCsvFilename = "ukpostcodes.csv";
+        public static readonly string FreeMapToolsUrl = "https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip";
         private const int BatchInterval = 100;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<LocationSyncJob> _logger;

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -52,6 +52,12 @@ namespace GetIntoTeachingApi.Models
             Coordinate = coordinate;
         }
 
+        public Location(string postcode, Point coordinate, Source source)
+         : this(postcode, coordinate)
+        {
+            Source = source;
+        }
+
         public Location(string postcode, double latitude, double longitude, Source source)
            : this(postcode, latitude, longitude)
         {

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -51,6 +51,12 @@ namespace GetIntoTeachingApi.Models
         {
             Coordinate = coordinate;
         }
+
+        public Location(string postcode, double latitude, double longitude, Source source)
+           : this(postcode, latitude, longitude)
+        {
+            Source = source;
+        }
     }
 
     public enum Source

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -270,7 +270,7 @@ namespace GetIntoTeachingApi.Services
 
         private async Task CacheLocation(string postcode, Point coordinate)
         {
-            var location = new Location(postcode, coordinate);
+            var location = new Location(postcode, coordinate, Source.Google);
             await _dbContext.Locations.AddAsync(location);
             await _dbContext.SaveChangesAsync();
         }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -25,6 +25,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.Xrm.Sdk;
 using Prometheus;
 using Swashbuckle.AspNetCore.Swagger;
+using static GetIntoTeachingApi.Utils.Constants;
 
 namespace GetIntoTeachingApi
 {
@@ -214,7 +215,7 @@ The GIT API aims to provide:
             RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
             RecurringJob.AddOrUpdate<LocationSyncJob>(
                 JobConfiguration.LocationSyncJobId,
-                (x) => x.RunAsync("https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip"),
+                (x) => x.RunAsync(FreeMapToolsUrl),
                 Cron.Weekly());
 
             // Don't seed test environment.

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -25,7 +25,6 @@ using Microsoft.OpenApi.Models;
 using Microsoft.Xrm.Sdk;
 using Prometheus;
 using Swashbuckle.AspNetCore.Swagger;
-using static GetIntoTeachingApi.Utils.Constants;
 
 namespace GetIntoTeachingApi
 {
@@ -215,7 +214,7 @@ The GIT API aims to provide:
             RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
             RecurringJob.AddOrUpdate<LocationSyncJob>(
                 JobConfiguration.LocationSyncJobId,
-                (x) => x.RunAsync(FreeMapToolsUrl),
+                (x) => x.RunAsync(LocationSyncJob.FreeMapToolsUrl),
                 Cron.Weekly());
 
             // Don't seed test environment.

--- a/GetIntoTeachingApi/Utils/Contants.cs
+++ b/GetIntoTeachingApi/Utils/Contants.cs
@@ -1,7 +1,0 @@
-﻿namespace GetIntoTeachingApi.Utils
-{
-    public static class Constants
-    {
-        public const string FreeMapToolsUrl = "https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip";
-    }
-}

--- a/GetIntoTeachingApi/Utils/Contants.cs
+++ b/GetIntoTeachingApi/Utils/Contants.cs
@@ -1,0 +1,7 @@
+﻿namespace GetIntoTeachingApi.Utils
+{
+    public static class Constants
+    {
+        public const string FreeMapToolsUrl = "https://www.freemaptools.com/download/full-postcodes/ukpostcodes.zip";
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -10,6 +10,8 @@ using Moq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
 using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -102,6 +104,13 @@ namespace GetIntoTeachingApiTests.Controllers
         public void LogRequests_IsPresent()
         {
             typeof(OperationsController).Should().BeDecoratedWith<LogRequestsAttribute>();
+        }
+
+        [Fact]
+        public void TriggerLocationSync_Authorize_IsPresent()
+        {
+            MethodInfo triggerLocationSync = typeof(OperationsController).GetMethod("TriggerLocationSync");
+            triggerLocationSync.Should().BeDecoratedWith<AuthorizeAttribute>();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationBatchJobTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
@@ -23,7 +24,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly IMetricService _metrics;
         private readonly Mock<ILogger<LocationBatchJob>> _mockLogger;
 
-        public LocationBatchJobTests(DatabaseFixture databaseFixture): base(databaseFixture)
+        public LocationBatchJobTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
             _mockLogger = new Mock<ILogger<LocationBatchJob>>();
             _metrics = new MetricService();
@@ -45,9 +46,10 @@ namespace GetIntoTeachingApiTests.Jobs
             await _job.RunAsync(JsonConvert.SerializeObject(batch));
             await _job.RunAsync(JsonConvert.SerializeObject(batch));
 
-            DbContext.Locations.Count().Should().Be(batch.Count());
+            DbContext.Locations.Count().Should().Be(batch.Count);
             DbContext.Locations.ToList().All(l =>
                 batch.Any(b => BatchLocationMatchesExistingLocation(b, l))).Should().BeTrue();
+            DbContext.Locations.All(l => l.Source == Source.CSV);
 
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Started");
             _mockLogger.VerifyInformationWasCalled("LocationBatchJob - Succeeded");

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -142,7 +142,8 @@ namespace GetIntoTeachingApiTests.Services
             var teachingEvent = DbContext.TeachingEvents.Include(te => te.Building)
                 .First(te => te.Building.AddressPostcode == postcode);
             teachingEvent.Building.Coordinate.Should().Be(coordinate);
-            DbContext.Locations.FirstOrDefault(l => l.Postcode == sanitizedPostcode).Should().NotBeNull();
+            DbContext.Locations.FirstOrDefault(l => (l.Postcode == sanitizedPostcode) &&
+                                                    (l.Source == Source.Google)).Should().NotBeNull();
         }
 
         [Fact]


### PR DESCRIPTION
- Add endpoint to trigger location batch job.
- When a location batch job is run, replace locations where the source is unknown with CSV source. 
- Tags locations cached from Google Geocoding as "Google"
- Specifies "postcodes" in the Google Geocode request.