### PR TITLE
Collect metrics for Timed One Time Passwords (TOTPs)

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -54,7 +55,7 @@ that can then be used for verification.",
                 return NotFound();
             }
 
-            var token = _tokenService.GenerateToken(request);
+            var token = _tokenService.GenerateToken(request, (Guid)candidate.Id);
             var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
 
             // We respond immediately/assume this will be successful.

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -76,16 +77,11 @@ exchanged for your token matches the request payload here).",
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
-            if (!_tokenService.IsValid(accessToken, request))
-            {
-                return Unauthorized();
-            }
-
             var candidate = _crm.MatchCandidate(request);
 
-            if (candidate == null)
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
             {
-                return NotFound();
+                return Unauthorized();
             }
 
             return Ok(new MailingListAddMember(candidate));

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -72,16 +73,11 @@ exchanged for your token matches the request payload here).",
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
-            if (!_tokenService.IsValid(accessToken, request))
-            {
-                return Unauthorized();
-            }
-
             var candidate = _crm.MatchCandidate(request);
 
-            if (candidate == null)
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
             {
-                return NotFound();
+                return Unauthorized();
             }
 
             return Ok(new TeacherTrainingAdviserSignUp(candidate));

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
@@ -182,16 +183,11 @@ exchanged for your token matches the request payload here).",
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
-            if (!_tokenService.IsValid(accessToken, request))
-            {
-                return Unauthorized();
-            }
-
             var candidate = _crm.MatchCandidate(request);
 
-            if (candidate == null)
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
             {
-                return NotFound();
+                return Unauthorized();
             }
 
             return Ok(new TeachingEventAddAttendee(candidate));

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -14,24 +14,29 @@ namespace GetIntoTeachingApi.Services
         public static readonly int StepInSeconds = 30;
         private const int Length = 6;
         private readonly IEnv _env;
+        private readonly IMetricService _metrics;
 
-        public CandidateAccessTokenService(IEnv env)
+        public CandidateAccessTokenService(IEnv env, IMetricService metrics)
         {
             _env = env;
+            _metrics = metrics;
         }
 
-        public string GenerateToken(ExistingCandidateRequest request)
+        public string GenerateToken(ExistingCandidateRequest request, Guid candidateId)
         {
-            var totp = CreateTotp(request);
-            return totp.ComputeTotp();
+            var totp = CreateTotp(request).ComputeTotp();
+
+            _metrics.GeneratedTotps.WithLabels(candidateId.ToString(), totp).Inc();
+
+            return totp;
         }
 
-        public bool IsValid(string token, ExistingCandidateRequest request)
+        public bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId)
         {
-            return IsValid(token, request, DateTime.UtcNow);
+            return IsValid(token, request, candidateId, DateTime.UtcNow);
         }
 
-        public bool IsValid(string token, ExistingCandidateRequest request, DateTime timestamp)
+        public bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId, DateTime timestamp)
         {
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -40,11 +45,15 @@ namespace GetIntoTeachingApi.Services
 
             var totp = CreateTotp(request);
 
-            return totp.VerifyTotp(
+            var valid = totp.VerifyTotp(
                 timestamp,
                 token,
                 out _,
                 new VerificationWindow(previous: VerificationWindow, future: 0));
+
+            _metrics.VerifiedTotps.WithLabels(candidateId.ToString(), token, valid.ToString()).Inc();
+
+            return valid;
         }
 
         private Totp CreateTotp(ExistingCandidateRequest request)

--- a/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/ICandidateAccessTokenService.cs
@@ -5,8 +5,8 @@ namespace GetIntoTeachingApi.Services
 {
     public interface ICandidateAccessTokenService
     {
-        string GenerateToken(ExistingCandidateRequest request);
-        bool IsValid(string token, ExistingCandidateRequest request, DateTime timestamp);
-        bool IsValid(string token, ExistingCandidateRequest request);
+        string GenerateToken(ExistingCandidateRequest request, Guid candidateId);
+        bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId, DateTime timestamp);
+        bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId);
     }
 }

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -10,5 +10,7 @@ namespace GetIntoTeachingApi.Services
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }
         Counter CacheLookups { get; }
+        Counter VerifiedTotps { get; }
+        Counter GeneratedTotps { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -25,6 +25,16 @@ namespace GetIntoTeachingApi.Services
             {
                 LabelNames = new[] { "outcome" },
             });
+        private static readonly Counter _generatedTotps = Metrics
+            .CreateCounter("api_generated_totps", "Number of generated timed one time passwords.", new CounterConfiguration
+            {
+                LabelNames = new[] { "candidate_id", "totp" },
+            });
+        private static readonly Counter _verifiedTotps = Metrics
+            .CreateCounter("api_verified_totps", "Number of verified timed one time passwords.", new CounterConfiguration
+            {
+                LabelNames = new[] { "candidate_id", "totp", "valid" },
+            });
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
@@ -32,5 +42,7 @@ namespace GetIntoTeachingApi.Services
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;
         public Counter CacheLookups => _cacheLookups;
