### PR TITLE
Increase Memory Allocation

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -9,3 +9,4 @@ paas_api_route_name        = "get-into-teaching-api-prod"
 paas_logging_endpoint_port = "syslog-tls://89d7be0f-ddcd-437e-ad3c-c8125d0bad00-ls.logit.io:18190"
 ASPNETCORE_ENVIRONMENT     = "Production"
 application_instances      = 2
+application_memory         = 2048

--- a/terraform/paas/test.env.tfvars
+++ b/terraform/paas/test.env.tfvars
@@ -9,3 +9,4 @@ paas_api_route_name        = "get-into-teaching-api-test"
 paas_logging_endpoint_port = "syslog-tls://89d7be0f-ddcd-437e-ad3c-c8125d0bad00-ls.logit.io:18190"
 ASPNETCORE_ENVIRONMENT     = "Staging"
 application_instances      = 2
+application_memory         = 2048


### PR DESCRIPTION
On the Test environment the memory allocation is set to 1GB. Recently the application has hit the limit on the Test environment, and as a precaution this PR will set the upper limit to 2GB. For both Test and Production.