### PR TITLE
Increase rate limit thresholds

### DIFF
--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -19,22 +19,22 @@
       {
         "Endpoint": "POST:/api/candidates/access_tokens",
         "Period": "1m",
-        "Limit": 250
+        "Limit": 500
       },
       {
         "Endpoint": "POST:/api/teacher_training_adviser/candidates",
         "Period": "1m",
-        "Limit": 100
+        "Limit": 250
       },
       {
         "Endpoint": "POST:/api/mailing_list/members",
         "Period": "1m",
-        "Limit": 100
+        "Limit": 250
       },
       {
         "Endpoint": "POST:/api/teaching_events/attendees",
         "Period": "1m",
-        "Limit": 100
+        "Limit": 250
       }
     ]
   }

--- a/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitingTests.cs
@@ -21,10 +21,10 @@ namespace GetIntoTeachingApiTests.Integration
         }
 
         [Theory]
-        [InlineData("/api/candidates/access_tokens", 250)]
-        [InlineData("/api/mailing_list/members", 100)]
-        [InlineData("/api/teaching_events/attendees", 100)]
-        [InlineData("/api/teacher_training_adviser/candidates", 100)]
+        [InlineData("/api/candidates/access_tokens", 500)]
+        [InlineData("/api/mailing_list/members", 250)]
+        [InlineData("/api/teaching_events/attendees", 250)]
+        [InlineData("/api/teacher_training_adviser/candidates", 250)]
         public async void Path_ExceedingRateLimit_ReturnsStatus429TooManyRequests(string path, int limit)
         {
             HttpResponseMessage response = null;

--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -28,7 +28,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1605107368852,
+  "iteration": 1607423005383,
   "links": [],
   "panels": [
     {
@@ -2237,7 +2237,7 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 100,
+          "value": 500,
           "yaxis": "left"
         },
         {
@@ -2245,7 +2245,7 @@
           "fill": true,
           "line": true,
           "op": "gt",
-          "value": 50,
+          "value": 150,
           "yaxis": "left"
         },
         {
@@ -2254,6 +2254,14 @@
           "line": true,
           "op": "gt",
           "value": 250,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 350,
           "yaxis": "left"
         }
       ],
@@ -2280,7 +2288,7 @@
           "format": "short",
           "label": "",
           "logBase": 1,
-          "max": "300",
+          "max": "550",
           "min": "0",
           "show": true
         },

--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -116,7 +116,7 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156134401/API+Runbook#GoogleApiErrors-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/28EURzZGz/get-into-teaching-api?viewPanel=57&orgId=1&var-App=get-into-teaching-api-prod
       - alert: ClientApproachingRateLimit
-        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 50'
+        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates|MailingList|TeachingEvents",action=~"AddMember|AddAttendee|SignUp",code=~".+"}[1m])) by (controller, action) > 175'
         labels:
           severity: medium
         annotations:
@@ -125,7 +125,7 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156134401/API+Runbook#ClientApproachingRateLimit-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/28EURzZGz/get-into-teaching-api?viewPanel=60&orgId=1&var-App=get-into-teaching-api-prod
       - alert: ClientApproachingRateLimit (CreateAccessToken)
-        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates",action=~"CreateAccessToken",code=~".+"}[1m])) by (controller, action) > 175'
+        expr: 'max(increase(http_request_duration_seconds_sum{controller=~"Candidates",action=~"CreateAccessToken",code=~".+"}[1m])) by (controller, action) > 350'
         labels:
           severity: medium
         annotations:


### PR DESCRIPTION
We are increasing the traffic from 10% to 25%; this ups the rate limit thresholds to ensure we have plenty of head room for the traffic increase.

Updates Grafana rate limit panel thresholds to match new values.

Updates Prometheus alerts to match new thresholds.