### PR TITLE
Dry up validation with custom property validator

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -46,5 +46,6 @@
 
 	<ItemGroup>
 	  <Folder Include="Redis\" />
+	  <Folder Include="Validators\" />
 	</ItemGroup>
 </Project>

--- a/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
@@ -1,37 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using FluentValidation;
+﻿using FluentValidation;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidatePastTeachingPositionValidator : AbstractValidator<CandidatePastTeachingPosition>
     {
-        private readonly IStore _store;
-
         public CandidatePastTeachingPositionValidator(IStore store)
         {
-            _store = store;
-
             RuleFor(position => position.EducationPhaseId)
-                .Must(id => EducationPhaseIds().Contains(id))
-                .WithMessage("Must be a valid past teaching position education phase.");
-            RuleFor(candidate => candidate.SubjectTaughtId)
-                .Must(id => TeachingSubjectIds().Contains(id))
-                .WithMessage("Must be a valid teaching subject.");
-        }
-
-        private IEnumerable<Guid?> TeachingSubjectIds()
-        {
-            return _store.GetLookupItems("dfe_teachingsubjectlist").Select(subject => subject.Id);
-        }
-
-        private IEnumerable<int?> EducationPhaseIds()
-        {
-            return _store.
-                GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase")
-                .Select(type => (int?)type.Id);
+                .SetValidator(new PickListItemIdValidator("dfe_candidatepastteachingposition", "dfe_educationphase", store));
+            RuleFor(position => position.SubjectTaughtId)
+                .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateQualificationValidator.cs
@@ -1,47 +1,24 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using FluentValidation;
+﻿using FluentValidation;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidateQualificationValidator : AbstractValidator<CandidateQualification>
     {
-        private readonly IStore _store;
-
         public CandidateQualificationValidator(IStore store)
         {
-            _store = store;
-
             RuleFor(qualification => qualification.UkDegreeGradeId)
-                .Must(id => UkDegreeGradeIds().Contains(id))
-                .Unless(qualification => qualification.UkDegreeGradeId == null)
-                .WithMessage("Must be a valid qualification uk degree grade.");
+                .SetValidator(new PickListItemIdValidator("dfe_candidatequalification", "dfe_ukdegreegrade", store))
+                .Unless(qualification => qualification.UkDegreeGradeId == null);
             RuleFor(qualification => qualification.DegreeStatusId)
-                .Must(id => StatusIds().Contains(id))
-                .Unless(qualification => qualification.DegreeStatusId == null)
-                .WithMessage("Must be a valid qualification degree status.");
+                .SetValidator(new PickListItemIdValidator("dfe_candidatequalification", "dfe_degreestatus", store))
+                .Unless(qualification => qualification.DegreeStatusId == null);
             RuleFor(qualification => qualification.TypeId)
-                .Must(id => TypeIds().Contains(id))
-                .Unless(qualification => qualification.TypeId == null)
-                .WithMessage("Must be a valid qualification types.");
+                .SetValidator(new PickListItemIdValidator("dfe_candidatequalification", "dfe_type", store))
+                .Unless(qualification => qualification.TypeId == null);
 
             RuleFor(qualification => qualification.DegreeSubject).MaximumLength(600);
-        }
-
-        private IEnumerable<int?> UkDegreeGradeIds()
-        {
-            return _store.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade").Select(grade => (int?)grade.Id);
-        }
-
-        private IEnumerable<int?> StatusIds()
-        {
-            return _store.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus").Select(status => (int?)status.Id);
-        }
-
-        private IEnumerable<int?> TypeIds()
-        {
-            return _store.GetPickListItems("dfe_candidatequalification", "dfe_type").Select(type => (int?)type.Id);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -4,18 +4,16 @@ using System.Linq;
 using FluentValidation;
 using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidateValidator : AbstractValidator<Candidate>
     {
-        private readonly IStore _store;
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
         public CandidateValidator(IStore store)
         {
-            _store = store;
-
             RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
@@ -40,151 +38,63 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must not contain multiple registrations for the same event.");
 
             RuleFor(candidate => candidate.PreferredTeachingSubjectId)
-                .Must(id => PreferredTeachingSubjectIds().Contains(id))
-                .Unless(candidate => candidate.PreferredTeachingSubjectId == null)
-                .WithMessage("Must be a valid teaching subject.");
+                .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store))
+                .Unless(candidate => candidate.PreferredTeachingSubjectId == null);
             RuleFor(candidate => candidate.CountryId)
-                .Must(id => CountryIds().Contains(id))
-                .Unless(candidate => candidate.CountryId == null)
-                .WithMessage("Must be a valid country.");
+                .SetValidator(new LookupItemIdValidator("dfe_country", store))
+                .Unless(candidate => candidate.CountryId == null);
             RuleFor(candidate => candidate.PreferredEducationPhaseId)
-                .Must(id => PreferredEducationPhaseIds().Contains(id))
-                .Unless(candidate => candidate.PreferredEducationPhaseId == null)
-                .WithMessage("Must be a valid candidate education phase.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_preferrededucationphase01", store))
+                .Unless(candidate => candidate.PreferredEducationPhaseId == null);
             RuleFor(candidate => candidate.InitialTeacherTrainingYearId)
-                .Must(id => InitialTeacherTrainingYearIds().Contains(id))
-                .Unless(candidate => candidate.InitialTeacherTrainingYearId == null)
-                .WithMessage("Must be a valid candidate initial teacher training year.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_ittyear", store))
+                .Unless(candidate => candidate.InitialTeacherTrainingYearId == null);
             RuleFor(candidate => candidate.ChannelId)
-                .Must(id => ChannelIds().Contains(id))
-                .Unless(candidate => candidate.Id != null)
-                .WithMessage("Must be a valid candidate channel.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_channelcreation", store))
+                .Unless(candidate => candidate.Id != null);
             RuleFor(candidate => candidate.ChannelId)
                 .Must(id => id == null)
                 .Unless(candidate => candidate.Id == null)
                 .WithMessage("You cannot change the channel of an existing candidate.");
             RuleFor(candidate => candidate.HasGcseEnglishId)
-                .Must(id => GcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.HasGcseEnglishId == null)
-                .WithMessage("Must be a valid candidate GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websitehasgcseenglish", store))
+                .Unless(candidate => candidate.HasGcseEnglishId == null);
             RuleFor(candidate => candidate.HasGcseMathsId)
