### PR TITLE
Devops/fix deploy

### DIFF
--- a/terraform/paas/network.tf
+++ b/terraform/paas/network.tf
@@ -11,7 +11,7 @@ data cloudfoundry_app tta_application {
 resource "cloudfoundry_network_policy" "api-policy" {
   count = var.monitoring
   policy {
-    destination_app = cloudfoundry_app.api_application.id_bg
+    destination_app = cloudfoundry_app.api_application.id
     source_app      = module.prometheus[0].app_id
     port            = 8080
   }

--- a/terraform/paas/network.tf
+++ b/terraform/paas/network.tf
@@ -10,8 +10,9 @@ data cloudfoundry_app tta_application {
 
 resource "cloudfoundry_network_policy" "api-policy" {
   count = var.monitoring
+  depends_on = [ module.prometheus ]
   policy {
-    destination_app = cloudfoundry_app.api_application.id
+    destination_app = cloudfoundry_app.api_application.id_bg
     source_app      = module.prometheus[0].app_id
     port            = 8080
   }


### PR DESCRIPTION
Trying to fix deploy network policies, where it works in certain conditions and not in others.
It seems to fail with an error

```
Error: Provider produced inconsistent final plan

When expanding the plan for cloudfoundry_network_policy.api-policy[0] to
include new values learned so far during apply, provider
"registry.terraform.io/cloudfoundry-community/cloudfoundry" produced an
invalid new value for .policy: planned set element
cty.ObjectVal(map[string]cty.Value{"destination_app":cty.StringVal("fca6e9f4-5955-470b-a6dc-558893368f99"),
"port":cty.StringVal("8080"), "protocol":cty.StringVal("tcp"),
"source_app":cty.StringVal("a6c46905-16e9-4c80-9f91-2b0f77134daf")}) does not
correlate with any element in actual.
```
