### PR TITLE
Remove x_teaching_events_indexed_by_type endpoints

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -42,51 +42,6 @@ namespace GetIntoTeachingApi.Controllers
         [HttpGet]
         [CrmETag]
         [PrivateShortTermResponseCache]
-        [Route("search_indexed_by_type")]
-        [SwaggerOperation(
-            Summary = "Searches for teaching events, returning grouped by type.",
-            Description = @"Searches for teaching events. Optionally limit the results by distance (in miles) from a postcode, event type and start date.",
-            OperationId = "SearchTeachingEventsIndexedByType",
-            Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(IDictionary<string, IEnumerable<TeachingEvent>>), 200)]
-        [ProducesResponseType(400)]
-        public async Task<IActionResult> SearchIndexedByType(
-            [FromQuery, SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request,
-            [FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
-        {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(this.ModelState);
-            }
-
-            if (request.Postcode != null)
-            {
-                _logger.LogInformation($"SearchIndexedByType: {request.Postcode}");
-            }
-
-            var teachingEvents = await _store.SearchTeachingEventsAsync(request);
-            return Ok(IndexTeachingEventsByType(teachingEvents, quantityPerType));
-        }
-
-        [HttpGet]
-        [CrmETag]
-        [PrivateShortTermResponseCache]
-        [Route("upcoming_indexed_by_type")]
-        [SwaggerOperation(
-            Summary = "Retrieves upcoming teaching events grouped by type.",
-            Description = @"Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.",
-            OperationId = "UpcomingTeachingEventsIndexedByType",
-            Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(IDictionary<string, IEnumerable<TeachingEvent>>), 200)]
-        public IActionResult UpcomingIndexedByType([FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
-        {
-            var teachingEventsByType = _store.GetUpcomingTeachingEvents();
-            return Ok(IndexTeachingEventsByType(teachingEventsByType, quantityPerType));
-        }
-
-        [HttpGet]
-        [CrmETag]
-        [PrivateShortTermResponseCache]
         [Route("search_grouped_by_type")]
         [SwaggerOperation(
     Summary = "Searches for teaching events, returning grouped by type.",
@@ -195,16 +150,6 @@ exchanged for your token matches the request payload here).",
             }
 
             return Ok(new TeachingEventAddAttendee(candidate));
-        }
-
-        private static IDictionary<string, IEnumerable<TeachingEvent>> IndexTeachingEventsByType(
-            IEnumerable<TeachingEvent> teachingEvents,
-            int quantityPerType)
-        {
-            return teachingEvents
-                .ToList()
-                .GroupBy(e => e.TypeId.ToString())
-                .ToDictionary(g => g.Key, g => g.Take(quantityPerType));
         }
 
         private static IEnumerable<TeachingEventsByType> GroupTeachingEventsByType(

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -18,6 +18,5 @@ namespace GetIntoTeachingApi.Services
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
-        IQueryable<TeachingEvent> GetUpcomingTeachingEvents();
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -113,14 +113,6 @@ namespace GetIntoTeachingApi.Services
             return await _dbContext.TeachingEvents.Include(e => e.Building).FirstOrDefaultAsync(e => e.ReadableId == readableId);
         }
 
-        public IQueryable<TeachingEvent> GetUpcomingTeachingEvents()
-        {
-            return _dbContext.TeachingEvents
-                .Include(e => e.Building)
-                .OrderBy(e => e.StartAt)
-                .Where(e => e.StartAt >= DateTime.UtcNow);
-        }
-
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new [] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType" };
+            var methods = new [] { "Get", "SearchGroupedByType" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<CrmETagAttribute>());
         }
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETagPrivateShortTermResponseCache_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = new[] { "Get", "SearchIndexedByType", "UpcomingIndexedByType", "SearchGroupedByType" };
+            var methods = new[] { "Get", "SearchGroupedByType" };
 
             methods.ForEach(m => typeof(TeachingEventsController).GetMethod(m).Should().BeDecoratedWith<PrivateShortTermResponseCacheAttribute>());
         }
@@ -98,36 +98,6 @@ namespace GetIntoTeachingApiTests.Controllers
                 It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
                 IsMatch(request.Candidate, (Candidate)job.Args[0])),
                 It.IsAny<EnqueuedState>()));
-        }
-
-        [Fact]
-        public async void SearchIndexedByType_InvalidRequest_RespondsWithValidationErrors()
-        {
-            var request = new TeachingEventSearchRequest() { Postcode = null };
-            _controller.ModelState.AddModelError("Postcode", "Postcode must be specified.");
-
-            var response = await _controller.SearchIndexedByType(request);
-
-            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Postcode").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Postcode must be specified.");
-        }
-
-        [Fact]
-        public async void SearchIndexedByType_ValidRequest_ReturnsTeachingEventsByType()
-        {
-            var request = new TeachingEventSearchRequest() { Postcode = "KY12 8FG" };
-            var mockEvents = MockEvents();
-            _mockStore.Setup(mock => mock.SearchTeachingEventsAsync(request)).ReturnsAsync(mockEvents);
-
-            var response = await _controller.SearchIndexedByType(request);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var result = (IDictionary<string, IEnumerable<TeachingEvent>>)ok.Value;
-            result["123"].Count().Should().Be(3);
-            result["456"].Count().Should().Be(1);
-
-            _mockLogger.VerifyInformationWasCalled("SearchIndexedByType: KY12 8FG");
         }
 
         [Fact]
@@ -183,20 +153,6 @@ namespace GetIntoTeachingApiTests.Controllers
             var response = await _controller.Get("-1");
 
             response.Should().BeOfType<NotFoundResult>();
-        }
-
-        [Fact]
-        public void UpcomingIndexedByType_ReturnsUpcomingEventsByType()
-        {
-            var mockEvents = MockEvents();
-            _mockStore.Setup(mock => mock.GetUpcomingTeachingEvents()).Returns(mockEvents.AsQueryable());
-
-            var response = _controller.UpcomingIndexedByType(3);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var result = (IDictionary<string, IEnumerable<TeachingEvent>>)ok.Value;
-            result["123"].Count().Should().Be(3);
-            result["456"].Count().Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -479,18 +479,6 @@ namespace GetIntoTeachingApiTests.Services
             result.Building.Should().NotBeNull();
         }
 
-        [Fact]
-        public async void GetUpcomingTeachingEventsByTypeAsync_ReturnsUpcomingEventsGroupedByType()
-        {
-            await SeedMockTeachingEventsAsync();
-
-            var result = _store.GetUpcomingTeachingEvents();
-
-            var dates = result.Select(e => e.StartAt);
-            dates.Should().BeEquivalentTo(dates.OrderBy(d => d), options => options.WithStrictOrdering());
-            dates.Should().OnlyContain(d => d >= DateTime.UtcNow);
-        }
-
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);


### PR DESCRIPTION
The `upcoming_teaching_events_indexed_by_type` endpoint is being removed completely (the clients have been updated to use the search endpoint to achieve the same thing). The `search_teaching_events_indexed_by_type` endpoint is being removed in favour of the newer `search_teaching_events_grouped_by_type`, which returns results in a more rest-ful structure.

This is safe to merge now that https://github.com/DFE-Digital/get-into-teaching-app/pull/742 has been deployed.