-                .Must(id => GcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.HasGcseMathsId == null)
-                .WithMessage("Must be a valid candidate GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websitehasgcseenglish", store))
+                .Unless(candidate => candidate.HasGcseMathsId == null);
             RuleFor(candidate => candidate.HasGcseScienceId)
-                .Must(id => GcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.HasGcseScienceId == null)
-                .WithMessage("Must be a valid candidate GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websitehasgcseenglish", store))
+                .Unless(candidate => candidate.HasGcseScienceId == null);
             RuleFor(candidate => candidate.PlanningToRetakeGcseScienceId)
-                .Must(id => RetakeGcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.PlanningToRetakeGcseScienceId == null)
-                .WithMessage("Must be a valid candidate retake GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websiteplanningretakeenglishgcse", store))
+                .Unless(candidate => candidate.PlanningToRetakeGcseScienceId == null);
             RuleFor(candidate => candidate.PlanningToRetakeGcseEnglishId)
-                .Must(id => RetakeGcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.PlanningToRetakeGcseEnglishId == null)
-                .WithMessage("Must be a valid candidate retake GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websiteplanningretakeenglishgcse", store))
+                .Unless(candidate => candidate.PlanningToRetakeGcseEnglishId == null);
             RuleFor(candidate => candidate.PlanningToRetakeGcseMathsId)
-                .Must(id => RetakeGcseStatusIds().Contains(id))
-                .Unless(candidate => candidate.PlanningToRetakeGcseMathsId == null)
-                .WithMessage("Must be a valid candidate retake GCSE status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websiteplanningretakeenglishgcse", store))
+                .Unless(candidate => candidate.PlanningToRetakeGcseMathsId == null);
             RuleFor(candidate => candidate.ConsiderationJourneyStageId)
