### PR TITLE
Allow event search with only start after date

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventSearchRequestValidator.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.Radius).GreaterThan(0);
             RuleFor(request => request)
                 .Must(StartAfterEarlierThanStartBefore)
-                .Unless(request => request.StartAfter == null)
+                .Unless(request => request.StartAfter == null || request.StartBefore == null)
                 .WithMessage("Start after must be earlier than start before.");
         }
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -59,6 +59,34 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_StartAfterAndNoStartBefore_HasNoError()
+        {
+            var request = new TeachingEventSearchRequest()
+            {
+                StartAfter = DateTime.UtcNow.AddDays(1),
+                StartBefore = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Validate_StartBeforeAndNoStartAfter_HasNoError()
+        {
+            var request = new TeachingEventSearchRequest()
+            {
+                StartBefore = DateTime.UtcNow.AddDays(1),
+                StartAfter = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
         public void Validate_RadiusIsNotNullAndPostcodeIsNull_HasError()
         {
             var request = new TeachingEventSearchRequest()


### PR DESCRIPTION
Currently if you try and do an event search for all events after a date it throws a validation error. Instead, we should allow this query and return all events after the given dates.

Whilst this should have been possible anyway the use case was not required in the app, but going forward we need to be able to do this exclude archived events (being introduced shortly) from the event search.