### PR TITLE
Long lived candidate access tokens

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -17,15 +20,18 @@ namespace GetIntoTeachingApi.Controllers
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly INotifyService _notifyService;
         private readonly ICrmService _crm;
+        private readonly IBackgroundJobClient _jobClient;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             INotifyService notifyService,
-            ICrmService crm)
+            ICrmService crm,
+            IBackgroundJobClient jobClient)
         {
             _tokenService = tokenService;
             _notifyService = notifyService;
             _crm = crm;
+            _jobClient = jobClient;
         }
 
         [HttpPost]
@@ -59,6 +65,33 @@ that can then be used for verification.",
 
             // We respond immediately/assume this will be successful.
             _notifyService.SendEmailAsync(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
+
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("{candidateId}/long_lived_access_tokens")]
+        [SwaggerOperation(
+    Summary = "Creates a long-lived candidate access token.",
+    Description = @"Creates a long-lived access token that can be exchanged for candidate information for up to 3 days.
+        Access tokens are stored against the contact in Dynamics CRM and are issued to candidates by email.",
+    OperationId = "CreateLongLivedCandidateAccessToken",
+    Tags = new[] { "Candidates" })]
+        [ProducesResponseType(204)]
+        [ProducesResponseType(404)]
+        public IActionResult CreateLongLivedAccessToken([FromRoute, SwaggerRequestBody("Candidate identifier.", Required = true)] Guid candidateId)
+        {
+            var candidate = _crm.GetCandidate(candidateId);
+
+            if (candidate == null)
+            {
+                return NotFound();
+            }
+
+            var token = Guid.NewGuid().ToString();
+            candidate.LongLivedAccessToken = token;
+
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(candidate, null));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -84,6 +85,30 @@ exchanged for your token matches the request payload here).",
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new MailingListAddMember(candidate));
+        }
+
+        [HttpPost]
+        [Route("members/{candidateId}/{longLivedAccessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated MailingListAddMember for the candidate.",
+            Description = @"Retrieves a pre-populated MailingListAddMember for the candidate.
+                The `longLivedAccessToken` is obtained from a `POST /candidates/long_lived_access_tokens` request.",
+            OperationId = "GetPreFilledMailingListAddMemberLongLived",
+            Tags = new[] { "Mailing List" })]
+        [ProducesResponseType(typeof(MailingListAddMember), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetMember(
+            [FromRoute, SwaggerParameter("Candidate id.", Required = true)] Guid candidateId,
+            [FromRoute, SwaggerParameter("Long lived access token.", Required = true)] Guid longLivedAccessToken)
+        {
+            var candidate = _crm.LookupCandidate(longLivedAccessToken);
+
+            if (candidate == null || candidate.Id != candidateId)
             {
                 return NotFound();
             }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -168,6 +168,8 @@ namespace GetIntoTeachingApi.Models
         public bool? OptOutOfGdpr { get; set; } = false;
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
+        [EntityField("dfe_bursaryemailtext")]
+        public string LongLivedAccessToken { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -103,6 +103,14 @@ namespace GetIntoTeachingApi.Services
             return entity == null ? null : new Candidate(entity, this);
         }
 
+        public Candidate LookupCandidate(Guid longLivedAccessToken)
+        {
+            var entity = _service.CreateQuery("contact", Context())
+                .FirstOrDefault(c => c.GetAttributeValue<string>("dfe_bursaryemailtext") == longLivedAccessToken.ToString());
+
+            return entity == null ? null : new Candidate(entity, this);
+        }
+
         public bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId)
         {
             return GetCandidate(candidateId).EventsSubscriptionTypeId == (int)Candidate.SubscriptionType.LocalEvent;

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
         Candidate GetCandidate(Guid id);
+        Candidate LookupCandidate(Guid longLivedAccessToken);
         IEnumerable<TeachingEvent> GetTeachingEvents();
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -217,7 +217,7 @@ The GIT API aims to provide:
             app.UseSwagger(c =>
             {
                 // The UI generated for V2 is buggy, so use V3 in development.
-                c.SerializeAsV2 = !env.IsDevelopment;
+                c.SerializeAsV2 = true; //#!env.IsDevelopment;
             });
 
             if (!env.IsProduction)

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -88,6 +88,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TeacherId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_dfesnumber");
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
+            type.GetProperty("LongLivedAccessToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_bursaryemailtext");
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApiTests.Services
     {
         private static readonly Guid JaneDoeGuid = new Guid("bf927e43-5650-44aa-859a-8297139b8ddd");
         private static readonly Guid JohnDoeGuid = new Guid("cf927e43-5650-44aa-859a-8297139b8eee");
+        private static readonly Guid JaneDoeLongLivedAccessToken = new Guid("de927e43-5650-44aa-859a-8297139b8efc");
         private readonly Mock<IOrganizationServiceAdapter> _mockService;
         private readonly OrganizationServiceContext _context;
         private readonly ICrmService _crm;
@@ -266,6 +267,25 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().BeNull();
         }
 
+        [Fact]
+        public void LookupCandidate_WithLongLivedAccessToken_ReturnsCorrectly()
+        {
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates);
+
+            var result = _crm.LookupCandidate(JaneDoeLongLivedAccessToken);
+
+            result.Id.Should().Be(JaneDoeGuid);
+        }
+
+        [Fact]
+        public void LookupCandidate_WithNonExistentLongLivedAccessToken_ReturnsNull()
+        {
+            var result = _crm.LookupCandidate(Guid.NewGuid());
+
+            result.Should().BeNull();
+        }
+
         [Theory]
         [InlineData("john@doe.com", "New John", "Doe", "New John")]
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
@@ -434,6 +454,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = JaneDoeGuid
             };
             candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
+            candidate1["dfe_bursaryemailtext"] = JaneDoeLongLivedAccessToken.ToString();
             candidate1["statecode"] = Candidate.Status.Active;
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";


### PR DESCRIPTION
- Add ability to generate long-lived access tokens for candidates

We want to be able to email candidates with a URL that links them straight into a pre-filled mailing list sign up form. In order to do this we need to be able to generate long-lived access tokens that are stored against a `contact` record in Dynamics. We can then send these out to candidates and use the token to retrieve their details from the API before presenting the form to them.

Add endpoint for generating long-lived access tokens against a candidate. Tokens are stored in Dynamics and are not returned, so the only way to expose them is via an email from the CRM itself.

- Exchange long lived access token for mailing list sign up

When a long lived access token is emailed out to a candidate we need a way for the Rails app to exchange this for the candidate information, so that the sign up form can be pre-filled.

Add method to exchange a long lived access token for mailing list sign up.

**Notes**

- Long lived tokens do not currently expire; we should store the date the token was generated so that we can verify it's still 'live'.
  - If we expire access tokens, we should auto-email the candidate with a newly generated token if they try and access using an expired one?
- Any API client could issue this request, but it would be ideal if only the CRM client could do this.
  - Add client API key for the CRM with elevated permissions.
- A GUID is used for the token; it may be worth using a more secure/random token generation?