-                .Must(id => ConsiderationJourneyStageIds().Contains(id))
-                .Unless(candidate => candidate.ConsiderationJourneyStageId == null)
-                .WithMessage("Must be a valid candidate consideration journey stage.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websitewhereinconsiderationjourney", store))
+                .Unless(candidate => candidate.ConsiderationJourneyStageId == null);
             RuleFor(candidate => candidate.TypeId)
-                .Must(id => TypeIds().Contains(id))
-                .Unless(candidate => candidate.TypeId == null)
-                .WithMessage("Must be a valid candidate type.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_typeofcandidate", store))
+                .Unless(candidate => candidate.TypeId == null);
             RuleFor(candidate => candidate.AssignmentStatusId)
-                .Must(id => AssignmentStatusIds().Contains(id))
-                .Unless(candidate => candidate.AssignmentStatusId == null)
-                .WithMessage("Must be a valid candidate assignment status.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_candidatestatus", store))
+                .Unless(candidate => candidate.AssignmentStatusId == null);
             RuleFor(candidate => candidate.AdviserEligibilityId)
-                .Must(id => AdviserEligibilityIds().Contains(id))
-                .Unless(candidate => candidate.AdviserEligibilityId == null)
-                .WithMessage("Must be a valid candidate adviser eligibility.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_iscandidateeligibleforadviser", store))
+                .Unless(candidate => candidate.AdviserEligibilityId == null);
             RuleFor(candidate => candidate.AdviserRequirementId)
-                .Must(id => AdviserRequirementIds().Contains(id))
-                .Unless(candidate => candidate.AdviserRequirementId == null)
-                .WithMessage("Must be a valid candidate adviser requirement.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_websitewhereinconsiderationjourney", store))
+                .Unless(candidate => candidate.AdviserRequirementId == null);
             RuleFor(candidate => candidate.EventsSubscriptionChannelId)
-                .Must(id => EventSubscriptionChannelIds().Contains(id))
-                .Unless(candidate => candidate.EventsSubscriptionChannelId == null)
-                .WithMessage("Must be a valid event subscription channel.");
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_gitiseventsservicesubscriptionchannel", store))
+                .Unless(candidate => candidate.EventsSubscriptionChannelId == null);
             RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
