### PR TITLE
Add TeachingEventsByType response model

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -116,22 +116,6 @@ namespace GetIntoTeachingApi.Controllers
         [HttpGet]
         [CrmETag]
         [PrivateShortTermResponseCache]
-        [Route("upcoming_grouped_by_type")]
-        [SwaggerOperation(
-            Summary = "Retrieves upcoming teaching events grouped by type.",
-            Description = @"Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.",
-            OperationId = "UpcomingTeachingEventsGroupedByType",
-            Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), 200)]
-        public IActionResult UpcomingGroupedByType([FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
-        {
-            var teachingEventsByType = _store.GetUpcomingTeachingEvents();
-            return Ok(GroupTeachingEventsByType(teachingEventsByType, quantityPerType));
-        }
-
-        [HttpGet]
-        [CrmETag]
-        [PrivateShortTermResponseCache]
         [Route("{readableId}")]
         [SwaggerOperation(
             Summary = "Retrieves an event.",

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -87,6 +87,51 @@ namespace GetIntoTeachingApi.Controllers
         [HttpGet]
         [CrmETag]
         [PrivateShortTermResponseCache]
+        [Route("search_grouped_by_type")]
+        [SwaggerOperation(
+    Summary = "Searches for teaching events, returning grouped by type.",
+    Description = @"Searches for teaching events. Optionally limit the results by distance (in miles) from a postcode, event type and start date.",
+    OperationId = "SearchTeachingEventsGroupedByType",
+    Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), 200)]
+        [ProducesResponseType(400)]
+        public async Task<IActionResult> SearchGroupedByType(
+    [FromQuery, SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request,
+    [FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(this.ModelState);
+            }
+
+            if (request.Postcode != null)
+            {
+                _logger.LogInformation($"SearchGroupedByType: {request.Postcode}");
+            }
+
+            var teachingEvents = await _store.SearchTeachingEventsAsync(request);
+            return Ok(GroupTeachingEventsByType(teachingEvents, quantityPerType));
+        }
+
+        [HttpGet]
+        [CrmETag]
+        [PrivateShortTermResponseCache]
+        [Route("upcoming_grouped_by_type")]
+        [SwaggerOperation(
+            Summary = "Retrieves upcoming teaching events grouped by type.",
+            Description = @"Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.",
+            OperationId = "UpcomingTeachingEventsGroupedByType",
+            Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), 200)]
+        public IActionResult UpcomingGroupedByType([FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
+        {
+            var teachingEventsByType = _store.GetUpcomingTeachingEvents();
+            return Ok(GroupTeachingEventsByType(teachingEventsByType, quantityPerType));
+        }
+
+        [HttpGet]
+        [CrmETag]
+        [PrivateShortTermResponseCache]
         [Route("{readableId}")]
         [SwaggerOperation(
             Summary = "Retrieves an event.",
@@ -176,6 +221,18 @@ exchanged for your token matches the request payload here).",
                 .ToList()
                 .GroupBy(e => e.TypeId.ToString())
                 .ToDictionary(g => g.Key, g => g.Take(quantityPerType));
+        }
+
+        private static IEnumerable<TeachingEventsByType> GroupTeachingEventsByType(
+            IEnumerable<TeachingEvent> teachingEvents,
+            int quantityPerType)
+        {
+            return teachingEvents
+                .GroupBy(e => e.TypeId, e => e, (typeId, events) => new TeachingEventsByType()
+                {
+                    TypeId = typeId,
+                    TeachingEvents = events.Take(quantityPerType),
+                });
         }
     }
 }

--- a/GetIntoTeachingApi/Models/TeachingEventsByType.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventsByType.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class TeachingEventsByType
+    {
+        public int TypeId { get; set; }
+        public IEnumerable<TeachingEvent> TeachingEvents { get; set; }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new [] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType", "UpcomingGroupedByType" };
+            var methods = new [] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETagPrivateShortTermResponseCache_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new[] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType", "UpcomingGroupedByType" };
+            var methods = new[] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<PrivateShortTermResponseCacheAttribute>());
         }
@@ -197,24 +197,6 @@ namespace GetIntoTeachingApiTests.Controllers
             var result = (IDictionary<string, IEnumerable<TeachingEvent>>)ok.Value;
             result["123"].Count().Should().Be(3);
             result["456"].Count().Should().Be(1);
-        }
-
-        [Fact]
-        public void UpcomingGroupedByType_ReturnsUpcomingEventsByType()
-        {
-            var mockEvents = MockEvents();
-            _mockStore.Setup(mock => mock.GetUpcomingTeachingEvents()).Returns(mockEvents.AsQueryable());
-
-            var response = _controller.UpcomingGroupedByType(3);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var result = (IEnumerable<TeachingEventsByType>)ok.Value;
-
-            result.First().TypeId.Should().Be(123);
-            result.First().TeachingEvents.Count().Should().Be(3);
-
-            result.Last().TypeId.Should().Be(456);
-            result.Last().TeachingEvents.Count().Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventsByTypeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventsByTypeTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class TeachingEventsByTypeTests
+    {
+    }
+}


### PR DESCRIPTION
Introduces a new response model for returning teaching events grouped by type. Previously we were using the format:

``` { "<typeid>": [<events>] } ```

This isn't a very RESTful response and also causes the type id to be returned in a string, where in actuality its an integer value.

This commit updates the response to be:

``` [{ "typeId": <typeid>, "teachingEvents": [<events>] }, { ... }] ```

In order to introduce the new response type an additional endpoint have been added:

``` 
teaching_events/search_grouped_by_type
```

These replace the existing methods, that will be removed once the clients have been updated (note the `upcoming_indexed_by_type` endpoint is going to be deprecated, which is why there is no equivalent `_grouped_` endpoint above for it):

``` 
teaching_events/search_indexed_by_type
teaching_events/upcoming_indexed_by_type
```