### PR TITLE
Scope Source enum to Location model

### DIFF
--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -72,7 +72,7 @@ namespace GetIntoTeachingApi.Jobs
 
             var postcode = csv.GetField<string>("postcode");
 
-            return new Location(postcode, (double)latitude, (double)longitude, Source.CSV);
+            return new Location(postcode, (double)latitude, (double)longitude, Location.SourceType.CSV);
         }
 
         private static string GetTempPath()
@@ -132,7 +132,7 @@ namespace GetIntoTeachingApi.Jobs
             {
                 new NpgsqlParameter($"postcode{index}", location.Postcode),
                 new NpgsqlParameter($"coordinate{index}", location.Coordinate),
-                new NpgsqlParameter($"source{index}", (int)Source.CSV),
+                new NpgsqlParameter($"source{index}", (int)Location.SourceType.CSV),
             };
         }
 

--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,6 +10,13 @@ namespace GetIntoTeachingApi.Models
 {
     public class Location
     {
+        public enum SourceType
+        {
+            Unknown,
+            Google,
+            CSV,
+        }
+
         public static readonly Regex OutwardOrFullPostcodeRegex = new Regex(
             $@"\A({OutwardPostcodePattern})\Z|\A({FullPostcodePattern})\z", RegexOptions.IgnoreCase);
         public static readonly Regex PostcodeRegex = new Regex(
@@ -24,7 +30,7 @@ namespace GetIntoTeachingApi.Models
         public string Postcode { get; set; }
         [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }
-        public Source Source { get; set; }
+        public SourceType Source { get; set; }
 
         public static string SanitizePostcode(string postcode)
         {
@@ -67,23 +73,16 @@ namespace GetIntoTeachingApi.Models
             Coordinate = coordinate;
         }
 
-        public Location(string postcode, Point coordinate, Source source)
+        public Location(string postcode, Point coordinate, SourceType source)
          : this(postcode, coordinate)
         {
             Source = source;
         }
 
-        public Location(string postcode, double latitude, double longitude, Source source)
+        public Location(string postcode, double latitude, double longitude, SourceType source)
            : this(postcode, latitude, longitude)
         {
             Source = source;
         }
-    }
-
-    public enum Source
-    {
-        Unknown,
-        Google,
-        CSV,
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -270,7 +270,7 @@ namespace GetIntoTeachingApi.Services
 
         private async Task CacheLocation(string postcode, Point coordinate)
         {
-            var location = new Location(postcode, coordinate, Source.Google);
+            var location = new Location(postcode, coordinate, Location.SourceType.Google);
             await _dbContext.Locations.AddAsync(location);
             await _dbContext.SaveChangesAsync();
         }

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -69,7 +69,7 @@ namespace GetIntoTeachingApiTests.Jobs
             DbContext.Locations.Count().Should().Be(batch.Count);
             DbContext.Locations.ToList().All(l =>
                 batch.Any(b => BatchLocationMatchesExistingLocation(b, l))).Should().BeTrue();
-            DbContext.Locations.All(l => l.Source == Source.CSV);
+            DbContext.Locations.All(l => l.Source == GetIntoTeachingApi.Models.Location.SourceType.CSV);
 
             _mockLogger.VerifyInformationWasCalled("LocationSyncJob - Started");
             _mockLogger.VerifyInformationWasCalled("LocationSyncJob - ZIP Downloaded");

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -143,7 +143,7 @@ namespace GetIntoTeachingApiTests.Services
                 .First(te => te.Building.AddressPostcode == postcode);
             teachingEvent.Building.Coordinate.Should().Be(coordinate);
             DbContext.Locations.FirstOrDefault(l => (l.Postcode == sanitizedPostcode) &&
-                                                    (l.Source == Source.Google)).Should().NotBeNull();
+                                                    (l.Source == Location.SourceType.Google)).Should().NotBeNull();
         }
 
         [Fact]


### PR DESCRIPTION
I missed this in the original review, but the `Source` enum should be scoped to the `Location` model.

Rename to `SourceType` so that it doesn't clash with the `Source` attribute.
