### PR TITLE
Fire and Forget Cypress Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,20 +211,6 @@ jobs:
            inputs: '{"application": "BOTH" , "reference": "${{ github.sha }}" }'
            ref:  refs/heads/master
 
-       - name: Wait for Cypress Tests
-         uses: fountainhead/action-wait-for-check@v1.0.0
-         id: wait-for-deploy
-         with:
-           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
-           checkName: ${{ github.sha }}
-           ref: refs/heads/master
-           repo: get-into-teaching-frontend-tests
-           intervalSeconds: 30
-           timeoutSeconds: 1800
-
-       - name: Check for test failure
-         if: steps.wait-for-build.outputs.conclusion == 'failure'
-         run: exit 1
 
   production:
      name: Production Deployment


### PR DESCRIPTION
The API workflow runs the full suit of cypress tests, these can take a while. Since it does not deliver to  production, we might as well allow cypress to trigger errors in slack if it fails, but not wait for it.