### PR TITLE
Enable rate limiting in test environment

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -187,10 +187,7 @@ The GIT API aims to provide:
             using var serviceScope = app.ApplicationServices.CreateScope();
             var env = serviceScope.ServiceProvider.GetService<IEnv>();
 
-            if (!env.IsStaging)
-            {
-                app.UseClientRateLimiting();
-            }
+            app.UseClientRateLimiting();
 
             if (hostEnv.IsDevelopment())
             {


### PR DESCRIPTION
Temporarily enables rate limiting in the test environment so we can ensure its functioning correctly with the Redis DB.