-                .Must(id => MailingListSubscriptionChannelIds().Contains(id))
-                .Unless(candidate => candidate.MailingListSubscriptionChannelId == null)
-                .WithMessage("Must be a valid mailing list subscription channel.");
-        }
-
-        private IEnumerable<Guid?> PreferredTeachingSubjectIds()
-        {
-            return _store.GetLookupItems("dfe_teachingsubjectlist").Select(subject => subject.Id);
-        }
-
-        private IEnumerable<Guid?> CountryIds()
-        {
-            return _store.GetLookupItems("dfe_country").Select(country => country.Id);
-        }
-
-        private IEnumerable<int?> PreferredEducationPhaseIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_preferrededucationphase01").Select(phase => (int?)phase.Id);
-        }
-
-        private IEnumerable<int?> InitialTeacherTrainingYearIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_ittyear").Select(year => (int?)year.Id);
-        }
-
-        private IEnumerable<int?> ChannelIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_channelcreation").Select(channel => (int?)channel.Id);
-        }
-
-        private IEnumerable<int?> MailingListSubscriptionChannelIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel").Select(channel => (int?)channel.Id);
-        }
-
-        private IEnumerable<int?> EventSubscriptionChannelIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel").Select(channel => (int?)channel.Id);
-        }
-
-        private IEnumerable<int?> GcseStatusIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_websitehasgcseenglish").Select(status => (int?)status.Id);
-        }
-
-        private IEnumerable<int?> RetakeGcseStatusIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_websiteplanningretakeenglishgcse").Select(status => (int?)status.Id);
-        }
-
-        private IEnumerable<int?> ConsiderationJourneyStageIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_websitewhereinconsiderationjourney").Select(describe => (int?)describe.Id);
-        }
-
-        private IEnumerable<int?> TypeIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_typeofcandidate").Select(type => (int?)type.Id);
-        }
-
-        private IEnumerable<int?> AssignmentStatusIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_candidatestatus").Select(type => (int?)type.Id);
-        }
-
-        private IEnumerable<int?> AdviserEligibilityIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_iscandidateeligibleforadviser").Select(eligibility => (int?)eligibility.Id);
-        }
-
-        private IEnumerable<int?> AdviserRequirementIds()
-        {
-            return _store.GetPickListItems("contact", "dfe_isadvisorrequiredos").Select(requirement => (int?)requirement.Id);
+                .SetValidator(new PickListItemIdValidator("contact", "dfe_gitismlservicesubscriptionchannel", store))
+                .Unless(candidate => candidate.MailingListSubscriptionChannelId == null);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
@@ -1,29 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentValidation;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class PhoneCallValidator : AbstractValidator<PhoneCall>
     {
-        private readonly IStore _store;
-
         public PhoneCallValidator(IStore store)
         {
-            _store = store;
-
             RuleFor(phoneCall => phoneCall.ScheduledAt).GreaterThan(candidate => DateTime.UtcNow);
-
-            RuleFor(candidate => candidate.ChannelId)
-                .Must(id => ChannelIds().Contains(id))
-                .WithMessage("Must be a valid candidate channel.");
-        }
-
-        private IEnumerable<int?> ChannelIds()
-        {
-            return _store.GetPickListItems("phonecall", "dfe_channelcreation").Select(channel => (int?)channel.Id);
+            RuleFor(phoneCall => phoneCall.ChannelId)
+                .SetValidator(new PickListItemIdValidator("phonecall", "dfe_channelcreation", store));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventRegistrationValidator.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentValidation;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
@@ -21,20 +20,13 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(registration => registration.EventId)
                 .Must(id => BeAvailableForOnlineRegistrations(id))
                 .WithMessage("Attendence cannot be registered for this event via the API (it has no WebFeedId).");
-
-            RuleFor(registration => registration.ChannelId)
-                .Must(id => ChannelIds().Contains(id))
-                .Unless(registration => registration.Id != null)
-                .WithMessage("Must be a valid teaching event registration channel.");
+            RuleFor(regigstration => regigstration.ChannelId)
+                .SetValidator(new PickListItemIdValidator("msevtmgt_eventregistration", "dfe_channelcreation", _store))
+                .Unless(regigstration => regigstration.Id != null);
             RuleFor(regigstration => regigstration.ChannelId)
                 .Must(id => id == null)
                 .Unless(regigstration => regigstration.Id == null)
                 .WithMessage("You cannot change the channel of an existing teaching event registration.");
-        }
-
-        private IEnumerable<int?> ChannelIds()
-        {
-            return _store.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation").Select(channel => (int?)channel.Id);
         }
 
         private bool BeAvailableForOnlineRegistrations(Guid id)

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
@@ -1,27 +1,21 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using FluentValidation;
+﻿using FluentValidation;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeachingEventSearchRequestValidator : AbstractValidator<TeachingEventSearchRequest>
     {
-        private readonly IStore _store;
-
         public TeachingEventSearchRequestValidator(IStore store)
         {
-            _store = store;
-
             RuleFor(request => request.Postcode)
                 .NotEmpty()
                 .MaximumLength(40)
                 .Matches(Location.OutwardOrFullPostcodeRegex)
                 .Unless(request => request.Postcode == null && request.Radius == null);
             RuleFor(request => request.TypeId)
-                .Must(id => TypeIds().Contains(id))
-                .Unless(request => request.TypeId == null)
-                .WithMessage("Must be a valid type.");
+                .SetValidator(new PickListItemIdValidator("msevtmgt_event", "dfe_event_type", store))
+                .Unless(request => request.TypeId == null);
             RuleFor(request => request.Radius).GreaterThan(0);
             RuleFor(request => request)
                 .Must(StartAfterEarlierThanStartBefore)
@@ -32,11 +26,6 @@ namespace GetIntoTeachingApi.Models.Validators
         private static bool StartAfterEarlierThanStartBefore(TeachingEventSearchRequest request)
         {
             return request.StartAfter < request.StartBefore;
-        }
-
-        private IEnumerable<int?> TypeIds()
-        {
-            return _store.GetPickListItems("msevtmgt_event", "dfe_event_type").Select(type => (int?)type.Id);
         }
     }
 }

--- a/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
@@ -1,10 +1,36 @@
 ﻿using System;
+using System.Linq;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
+
 namespace GetIntoTeachingApi.Validators
 {
-    public class LookupItemIdValidator
+    public class LookupItemIdValidator : PropertyValidator
     {
-        public LookupItemIdValidator()
+        private readonly string _entityName;
+        private readonly IStore _store;
+
+        public LookupItemIdValidator(string entityName, IStore store)
+            : base("{PropertyName} must be a valid {EntityName} item.")
         {
+            _entityName = entityName;
+            _store = store;
+        }
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            var id = (Guid?)context.PropertyValue;
+
+            var exists = _store.GetLookupItems(_entityName).Any(i => i.Id == id);
+
+            if (exists)
+            {
+                return true;
+            }
+
+            context.MessageFormatter.AppendArgument("EntityName", _entityName);
+
+            return false;
         }
     }
 }

--- a/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
@@ -28,6 +28,7 @@ namespace GetIntoTeachingApi.Validators
                 return true;
             }
 
