### PR TITLE
Remove PEN_TEST_SHARED_SECRET

### DIFF
--- a/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
+++ b/GetIntoTeachingApi/Auth/SharedSecretHandler.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApi.Auth
 
             var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", string.Empty);
 
-            var secrets = new[] { _env.SharedSecret, _env.PenTestSharedSecret };
+            var secrets = new[] { _env.SharedSecret };
 
             if (string.IsNullOrWhiteSpace(token) || !secrets.Contains(token))
             {

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -20,7 +20,6 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
-        public string PenTestSharedSecret => Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
         public int InstanceIndex
         {

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -18,7 +18,6 @@
         string CrmClientSecret { get; }
         string NotifyApiKey { get; }
         string SharedSecret { get; }
-        string PenTestSharedSecret { get; }
         string GoogleApiKey { get; }
         int InstanceIndex { get; }
     }

--- a/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/SharedSecretHandlerTests.cs
@@ -22,7 +22,6 @@ namespace GetIntoTeachingApiTests.Auth
         {
             _mockEnv = new Mock<IEnv>();
             _mockEnv.Setup(m => m.SharedSecret).Returns("shared_secret");
-            _mockEnv.Setup(m => m.PenTestSharedSecret).Returns("pen_test_shared_secret");
 
             var mockOptionsMonitor = new Mock<IOptionsMonitor<SharedSecretSchemeOptions>>();
             mockOptionsMonitor.Setup(m => m.Get("SharedSecretHandler")).Returns(new SharedSecretSchemeOptions());
@@ -38,8 +37,6 @@ namespace GetIntoTeachingApiTests.Auth
         [Theory]
         [InlineData("Bearer shared_secret", true)]
         [InlineData("shared_secret", true)]
-        [InlineData("Bearer pen_test_shared_secret", true)]
-        [InlineData("pen_test_shared_secret", true)]
         [InlineData("Bearer incorrect_shared_secret", false)]
         [InlineData("Bearer ", false)]
         [InlineData("", false)]
@@ -72,7 +69,6 @@ namespace GetIntoTeachingApiTests.Auth
         public async void InitializeAsync_EmptyOrNullSecretAndToken_ReturnsUnauthorized(string authHeaderValue, string secret)
         {
             _mockEnv.Setup(m => m.SharedSecret).Returns(secret);
-            _mockEnv.Setup(m => m.PenTestSharedSecret).Returns(secret);
 
             var context = new DefaultHttpContext();
             context.Request.Headers.Add("Authorization", authHeaderValue);

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -194,17 +194,6 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void PenTestSharedSecret_ReturnsCorrectly()
-        {
-            var previous = Environment.GetEnvironmentVariable("PEN_TEST_SHARED_SECRET");
-            Environment.SetEnvironmentVariable("PEN_TEST_SHARED_SECRET", "pen-test-shared-secret");
-
-            _env.PenTestSharedSecret.Should().Be("pen-test-shared-secret");
-
-            Environment.SetEnvironmentVariable("PEN_TEST_SHARED_SECRET", previous);
-        }
-
-        [Fact]
         public void GoogleApiKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -44,7 +44,6 @@ resource "cloudfoundry_app" "api_application" {
     NOTIFY_API_KEY         = var.NOTIFY_API_KEY
     TOTP_SECRET_KEY        = var.TOTP_SECRET_KEY
     SHARED_SECRET          = var.SHARED_SECRET
-    PEN_TEST_SHARED_SECRET = var.PEN_TEST_SHARED_SECRET
     Sentry__Dsn            = var.SENTRY_DSN
     GOOGLE_API_KEY         = var.GOOGLE_API_KEY
     ASPNETCORE_ENVIRONMENT = var.ASPNETCORE_ENVIRONMENT

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -95,9 +95,6 @@ variable "CRM_CLIENT_ID" {}
 variable "CRM_TENANT_ID" {}
 variable "CRM_CLIENT_SECRET" {}
 variable "SHARED_SECRET" {}
-variable "PEN_TEST_SHARED_SECRET" {
-  default = ""
-}
 variable "NOTIFY_API_KEY" {}
 variable "TOTP_SECRET_KEY" {}
 variable "SENTRY_DSN" {


### PR DESCRIPTION
We introduced this for the penetration test company to be able to access the app in the test environment; they no longer need access so we can remove it.