### PR TITLE
Use ID rather than BLUE/GREEN ID

### DIFF
--- a/terraform/paas/network.tf
+++ b/terraform/paas/network.tf
@@ -11,7 +11,7 @@ data cloudfoundry_app tta_application {
 resource "cloudfoundry_network_policy" "api-policy" {
   count = var.monitoring
   policy {
-    destination_app = cloudfoundry_app.api_application.id_bg
+    destination_app = cloudfoundry_app.api_application.id
     source_app      = module.prometheus[0].app_id
     port            = 8080
   }


### PR DESCRIPTION
Logic suggests use the blue/green id when using the network id, however that fails with an error. so using the natural id