### PR TITLE
Change distance filter to work in database

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Models;
-using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
 using MoreLinq;
 using NetTopologySuite.Geometries;
@@ -139,9 +138,9 @@ namespace GetIntoTeachingApi.Services
             var result = teachingEvents.Where(teachingEvent => teachingEvent.Building.Coordinate.Distance(origin)
                 < request.RadiusInKm() * 1000).AsEnumerable();
 
-            // We need to include online events in distance-based searches (unless explicitly filtered out by the request).
-            var includeOnlineEvents = request.TypeId == null || request.TypeId == (int)TeachingEvent.EventType.OnlineEvent;
-            if (includeOnlineEvents)
+            // We need to include the various 'online' event types in distance based search results.
+            result = result.Concat(await OnlineEventsMatchingRequest(request));
+
             return result;
         }
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -344,6 +344,46 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SearchTeachingEvents_WithFilters_ReturnsEventNarrowlyInRange()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAsync();
+            var request = new TeachingEventSearchRequest()
+            {
+                Postcode = "KY6 2NJ",
+                Radius = 13,
+                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                StartAfter = DateTime.UtcNow,
+                StartBefore = DateTime.UtcNow.AddDays(3)
+            };
+
+            var result = await _store.SearchTeachingEventsAsync(request);
+
+            result.Select(e => e.Name).Should().BeEquivalentTo(
+                new string[] { "Event 2" },
+                options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public async void SearchTeachingEvents_WithFilters_ExcludesEventNarrowlyOutOfRange()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAsync();
+            var request = new TeachingEventSearchRequest()
+            {
+                Postcode = "KY6 2NJ",
+                Radius = 12,
+                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                StartAfter = DateTime.UtcNow,
+                StartBefore = DateTime.UtcNow.AddDays(3)
+            };
+
+            var result = await _store.SearchTeachingEventsAsync(request);
+
+            result.Select(e => e.Name).Should().BeEmpty();
+        }
+
+        [Fact]
         public async void SearchTeachingEvents_FilteredByRadius_ReturnsMatchingAndOnlineEvents()
         {
             SeedMockLocations();


### PR DESCRIPTION
Geometry.Distance is translated to PostGIS [ST_Distance](https://postgis.net/docs/ST_Distance.html). Because teachingEvent.Building.Coordinate is attributed with column type geography, and because origin is implicitly converted to the geography type (it has an SRID), ST_Distance returns the distance between two points in meters.

This means that the events distance filtering can be performed in the database instead of in memory.