+            context.MessageFormatter.AppendArgument("PropertyName", context.PropertyName);
             context.MessageFormatter.AppendArgument("EntityName", _entityName);
 
             return false;

--- a/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/LookupItemIdValidator.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace GetIntoTeachingApi.Validators
+{
+    public class LookupItemIdValidator
+    {
+        public LookupItemIdValidator()
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
@@ -29,6 +29,7 @@ namespace GetIntoTeachingApi.Validators
                 return true;
             }
 
+            context.MessageFormatter.AppendArgument("PropertyName", context.PropertyName);
             context.MessageFormatter.AppendArgument("EntityName", _entityName);
             context.MessageFormatter.AppendArgument("AttributeName", _attributeName);
 

--- a/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace GetIntoTeachingApi.Validators
+{
+    public class PickListItemIdValidator
+    {
+        public PickListItemIdValidator()
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
@@ -1,10 +1,38 @@
-﻿using System;
+﻿using System.Linq;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
+
 namespace GetIntoTeachingApi.Validators
 {
-    public class PickListItemIdValidator
+    public class PickListItemIdValidator : PropertyValidator
     {
-        public PickListItemIdValidator()
+        private readonly string _entityName;
+        private readonly string _attributeName;
+        private readonly IStore _store;
+
+        public PickListItemIdValidator(string entityName, string attributeName, IStore store)
+            : base("{PropertyName} must be a valid {EntityName}/{AttributeName} item.")
         {
+            _entityName = entityName;
+            _attributeName = attributeName;
+            _store = store;
+        }
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            var id = (int?)context.PropertyValue;
+
+            var exists = _store.GetPickListItems(_entityName, _attributeName).Any(i => i.Id == id);
+
+            if (exists)
+            {
+                return true;
+            }
+
+            context.MessageFormatter.AppendArgument("EntityName", _entityName);
+            context.MessageFormatter.AppendArgument("AttributeName", _attributeName);
+
+            return false;
         }
     }
 }

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <Folder Include="Redis\" />
+    <Folder Include="Validators\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Controllers\LookupItemsControllerTests.cs" />

--- a/GetIntoTeachingApiTests/Validators/LookupItemIdValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/LookupItemIdValidatorTests.cs
@@ -33,7 +33,7 @@ namespace GetIntoTeachingApiTests.Validators
         {
             var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
             var validationContext = new ValidationContext(_item.Id, new PropertyChain(), selector);
-            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "prop");
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "Prop");
 
             var errors = _validator.Validate(propertyValidatorContext);
 
@@ -45,11 +45,12 @@ namespace GetIntoTeachingApiTests.Validators
         {
             var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
             var validationContext = new ValidationContext(Guid.NewGuid(), new PropertyChain(), selector);
-            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "prop");
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "Prop");
 
             var errors = _validator.Validate(propertyValidatorContext);
 
             errors.Should().NotBeEmpty();
