### PR TITLE
Remove manual location sync endpoint

### DIFF
--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -2,12 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
-using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
-using Hangfire;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -23,22 +20,19 @@ namespace GetIntoTeachingApi.Controllers
         private readonly INotifyService _notifyService;
         private readonly IHangfireService _hangfire;
         private readonly IEnv _env;
-        private readonly IBackgroundJobClient _jobClient;
 
         public OperationsController(
             ICrmService crm,
             IStore store,
             INotifyService notifyService,
             IHangfireService hangfire,
-            IEnv env,
-            IBackgroundJobClient jobClient)
+            IEnv env)
         {
             _store = store;
             _crm = crm;
             _notifyService = notifyService;
             _hangfire = hangfire;
             _env = env;
-            _jobClient = jobClient;
         }
 
         [HttpGet]
@@ -93,19 +87,6 @@ namespace GetIntoTeachingApi.Controllers
             System.Text.StringBuilder builder = null;
 
             builder.Append("throw error");
-        }
-
-        [HttpGet]
-        [Authorize]
-        [Route("trigger_location_sync")]
-        [SwaggerOperation(
-            Summary = "Manually triggers a location sync job",
-            OperationId = "TriggerLocationSync",
-            Tags = new[] { "Operations" })]
-        [ProducesResponseType(typeof(void), 200)]
-        public void TriggerLocationSync()
-        {
-            _jobClient.Enqueue<LocationSyncJob>(job => job.RunAsync(LocationSyncJob.FreeMapToolsUrl));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -10,12 +10,6 @@ using Moq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
 using System;
-using System.Reflection;
-using Microsoft.AspNetCore.Authorization;
-using Hangfire;
-using Hangfire.Common;
-using GetIntoTeachingApi.Jobs;
-using Hangfire.States;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -26,7 +20,6 @@ namespace GetIntoTeachingApiTests.Controllers
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly Mock<IHangfireService> _mockHangfire;
         private readonly Mock<IEnv> _mockEnv;
-        private readonly Mock<IBackgroundJobClient> _mockClient;
         private readonly OperationsController _controller;
 
         public OperationsControllerTests()
@@ -36,15 +29,13 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockNotifyService = new Mock<INotifyService>();
             _mockHangfire = new Mock<IHangfireService>();
             _mockEnv = new Mock<IEnv>();
-            _mockClient = new Mock<IBackgroundJobClient>();
 
             _controller = new OperationsController(
                 _mockCrm.Object,
                 _mockStore.Object,
                 _mockNotifyService.Object,
                 _mockHangfire.Object,
-                _mockEnv.Object,
-                _mockClient.Object);
+                _mockEnv.Object);
         }
 
         [Fact]
@@ -111,24 +102,6 @@ namespace GetIntoTeachingApiTests.Controllers
         public void LogRequests_IsPresent()
         {
             typeof(OperationsController).Should().BeDecoratedWith<LogRequestsAttribute>();
-        }
-
-        [Fact]
-        public void TriggerLocationSync_Authorize_IsPresent()
-        {
-            MethodInfo triggerLocationSync = typeof(OperationsController).GetMethod("TriggerLocationSync");
-            triggerLocationSync.Should().BeDecoratedWith<AuthorizeAttribute>();
-        }
-
-        [Fact]
-        public void TriggerLocationSync_EnqueuesLocationSyncJob()
-        {
-            _controller.TriggerLocationSync();
-
-            _mockClient.Verify(client => client.Create(
-                It.Is<Job>(job => (job.Type == typeof(LocationSyncJob)) &&
-                                  (job.Method.Name == "RunAsync")),
-                It.IsAny<EnqueuedState>()));
         }
     }
 }


### PR DESCRIPTION
Some postcodes were being saved in postgres incorrectly (see PRs [390](https://github.com/DFE-Digital/get-into-teaching-api/pull/390) and [395](https://github.com/DFE-Digital/get-into-teaching-api/pull/395) for more details). As part of the fix, it was necessary to trigger a manual location sync. This is being removed as it is no longer needed. 