### PR TITLE
Add endpoint to remove locations of unknown source

### DIFF
--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -107,5 +107,25 @@ namespace GetIntoTeachingApi.Controllers
         {
             _jobClient.Enqueue<LocationSyncJob>(job => job.RunAsync(LocationSyncJob.FreeMapToolsUrl));
         }
+
+        [HttpGet]
+        [Authorize]
+        [Route("remove_unknown_locations")]
+        [SwaggerOperation(
+      Summary = "Remove locations of unknown source from the database",
+      OperationId = "RemoveUnknownLocations",
+      Tags = new[] { "Operations" })]
+        [ProducesResponseType(typeof(void), 200)]
+        [ProducesResponseType(typeof(string), 200)]
+        public async Task<IActionResult> RemoveUnknownLocations(bool dryRun)
+        {
+            if (dryRun)
+            {
+                return Ok($"Number of locations with Unknown source: {_store.GetNumberOfUnknownLocations()}");
+            }
+
+            await _store.RemoveUnknownLocations();
+            return Ok();
+        }
     }
 }

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -115,7 +115,7 @@ namespace GetIntoTeachingApi.Controllers
       Summary = "Remove locations of unknown source from the database",
       OperationId = "RemoveUnknownLocations",
       Tags = new[] { "Operations" })]
-        [ProducesResponseType(typeof(void), 200)]
+        [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 200)]
         public async Task<IActionResult> RemoveUnknownLocations(bool dryRun)
         {
@@ -125,7 +125,7 @@ namespace GetIntoTeachingApi.Controllers
             }
 
             await _store.RemoveUnknownLocations();
-            return Ok();
+            return NoContent();
         }
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -19,5 +19,7 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEvent> GetUpcomingTeachingEvents();
+        Task RemoveUnknownLocations();
+        int GetNumberOfUnknownLocations();
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -120,14 +120,12 @@ namespace GetIntoTeachingApi.Services
 
         public int GetNumberOfUnknownLocations()
         {
-            IQueryable<Location> unknownLocations = GetUnknownLocations();
-            return unknownLocations.Count();
+            return GetUnknownLocations().Count();
         }
 
         public async Task RemoveUnknownLocations()
         {
-            IQueryable<Location> unknownLocations = GetUnknownLocations();
-            _dbContext.RemoveRange(unknownLocations);
+            _dbContext.RemoveRange(GetUnknownLocations());
             await _dbContext.SaveChangesAsync();
         }
 

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -118,6 +118,24 @@ namespace GetIntoTeachingApi.Services
                 .Where(e => e.StartAt >= DateTime.UtcNow);
         }
 
+        public int GetNumberOfUnknownLocations()
+        {
+            IQueryable<Location> unknownLocations = GetUnknownLocations();
+            return unknownLocations.Count();
+        }
+
+        public async Task RemoveUnknownLocations()
+        {
+            IQueryable<Location> unknownLocations = GetUnknownLocations();
+            _dbContext.RemoveRange(unknownLocations);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        private IQueryable<Location> GetUnknownLocations()
+        {
+            return _dbContext.Locations.Where(location => location.Source == Source.Unknown);
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -522,7 +522,7 @@ namespace GetIntoTeachingApiTests.Services
 
             await _store.RemoveUnknownLocations();
 
-            DbContext.Locations.Count().Should().Be(1);
+            DbContext.Locations.All(l => l.Source != Source.Unknown).Should().BeTrue();
         }
 
         private static IEnumerable<TeachingEvent> MockTeachingEvents()

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -495,6 +495,36 @@ namespace GetIntoTeachingApiTests.Services
             dates.Should().OnlyContain(d => d >= DateTime.UtcNow);
         }
 
+        [Fact]
+        public async Task GetNumberOfUnknownLocations_ReturnsUnknownLocationsCount()
+        {
+            var locations = new List<Location>() {
+                new Location { Postcode =  "ky119yu", Source = Source.Unknown },
+                new Location { Postcode = "ca48le", Source = Source.CSV },
+            };
+            DbContext.Locations.AddRange(locations);
+            await DbContext.SaveChangesAsync();
+
+            int result = _store.GetNumberOfUnknownLocations();
+
+            result.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task RemoveUnknownLocations_RemovesUnknownLocations()
+        {
+            var locations = new List<Location>() {
+                new Location { Postcode =  "ky119yu", Source = Source.Unknown },
+                new Location { Postcode = "ca48le", Source = Source.CSV },
+            };
+            DbContext.Locations.AddRange(locations);
+            await DbContext.SaveChangesAsync();
+
+            await _store.RemoveUnknownLocations();
+
+            DbContext.Locations.Count().Should().Be(1);
+        }
+
         private static IEnumerable<TeachingEvent> MockTeachingEvents()
         {
             var sharedBuildingId = Guid.NewGuid();


### PR DESCRIPTION
Some locations were being added to the database with incorrect coordinates, these have been tagged as having an unknown source. This PR adds and endpoint which removes them from the database.