### PR TITLE
Removed List of Default Status Codes

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -21,6 +21,5 @@ alerts = {
     trigger_rate  = 0
     timeout       = 80
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }
 }

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -8,7 +8,6 @@ resource statuscake_test alert {
   contact_group = each.value.contact_group
   trigger_rate  = each.value.trigger_rate
   custom_header = each.value.custom_header
-  status_codes  = each.value.status_codes
   test_tags     = ["GIT", "BETA"]
   timeout       = each.value.timeout
 }

--- a/terraform/paas/test.env.tfvars
+++ b/terraform/paas/test.env.tfvars
@@ -21,6 +21,5 @@ alerts = {
     trigger_rate  = 0
     timeout       = 80
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }
 }


### PR DESCRIPTION
A comment on an another repository suggested removing the set list of status codes as they were just the default. Allowing the  upstream API to do the work.
This hadn't been picked up on the changes to this repository and therefore needed to be done.