### PR TITLE
Only run CrmSyncJob on first boot

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -243,11 +243,15 @@ The GIT API aims to provide:
             // Don't seed test environment.
             if (!env.IsTest)
             {
-                // Sync with the CRM.
-                RecurringJob.Trigger(JobConfiguration.CrmSyncJobId);
+                var dbContext = serviceScope.ServiceProvider.GetService<GetIntoTeachingDbContext>();
+
+                // Initial CRM sync.
+                if (!dbContext.TypeEntities.Any())
+                {
+                    RecurringJob.Trigger(JobConfiguration.CrmSyncJobId);
+                }
 
                 // Initial locations sync.
-                var dbContext = serviceScope.ServiceProvider.GetService<GetIntoTeachingDbContext>();
                 if (!dbContext.Locations.Any())
                 {
                     RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);


### PR DESCRIPTION
We used to run this every time the app booted as syncs were infrequent and it could have been helpful, but we now run the CrmSync every 5 minutes so its not really necessary any longer.

Also this may prevent the exception thats often raised when the app boots and tries to sync before the permissions to the DB have propagated.