### PR TITLE
Log request details on validation failure

### DIFF
--- a/GetIntoTeachingApi/Attributes/LogRequestsAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/LogRequestsAttribute.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using GetIntoTeachingApi.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace GetIntoTeachingApi.Attributes
 {
@@ -31,8 +29,8 @@ namespace GetIntoTeachingApi.Attributes
         {
             var descriptor = (ControllerActionDescriptor)context.ActionDescriptor;
 
-            var messages = context.ActionArguments.Select(a => LogMessageForObject(a.Value));
-            var message = LogMessage("Request", descriptor, messages);
+            var messages = context.ActionArguments.Select(a => LoggableMessageComposer.LogMessageForObject(a.Value));
+            var message = LoggableMessageComposer.LogMessage("Request", descriptor, messages);
             _logger.LogInformation(message);
         }
 
@@ -41,56 +39,9 @@ namespace GetIntoTeachingApi.Attributes
             if (context.Result is ObjectResult result)
             {
                 var descriptor = (ControllerActionDescriptor)context.ActionDescriptor;
-                var messages = new List<string> { LogMessageForObject(result.Value) };
-                var message = LogMessage("Response", descriptor, messages);
+                var messages = new List<string> { LoggableMessageComposer.LogMessageForObject(result.Value) };
+                var message = LoggableMessageComposer.LogMessage("Response", descriptor, messages);
                 _logger.LogInformation(message);
-            }
-        }
-
-        private static string LogMessage(string type, ControllerActionDescriptor descriptor, IEnumerable<string> messages)
-        {
-            var actionName = descriptor.ActionName;
-            var controllerName = descriptor.ControllerName;
-            var payload = string.Join("\n", messages.Where(m => !string.IsNullOrEmpty(m)));
-
-            return $"{type} {controllerName}:{actionName} - {payload}";
-        }
-
-        private static string LogMessageForObject(object obj)
-        {
-            var type = obj.GetType().GetGenericArguments().FirstOrDefault();
-
-            if (type == null)
-            {
-                type = obj.GetType();
-            }
-
-            if (type.GetCustomAttribute<LoggableAttribute>() == null)
-            {
-                return null;
-            }
-
-            return JsonConvert.SerializeObject(
-                obj,
-                Formatting.None,
-                new JsonSerializerSettings
-                {
-                    ContractResolver = new FilterSensitiveDataContractResolver(),
-                });
-        }
-
-        private class FilterSensitiveDataContractResolver : DefaultContractResolver
-        {
-            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
-            {
-                var property = base.CreateProperty(member, memberSerialization);
-
-                property.ShouldSerialize = instance =>
-                    instance.GetType().GetCustomAttribute<LoggableAttribute>() != null &&
-                    member.GetCustomAttribute<SensitiveDataAttribute>() == null &&
-                    member.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() == null;
-
-                return property;
             }
         }
     }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -17,10 +17,14 @@ using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Microsoft.Xrm.Sdk;
 using Prometheus;
@@ -90,6 +94,25 @@ namespace GetIntoTeachingApi
                 // Workaround for https://github.com/dotnet/aspnetcore/issues/8302
                 // caused by Prometheus.HttpMetrics.HttpRequestDurationMiddleware
                 options.AllowSynchronousIO = true;
