### PR TITLE
Add TOTP metrics to engagement row

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1607616701952,
+  "id": 2,
+  "iteration": 1610633064571,
   "links": [],
   "panels": [
     {
@@ -84,7 +84,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -177,8 +177,8 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 8,
         "y": 1
       },
       "id": 30,
@@ -270,8 +270,8 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 6,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 1
       },
       "id": 31,
@@ -344,10 +344,10 @@
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 18,
-        "y": 1
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 10
       },
       "id": 32,
       "interval": null,
@@ -469,13 +469,202 @@
       "valueName": "total"
     },
     {
+      "aliasColors": {
+        "Unverified": "#F2495C"
+      },
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 63,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.2.2",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(max_over_time(api_generated_totps[$__range]) or vector(0)) - sum(max_over_time(api_generated_totps[$__range] offset $__range) or vector(0))",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "interval": "",
+          "legendFormat": "Generated",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "expr": "sum(max_over_time(api_verified_totps[$__range]) or vector(0)) - sum(max_over_time(api_verified_totps[$__range] offset $__range) or vector(0))",
+          "interval": "",
+          "legendFormat": "Verified",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(max_over_time(api_generated_totps[$__range]) or vector(0)) - sum(max_over_time(api_generated_totps[$__range] offset $__range) or vector(0))) - (sum(max_over_time(api_verified_totps[$__range]) or vector(0)) - sum(max_over_time(api_verified_totps[$__range] offset $__range) or vector(0)))",
+          "interval": "",
+          "legendFormat": "Unverified",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TOTPs Generated vs Verified",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 64,
+      "interval": null,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(max_over_time(api_verified_totps{valid=\"False\"}[$__range]) or vector(0)) - sum(max_over_time(api_verified_totps{valid=\"False\"}[$__range] offset $__range) or vector(0))",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "interval": "",
+          "legendFormat": "Failed Attempts",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TOTP Failed Attempts",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 20
       },
       "id": 46,
       "panels": [],
@@ -502,7 +691,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 11
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 52,
@@ -606,7 +795,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 11
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 44,
@@ -794,7 +983,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "id": 38,
       "panels": [],
@@ -820,7 +1009,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 23,
@@ -916,7 +1105,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1012,7 +1201,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1113,7 +1302,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 56
       },
       "id": 40,
       "panels": [],
@@ -1154,7 +1343,7 @@
         "h": 10,
         "w": 6,
         "x": 0,
-        "y": 47
+        "y": 57
       },
       "id": 50,
       "interval": null,
@@ -1221,7 +1410,7 @@
         "h": 10,
         "w": 6,
         "x": 6,
-        "y": 47
+        "y": 57
       },
       "id": 48,
       "interval": null,
@@ -1295,7 +1484,7 @@
         "h": 10,
         "w": 6,
         "x": 12,
-        "y": 47
+        "y": 57
       },
       "id": 6,
       "interval": null,
@@ -1371,7 +1560,7 @@
         "h": 10,
         "w": 6,
         "x": 18,
-        "y": 47
+        "y": 57
       },
       "id": 21,
       "interval": null,
@@ -1425,7 +1614,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1535,7 +1724,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 57
+        "y": 67
       },
       "id": 25,
       "interval": null,
@@ -1595,7 +1784,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 57
+        "y": 67
       },
       "id": 14,
       "interval": null,
@@ -1679,7 +1868,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 79
       },
       "id": 16,
       "pageSize": null,
@@ -1741,7 +1930,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 80
+        "y": 90
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1842,7 +2031,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 80
+        "y": 90
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1907,7 +2096,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 92
+        "y": 102
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2025,7 +2214,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 92
+        "y": 102
       },
       "hiddenSeries": false,
       "id": 60,
@@ -2238,7 +2427,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 112
       },
       "id": 34,
       "panels": [],
@@ -2264,7 +2453,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 61,
@@ -2398,7 +2587,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 2,
@@ -2485,7 +2674,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 115
+        "y": 125
       },
       "id": 42,
       "panels": [],
@@ -2533,7 +2722,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 116
+        "y": 126
       },
       "id": 27,
       "interval": null,
@@ -2608,7 +2797,7 @@
         "h": 10,
         "w": 4,
         "x": 4,
-        "y": 116
+        "y": 126
       },
       "id": 55,
       "interval": null,
@@ -2679,7 +2868,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 116
+        "y": 126
       },
       "id": 57,
       "pageSize": null,
@@ -2742,7 +2931,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 116
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 58,


### PR DESCRIPTION
We are now sending metrics for generated/verified Timed One Time Passwords. This enables us to see how many we are generating vs how many are being verified, in addition to how many times a user is failing to enter a valid TOTP.

Add Grafana panels to visualize the new metrics.

<img width="951" alt="Screenshot 2021-01-15 at 11 51 46" src="https://user-images.githubusercontent.com/29867726/104724060-0f2f5280-5728-11eb-8b4d-030c61324fcd.png">