+            errors.First().ErrorMessage.Should().Equals("Prop must be a valid dfe_country item.");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Validators/LookupItemIdValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/LookupItemIdValidatorTests.cs
@@ -1,0 +1,55 @@
+﻿using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
+using Moq;
+using Xunit;
+using System;
+using FluentValidation;
+using FluentValidation.Internal;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Models;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Validators
+{
+    public class LookupItemIdValidatorTests
+    {
+        private readonly Mock<IStore> _mockStore;
+        private readonly LookupItem _item;
+        private readonly LookupItemIdValidator _validator;
+
+        public LookupItemIdValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new LookupItemIdValidator("dfe_country", _mockStore.Object);
+            _item = new LookupItem() { Id = Guid.NewGuid() };
+
+            _mockStore.Setup(m => m.GetLookupItems("dfe_country")).Returns(new List<LookupItem>() { _item }.AsQueryable());
+        }
+
+        [Fact]
+        public void IsValid_WhenValidId_ReturnsTrue()
+        {
+            var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
+            var validationContext = new ValidationContext(_item.Id, new PropertyChain(), selector);
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "prop");
+
+            var errors = _validator.Validate(propertyValidatorContext);
+
+            errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void IsValid_WhenInvalidId_ReturnsFalse()
+        {
+            var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
+            var validationContext = new ValidationContext(Guid.NewGuid(), new PropertyChain(), selector);
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<Guid, Guid>(t => t), "prop");
+
+            var errors = _validator.Validate(propertyValidatorContext);
+
+            errors.Should().NotBeEmpty();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Validators/PickListItemIdValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/PickListItemIdValidatorTests.cs
@@ -1,0 +1,54 @@
+﻿using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
+using Moq;
+using Xunit;
+using FluentValidation;
+using FluentValidation.Internal;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Models;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Validators
+{
+    public class PickListItemIdValidatorTests
+    {
+        private readonly Mock<IStore> _mockStore;
+        private readonly PickListItem _item;
+        private readonly PickListItemIdValidator _validator;
+
+        public PickListItemIdValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new PickListItemIdValidator("contact", "dfe_channel", _mockStore.Object);
+            _item = new PickListItem() { Id = 123 };
+
+            _mockStore.Setup(m => m.GetPickListItems("contact", "dfe_channel")).Returns(new List<PickListItem>() { _item }.AsQueryable());
+        }
+
+        [Fact]
+        public void IsValid_WhenValidId_ReturnsTrue()
+        {
+            var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
+            var validationContext = new ValidationContext(_item.Id, new PropertyChain(), selector);
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "prop");
+
+            var errors = _validator.Validate(propertyValidatorContext);
+
+            errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void IsValid_WhenInvalidId_ReturnsFalse()
+        {
+            var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
+            var validationContext = new ValidationContext(456, new PropertyChain(), selector);
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "prop");
+
+            var errors = _validator.Validate(propertyValidatorContext);
+
+            errors.Should().NotBeEmpty();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Validators/PickListItemIdValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/PickListItemIdValidatorTests.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApiTests.Validators
         {
             var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
             var validationContext = new ValidationContext(_item.Id, new PropertyChain(), selector);
-            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "prop");
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "Prop");
 
             var errors = _validator.Validate(propertyValidatorContext);
 
@@ -44,11 +44,12 @@ namespace GetIntoTeachingApiTests.Validators
         {
             var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
             var validationContext = new ValidationContext(456, new PropertyChain(), selector);
-            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "prop");
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<int?, int?>(t => t), "Prop");
 
             var errors = _validator.Validate(propertyValidatorContext);
 
             errors.Should().NotBeEmpty();
+            errors.First().ErrorMessage.Should().Equals("Prop must be a valid contact/dfe_channel item.");
         }
     }
 }


### PR DESCRIPTION
- Add custom property validators for pick list/lookup item ids

We often validate a foreign key against the available pick list/lookup items that are in the CRM. Until know we've been doing this in a fairly verbose way; instead this adds a custom property validator that will make the syntax more concise.

- Update validation rules to use PickList/LookupItemIdValidator

Updates the validation rules that were previously querying the store in private methods to now use a custom property validator that handles querying the store and matching an `Id`.