+            });
+
+            services.PostConfigure<ApiBehaviorOptions>(options =>
+            {
+                var builtInFactory = options.InvalidModelStateResponseFactory;
+
+                options.InvalidModelStateResponseFactory = context =>
+                {
+                    var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Startup>>();
+
+                    var actionExecutingContext = (ActionExecutingContext)context;
+                    var descriptor = (ControllerActionDescriptor)context.ActionDescriptor;
+
+                    var messages = actionExecutingContext.ActionArguments.Select(a => LoggableMessageComposer.LogMessageForObject(a.Value));
+                    var message = LoggableMessageComposer.LogMessage("ValidationFailure", descriptor, messages);
+                    logger.LogWarning(message);
+
+                    return builtInFactory(context);
+                };
             });
 
             services.AddSwaggerGen(c =>

--- a/GetIntoTeachingApi/Utils/LoggableMessageComposer.cs
+++ b/GetIntoTeachingApi/Utils/LoggableMessageComposer.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using GetIntoTeachingApi.Attributes;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class LoggableMessageComposer
+    {
+        public static string LogMessage(string prefix, ControllerActionDescriptor descriptor, IEnumerable<string> messages)
+        {
+            var actionName = descriptor.ActionName;
+            var controllerName = descriptor.ControllerName;
+            var payload = string.Join("\n", messages.Where(m => !string.IsNullOrEmpty(m)));
+
+            return $"{prefix} {controllerName}:{actionName} - {payload}";
+        }
+
+        public static string LogMessageForObject(object obj)
+        {
+            var type = obj.GetType().GetGenericArguments().FirstOrDefault();
+
+            if (type == null)
+            {
+                type = obj.GetType();
+            }
+
+            if (type.GetCustomAttribute<LoggableAttribute>() == null)
+            {
+                return null;
+            }
+
+            return JsonConvert.SerializeObject(
+                obj,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new FilterSensitiveDataContractResolver(),
+                });
+        }
+
+        private class FilterSensitiveDataContractResolver : DefaultContractResolver
+        {
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                var property = base.CreateProperty(member, memberSerialization);
+
+                property.ShouldSerialize = instance =>
+                    instance.GetType().GetCustomAttribute<LoggableAttribute>() != null &&
+                    member.GetCustomAttribute<SensitiveDataAttribute>() == null &&
+                    member.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() == null;
+
+                return property;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Attributes/LogRequestsAttributeTests.cs
+++ b/GetIntoTeachingApiTests/Attributes/LogRequestsAttributeTests.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApiTests.Helpers;
+using GetIntoTeachingApiTests.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -148,28 +149,6 @@ namespace GetIntoTeachingApiTests.Filters
             _filter.OnActionExecuted(_actionExecutedContext);
 
             _mockLogger.VerifyInformationWasCalledExactly("Response Controller:Action - ");
-        }
-
-        [Loggable]
-        private class StubLoggable
-        {
-            public string Name { get; set; } = "Ross";
-            [SensitiveData]
-            public string Password { get; set; } = "sensitive";
-            [JsonIgnore]
-            public string Ignored { get; set; } = "ignored";
-
-            public StubLoggable() { }
-
-            public StubLoggable(string name)
-            {
-                Name = name;
-            }
-        }
-
-        private class StubUnloggable
-        {
-            public string Name { get; set; } = "Ross";
         }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/LoggableMessageComposerTests.cs
+++ b/GetIntoTeachingApiTests/Utils/LoggableMessageComposerTests.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class LoggableMessageComposerTests
+    {
+        [Fact]
+        public void LogMessageForObject__WithLoggable_SerializesLoggableAttributes()
+        {
+            var message = LoggableMessageComposer.LogMessageForObject(new StubLoggable());
+
+            message.Should().Be("{\"Name\":\"Ross\"}");
+        }
+
+        [Fact]
+        public void LogMessageForObject_WithArrayOfLoggable_SerializesAllObjectLoggableAttributes()
+        {
+            var objs = new List<StubLoggable>() { new StubLoggable("Ross"), new StubLoggable("James") };
+
+            var message = LoggableMessageComposer.LogMessageForObject(objs);
+
+            message.Should().Be("[{\"Name\":\"Ross\"},{\"Name\":\"James\"}]");
+        }
+
+        [Fact]
+        public void LogMessageForObject_WithUnloggable_ReturnsNull()
+        {
+            var message = LoggableMessageComposer.LogMessageForObject(new StubUnloggable());
+
+            message.Should().BeNull();
+        }
+
+        [Fact]
+        public void LogMessageForObject_WithPrimitive_ReturnsNull()
+        {
+            var message = LoggableMessageComposer.LogMessageForObject(123);
+
+            message.Should().BeNull();
+        }
+
+        [Fact]
+        public void LogMessage_WithSingleMessage_FormatsCorrectly()
+        {
+            var messages = new[] { "message" };
+            var descriptor = new ControllerActionDescriptor()
+            {
+                ActionName = "Action",
+                ControllerName = "Controller"
+            };
+
+            var message = LoggableMessageComposer.LogMessage("Prefix", descriptor, messages);
+
+            message.Should().Be("Prefix Controller:Action - message");
+        }
+
+        [Fact]
+        public void LogMessage_WithMultipleMessages_FormatsCorrectly()
+        {
+            var messages = new[] { "message1", "message2" };
+            var descriptor = new ControllerActionDescriptor()
+            {
+                ActionName = "Action",
+                ControllerName = "Controller"
+            };
+
+            var message = LoggableMessageComposer.LogMessage("Prefix", descriptor, messages);
+
+            message.Should().Be("Prefix Controller:Action - message1\nmessage2");
+        }
+
+        [Fact]
+        public void LogMessage_WithNullMessages_FormatsCorrectly()
+        {
+            var messages = new[] { null as string };
+            var descriptor = new ControllerActionDescriptor()
+            {
+                ActionName = "Action",
+                ControllerName = "Controller"
+            };
+
+            var message = LoggableMessageComposer.LogMessage("Prefix", descriptor, messages);
+
+            message.Should().Be("Prefix Controller:Action - ");
+        }
+    }
+
+    [Loggable]
+    public class StubLoggable
+    {
+        public string Name { get; set; } = "Ross";
+        [SensitiveData]
+        public string Password { get; set; } = "sensitive";
+        [JsonIgnore]
+        public string Ignored { get; set; } = "ignored";
+
+        public StubLoggable() { }
+
+        public StubLoggable(string name)
+        {
+            Name = name;
+        }
+    }
+
+    public class StubUnloggable
+    {
+        public string Name { get; set; } = "Ross";
+    }
+}


### PR DESCRIPTION
Currently when the API receives a request the appropriate request model validator is ran automatically before the controller action is called. The side effect of this is that the `LoggableAttribute` action filter is never ran for these requests, meaning we don't have meaningful logs around what was in the request payload.

This PR breaks out the logic to translate an `ActionExecutingContext` and `ControllerActionDescriptor` into formatted, sanitised log messages to a new utility class `LoggableMessageComposer`.

We then hook into the `PostConfigure` callback and override the `InvalidModelStateResponseFactory` to log out the request details before calling the built in factory that formats and returns a helpful 400 response..