### PR TITLE
Return all 'Online Events' on distance-based search

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -68,6 +68,7 @@ namespace GetIntoTeachingApi.Models
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]
         public Guid? BuildingId { get; set; }
+        public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 
         public TeachingEvent()
             : base()

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -45,5 +45,25 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));
         }
+
+        [Theory]
+        [InlineData(true, "", false)]
+        [InlineData(true, "  ", false)]
+        [InlineData(true, "KY11 9YU", true)]
+        [InlineData(true, null, false)]
+        [InlineData(false, null, false)]
+        [InlineData(false, "", false)]
+        [InlineData(false, "  ", false)]
+        [InlineData(false, "KY11 9YU", false)]
+        public void IsVirtual_ReturnsCorrectly(bool isOnline, string addressPostcode, bool expected)
+        {
+            var teachingEvent = new TeachingEvent()
+            {
+                IsOnline = isOnline,
+                Building = new TeachingEventBuilding() { AddressPostcode = addressPostcode },
+            };
+
+            teachingEvent.IsVirtual.Should().Be(expected);
+    }
     }
 }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -352,7 +352,7 @@ namespace GetIntoTeachingApiTests.Services
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 3", "Event 5" },
+            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 3", "Event 1", "Event 5" },
                 options => options.WithStrictOrdering());
         }
 
@@ -365,7 +365,7 @@ namespace GetIntoTeachingApiTests.Services
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
-            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 3", "Event 5" },
+            result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2", "Event 3", "Event 1", "Event 5" },
                 options => options.WithStrictOrdering());
         }
 
@@ -460,11 +460,11 @@ namespace GetIntoTeachingApiTests.Services
                 ReadableId = "1",
                 Name = "Event 1",
                 TypeId = (int)TeachingEvent.EventType.TrainToTeachEvent,
+                IsOnline = true,
                 StartAt = DateTime.UtcNow.AddDays(5),
                 Building = new TeachingEventBuilding()
                 {
                     Id = sharedBuildingId,
-                    AddressLine1 = "Line 1"
                 }
             };
 
@@ -518,6 +518,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "5",
                 Name = "Event 5",
+                IsOnline = true,
                 TypeId = (int)TeachingEvent.EventType.OnlineEvent,
                 StartAt = DateTime.UtcNow.AddDays(15),
             };


### PR DESCRIPTION
[Trello-660](https://trello.com/c/npt5sr4O/660-add-functionality-within-the-api-to-show-non-postcode-tagged-virtual-ttt-events-in-all-postcode-searches)

At the moment we have a few different kinds of 'Online Event':

- Events with type 'Online Event'
- Events with `IsOnline` set to `true` and no `Buillding.AddressPostcode`
- Events with `IsOnline` set to `true` and a `Building.AddressPostcode` (virtual)

When a radius-based search is performed we currently return events with type 'Online Event' in the results.

Going forward there will be another kind of fully online event type (not virtual) that is a 'Train to Teach' type event where `IsOnline` is `true` and there is no `Building.AddressPostcode`.

Instead of only returning 'Online Event' type events in radius-based searches, we want to return any event that is an online, but not 'virtual' event.