### PR TITLE
Sync archived teaching events

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -171,14 +171,19 @@ namespace GetIntoTeachingApi.Services
             model.Id = entity.Id;
         }
 
-        public IEnumerable<TeachingEvent> GetTeachingEvents()
+        public IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null)
         {
+            if (startAfter == null)
+            {
+                startAfter = DateTime.UtcNow;
+            }
+
             var query = new QueryExpression("msevtmgt_event");
             query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEvent)));
 
             var status = new[] { (int)TeachingEvent.Status.Open, (int)TeachingEvent.Status.Closed };
             var statusCondition = new ConditionExpression("dfe_eventstatus", ConditionOperator.In, status);
-            var futureDatedCondition = new ConditionExpression("msevtmgt_eventenddate", ConditionOperator.GreaterThan, DateTime.UtcNow);
+            var futureDatedCondition = new ConditionExpression("msevtmgt_eventenddate", ConditionOperator.GreaterThan, startAfter);
             var types = Enum.GetValues(typeof(TeachingEvent.EventType)).Cast<int>().ToArray();
             var typeCondition = new ConditionExpression("dfe_event_type", ConditionOperator.In, types);
             var readableIdCondition = new ConditionExpression("dfe_websiteeventpartialurl", ConditionOperator.NotNull);

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
         Candidate GetCandidate(Guid id);
-        IEnumerable<TeachingEvent> GetTeachingEvents();
+        IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
         bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class Store : IStore
     {
+        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 4);
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;
         private readonly ICrmService _crm;
@@ -157,7 +158,8 @@ namespace GetIntoTeachingApi.Services
 
         private async Task SyncTeachingEvents()
         {
-            var teachingEvents = _crm.GetTeachingEvents().ToList();
+            var afterDate = DateTime.UtcNow.Subtract(TeachingEventArchiveSize);
+            var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
             await PopulateTeachingEventCoordinates(teachingEvents);
 
             var buildings = teachingEvents.Where(te => te.Building != null)

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -64,7 +64,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SyncAsync_InsertsNewTeachingEvents()
         {
             var mockTeachingEvents = MockTeachingEvents().ToList();
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(mockTeachingEvents);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(mockTeachingEvents);
 
             await _store.SyncAsync();
 
@@ -83,7 +83,7 @@ namespace GetIntoTeachingApiTests.Services
                 te.Name += "Updated";
                 if (te.Building != null) te.Building.AddressLine1 += "Updated";
             });
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(updatedTeachingEvents);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(updatedTeachingEvents);
 
             await _store.SyncAsync();
 
@@ -100,7 +100,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             await SeedMockTeachingEventsAsync();
             var teachingEvents = MockTeachingEvents().ToList();
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(teachingEvents.GetRange(0, 1));
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(teachingEvents.GetRange(0, 1));
 
             await _store.SyncAsync();
 
@@ -113,7 +113,8 @@ namespace GetIntoTeachingApiTests.Services
         public async void SyncAsync_PopulatesTeachingEventBuildingCoordinates()
         {
             SeedMockLocations();
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(MockTeachingEvents);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(MockTeachingEvents);
+
 
             await _store.SyncAsync();
 
@@ -125,7 +126,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SyncAsync_FallbackToGeocodeClient_PopulatesTeachingEventBuildingCoordinatesAndCachesLocation()
         {
             SeedMockLocations();
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(MockTeachingEvents);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(MockTeachingEvents);
             var postcode = "TE7 9IN";
             var coordinate = new Point(1, 2);
             var sanitizedPostcode = Location.SanitizePostcode(postcode);
@@ -450,6 +451,15 @@ namespace GetIntoTeachingApiTests.Services
             dates.Should().OnlyContain(d => d >= DateTime.UtcNow);
         }
 
+        private static bool CheckGetTeachingEventsAfterDate(DateTime date)
+        {
+            var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);
+
+            date.Should().BeCloseTo(afterDate);
+
+            return true;
+        }
+
         private static IEnumerable<TeachingEvent> MockTeachingEvents()
         {
             var sharedBuildingId = Guid.NewGuid();
@@ -557,7 +567,7 @@ namespace GetIntoTeachingApiTests.Services
         private async Task<IEnumerable<TeachingEvent>> SeedMockTeachingEventsAsync()
         {
             var teachingEvents = MockTeachingEvents().ToList();
-            _mockCrm.Setup(m => m.GetTeachingEvents()).Returns(teachingEvents);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.IsAny<DateTime>())).Returns(teachingEvents);
 
             await _store.SyncAsync();
 


### PR DESCRIPTION
[Trello-672](https://trello.com/c/Mx2EzMU4/672-development-create-an-archive-repository-for-online-events-which-are-3-4-months-old)

We are going to be adding a new page to the website that will allow users to browse 'archived' online events - these are events that are now in the past, up to 4 months old.

This commit updates the sync logic to query and cache events as far back as 4 months ago. The 4 month threshold isn't 'strict', so for ease I've treated it as 4 * 31 days.

The app needs to be updated first to ensure all requests are scoped to a date, so as not to inadvertently include archived events under 'all months'.