+        public Counter GeneratedTotps => _generatedTotps;
+        public Counter VerifiedTotps => _verifiedTotps;
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -8,6 +8,7 @@ using GetIntoTeachingApi.Services;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using GetIntoTeachingApi.Attributes;
+using System;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -55,8 +56,8 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CreateAccessToken_ValidRequest_SendsPINCodeEmail()
         {
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
-            var candidate = new Candidate { Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
-            _mockTokenService.Setup(mock => mock.GenerateToken(request)).Returns("123456");
+            var candidate = new Candidate { Id = Guid.NewGuid(), Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
+            _mockTokenService.Setup(mock => mock.GenerateToken(request, (Guid)candidate.Id)).Returns("123456");
             _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns(candidate);
 
             var response = _controller.CreateAccessToken(request);
@@ -81,8 +82,8 @@ namespace GetIntoTeachingApiTests.Controllers
 
             response.Should().BeOfType<NotFoundResult>();
 
-            _mockNotifyService.Verify(mock => 
-                mock.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()), 
+            _mockNotifyService.Verify(mock =>
+                mock.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()),
                 Times.Never()
             );
         }

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -47,7 +47,9 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void GetMember_InvalidAccessToken_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request)).Returns(false);
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.GetMember("000000", _request);
 
@@ -58,7 +60,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void GetMember_ValidToken_RespondsWithMailingListAddMember()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
 
             var response = _controller.GetMember("000000", _request);
@@ -69,14 +71,13 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetMember_MissingCandidate_RespondsWithNotFound()
+        public void GetMember_MissingCandidate_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
 
             var response = _controller.GetMember("000000", _request);
 
-            response.Should().BeOfType<NotFoundResult>();
+            response.Should().BeOfType<UnauthorizedResult>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -47,7 +47,9 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Get_InvalidAccessToken_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request)).Returns(false);
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.Get("000000", _request);
 
@@ -58,7 +60,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         public void Get_ValidToken_RespondsWithTeacherTrainingAdviserSignUp()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
 
             var response = _controller.Get("000000", _request);
@@ -69,14 +71,13 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Get_MissingCandidate_RespondsWithNotFound()
+        public void Get_MissingCandidate_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
 
             var response = _controller.Get("000000", _request);
 
-            response.Should().BeOfType<NotFoundResult>();
+            response.Should().BeOfType<UnauthorizedResult>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -202,7 +202,9 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void GetAttendee_InvalidAccessToken_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request)).Returns(false);
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.GetAttendee("000000", _request);
 
@@ -213,7 +215,7 @@ namespace GetIntoTeachingApiTests.Controllers
         public void GetAttendee_ValidToken_RespondsWithTeachingEventAddAttendee()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
 
             var response = _controller.GetAttendee("000000", _request);
@@ -224,14 +226,13 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetAttendee_MissingCandidate_RespondsWithNotFound()
+        public void GetAttendee_MissingCandidate_RespondsWithUnauthorized()
         {
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request)).Returns(true);
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
 
             var response = _controller.GetAttendee("000000", _request);
 
-            response.Should().BeOfType<NotFoundResult>();
+            response.Should().BeOfType<UnauthorizedResult>();
         }
 
         private static IEnumerable<TeachingEvent> MockEvents()

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -52,5 +52,19 @@ namespace GetIntoTeachingApiTests.Services
             _metrics.CacheLookups.Name.Should().Be("api_cache_lookups");
             _metrics.CacheLookups.LabelNames.Should().BeEquivalentTo(new[] { "outcome" });
         }
+
+        [Fact]
+        public void GeneratedTotps_ReturnsMetric()
+        {
+            _metrics.GeneratedTotps.Name.Should().Be("api_generated_totps");
+            _metrics.GeneratedTotps.LabelNames.Should().BeEquivalentTo(new[] { "candidate_id", "totp" });
+        }
+
+        [Fact]
+        public void VerifiedTotps_ReturnsMetric()
+        {
+            _metrics.VerifiedTotps.Name.Should().Be("api_verified_totps");
+            _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "candidate_id", "totp", "valid" });
+        }
     }
 }


### PR DESCRIPTION
- Add metrics for TOTP generation/verification

We want to be able to track how many TOTPs are generated and, out of those, which are successfully verified (and, similarly, which are generated but never verified).

The metrics collect the `candidate_id` and the token so that we can attribute metrics to specific users without storing PII. The outcome of the verification process is also stored as a label, so we can determine if the correct TOTP was provided.

- Increment TOTP generated/verified metrics

When a TOTP is generated or verified we want to increment the corresponding metric. In order to link OTPs to a candidate the TOTP interfaces have been expanded to include a `candidateId`.

We also store the TOTP itself in the metric label so that we can see when the candidate verified the TOTP and _which_ one was verified (if they generated multiple). We store these in plain text as they are within our internal influxdb instance, only last 15 minutes and are useless without the candidate information that we don't store.