### PR TITLE
Revert "Enable rate limiting in test environment"

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -187,7 +187,10 @@ The GIT API aims to provide:
             using var serviceScope = app.ApplicationServices.CreateScope();
             var env = serviceScope.ServiceProvider.GetService<IEnv>();
 
-            app.UseClientRateLimiting();
+            if (!env.IsStaging)
+            {
+                app.UseClientRateLimiting();
+            }
 
             if (hostEnv.IsDevelopment())
             {


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#412 - this was enabled temporarily in the test environment so that we can ensure the rate limiting counters work correctly when backed by the Redis store.