### PR TITLE
Simplify the service request models

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -116,29 +117,12 @@ namespace GetIntoTeachingApi.Models
 
         private void ConfigureSubscriptions(Candidate candidate)
         {
-            candidate.HasMailingListSubscription = true;
-            candidate.MailingListSubscriptionChannelId = ChannelId ?? (int)Candidate.SubscriptionChannel.MailingList;
-            candidate.MailingListSubscriptionStartAt = DateTime.UtcNow;
-            candidate.MailingListSubscriptionDoNotEmail = false;
-            candidate.MailingListSubscriptionDoNotBulkEmail = false;
-            candidate.MailingListSubscriptionDoNotBulkPostalMail = true;
-            candidate.MailingListSubscriptionDoNotPostalMail = true;
-            candidate.MailingListSubscriptionDoNotSendMm = false;
+            SubscriptionManager.SubscribeToMailingList(candidate, ChannelId);
 
-            if (string.IsNullOrWhiteSpace(AddressPostcode))
+            if (!string.IsNullOrWhiteSpace(AddressPostcode))
             {
-                return;
+                SubscriptionManager.SubscribeToEvents(candidate, ChannelId);
             }
-
-            candidate.HasEventsSubscription = true;
-            candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
-            candidate.EventsSubscriptionChannelId = ChannelId ?? (int)Candidate.SubscriptionChannel.Events;
-            candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
-            candidate.EventsSubscriptionDoNotEmail = false;
-            candidate.EventsSubscriptionDoNotBulkEmail = false;
-            candidate.EventsSubscriptionDoNotBulkPostalMail = true;
-            candidate.EventsSubscriptionDoNotPostalMail = true;
-            candidate.EventsSubscriptionDoNotSendMm = false;
         }
 
         private void AcceptPrivacyPolicy(Candidate candidate)

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -89,12 +89,6 @@ namespace GetIntoTeachingApi.Models
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
                 ChannelId = CandidateId == null ? ChannelId ?? (int?)Candidate.Channel.MailingList : null,
-                OptOutOfSms = false,
-                DoNotBulkEmail = false,
-                DoNotEmail = false,
-                DoNotBulkPostalMail = true,
-                DoNotPostalMail = true,
-                DoNotSendMm = false,
                 EligibilityRulesPassed = "false",
             };
 

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -162,7 +162,6 @@ namespace GetIntoTeachingApi.Models
             DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
-            ConfigureConsent(candidate);
 
             return candidate;
         }
@@ -285,16 +284,6 @@ namespace GetIntoTeachingApi.Models
             {
                 candidate.TypeId = (int)Candidate.Type.InterestedInTeacherTraining;
             }
-        }
-
-        private void ConfigureConsent(Candidate candidate)
-        {
-            candidate.OptOutOfSms = false;
-            candidate.DoNotBulkEmail = candidate.IsReturningToTeaching();
-            candidate.DoNotEmail = false;
-            candidate.DoNotBulkPostalMail = candidate.IsReturningToTeaching();
-            candidate.DoNotPostalMail = candidate.IsReturningToTeaching();
-            candidate.DoNotSendMm = candidate.IsReturningToTeaching();
         }
 
         private int? DestinationForTelephone(string telephone)

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -160,7 +161,7 @@ namespace GetIntoTeachingApi.Models
             SetType(candidate);
             DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
-            ConfigureSubscription(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
             ConfigureConsent(candidate);
 
             return candidate;
@@ -294,18 +295,6 @@ namespace GetIntoTeachingApi.Models
             candidate.DoNotBulkPostalMail = candidate.IsReturningToTeaching();
             candidate.DoNotPostalMail = candidate.IsReturningToTeaching();
             candidate.DoNotSendMm = candidate.IsReturningToTeaching();
-        }
-
-        private void ConfigureSubscription(Candidate candidate)
-        {
-            candidate.HasTeacherTrainingAdviserSubscription = true;
-            candidate.TeacherTrainingAdviserSubscriptionChannelId = (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
-            candidate.TeacherTrainingAdviserSubscriptionStartAt = DateTime.UtcNow;
-            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = candidate.IsReturningToTeaching();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail = candidate.IsReturningToTeaching();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm = candidate.IsReturningToTeaching();
         }
 
         private int? DestinationForTelephone(string telephone)

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -126,37 +127,12 @@ namespace GetIntoTeachingApi.Models
 
         private void ConfigureSubscriptions(Candidate candidate)
         {
-            candidate.HasEventsSubscription = true;
-            candidate.EventsSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Events;
-            candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
-            candidate.EventsSubscriptionDoNotEmail = false;
-            candidate.EventsSubscriptionDoNotBulkEmail = false;
-            candidate.EventsSubscriptionDoNotBulkPostalMail = true;
-            candidate.EventsSubscriptionDoNotPostalMail = true;
-            candidate.EventsSubscriptionDoNotSendMm = false;
+            SubscriptionManager.SubscribeToEvents(candidate);
 
-            if (string.IsNullOrWhiteSpace(AddressPostcode))
+            if (SubscribeToMailingList)
             {
-                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
+                SubscriptionManager.SubscribeToMailingList(candidate);
             }
-            else
-            {
-                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
-            }
-
-            if (!SubscribeToMailingList)
-            {
-                return;
-            }
-
-            candidate.HasMailingListSubscription = true;
-            candidate.MailingListSubscriptionChannelId = (int)Candidate.SubscriptionChannel.MailingList;
-            candidate.MailingListSubscriptionStartAt = DateTime.UtcNow;
-            candidate.MailingListSubscriptionDoNotEmail = false;
-            candidate.MailingListSubscriptionDoNotBulkEmail = false;
-            candidate.MailingListSubscriptionDoNotBulkPostalMail = true;
-            candidate.MailingListSubscriptionDoNotPostalMail = true;
-            candidate.MailingListSubscriptionDoNotSendMm = false;
         }
 
         private void AddTeachingEventRegistration(Candidate candidate)

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -32,8 +32,6 @@ namespace GetIntoTeachingApi.Models
         public string AddressPostcode { get; set; }
         [SensitiveData]
         public string Telephone { get; set; }
-        [SwaggerSchema(ReadOnly = true)]
-        public bool SubscribeToEvents => AddressPostcode != null && SubscribeToMailingList;
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -100,7 +98,6 @@ namespace GetIntoTeachingApi.Models
             AddQualification(candidate);
             AcceptPrivacyPolicy(candidate);
             ConfigureSubscriptions(candidate);
-            ConfigureConsent(candidate);
 
             return candidate;
         }
@@ -113,16 +110,6 @@ namespace GetIntoTeachingApi.Models
                 DegreeStatusId = DegreeStatusId,
                 TypeId = (int)CandidateQualification.DegreeType.Degree,
             });
-        }
-
-        private void ConfigureConsent(Candidate candidate)
-        {
-            candidate.OptOutOfSms = false;
-            candidate.DoNotBulkEmail = false;
-            candidate.DoNotBulkPostalMail = !SubscribeToMailingList;
-            candidate.DoNotEmail = false;
-            candidate.DoNotPostalMail = !SubscribeToMailingList;
-            candidate.DoNotSendMm = !SubscribeToEvents && !SubscribeToMailingList;
         }
 
         private void ConfigureSubscriptions(Candidate candidate)

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public static class SubscriptionManager
+    {
+        public static void SubscribeToMailingList(Candidate candidate, int? channelId = null)
+        {
+            candidate.HasMailingListSubscription = true;
+            candidate.MailingListSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.MailingList;
+            candidate.MailingListSubscriptionStartAt = DateTime.UtcNow;
+            candidate.MailingListSubscriptionDoNotEmail = false;
+            candidate.MailingListSubscriptionDoNotBulkEmail = false;
+            candidate.MailingListSubscriptionDoNotBulkPostalMail = true;
+            candidate.MailingListSubscriptionDoNotPostalMail = true;
+            candidate.MailingListSubscriptionDoNotSendMm = false;
+        }
+
+        public static void SubscribeToEvents(Candidate candidate, int? channelId = null)
+        {
+            candidate.HasEventsSubscription = true;
+            candidate.EventsSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Events;
+            candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
+            candidate.EventsSubscriptionDoNotEmail = false;
+            candidate.EventsSubscriptionDoNotBulkEmail = false;
+            candidate.EventsSubscriptionDoNotBulkPostalMail = true;
+            candidate.EventsSubscriptionDoNotPostalMail = true;
+            candidate.EventsSubscriptionDoNotSendMm = false;
+
+            if (string.IsNullOrWhiteSpace(candidate.AddressPostcode))
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent;
+            }
+            else
+            {
+                candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
+            }
+        }
+
+        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate)
+        {
+            candidate.HasTeacherTrainingAdviserSubscription = true;
+            candidate.TeacherTrainingAdviserSubscriptionChannelId = (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
+            candidate.TeacherTrainingAdviserSubscriptionStartAt = DateTime.UtcNow;
+            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = candidate.IsReturningToTeaching();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail = candidate.IsReturningToTeaching();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm = candidate.IsReturningToTeaching();
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -15,6 +15,13 @@ namespace GetIntoTeachingApi.Services
             candidate.MailingListSubscriptionDoNotBulkPostalMail = true;
             candidate.MailingListSubscriptionDoNotPostalMail = true;
             candidate.MailingListSubscriptionDoNotSendMm = false;
+
+            candidate.OptOutOfSms = ConsentValue(candidate.OptOutOfSms, false);
+            candidate.DoNotBulkEmail = ConsentValue(candidate.DoNotBulkEmail, false);
+            candidate.DoNotEmail = ConsentValue(candidate.DoNotEmail, false);
+            candidate.DoNotBulkPostalMail = ConsentValue(candidate.DoNotBulkPostalMail, true);
+            candidate.DoNotPostalMail = ConsentValue(candidate.DoNotPostalMail, true);
+            candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, false);
         }
 
         public static void SubscribeToEvents(Candidate candidate, int? channelId = null)
@@ -36,6 +43,13 @@ namespace GetIntoTeachingApi.Services
             {
                 candidate.EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.LocalEvent;
             }
+
+            candidate.OptOutOfSms = ConsentValue(candidate.OptOutOfSms, false);
+            candidate.DoNotBulkEmail = ConsentValue(candidate.DoNotBulkEmail, false);
+            candidate.DoNotEmail = ConsentValue(candidate.DoNotEmail, false);
+            candidate.DoNotBulkPostalMail = ConsentValue(candidate.DoNotBulkPostalMail, true);
+            candidate.DoNotPostalMail = ConsentValue(candidate.DoNotPostalMail, true);
+            candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, true);
         }
 
         public static void SubscribeToTeacherTrainingAdviser(Candidate candidate)
@@ -48,6 +62,24 @@ namespace GetIntoTeachingApi.Services
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = candidate.IsReturningToTeaching();
             candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail = candidate.IsReturningToTeaching();
             candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm = candidate.IsReturningToTeaching();
+
+            candidate.OptOutOfSms = ConsentValue(candidate.OptOutOfSms, false);
+            candidate.DoNotBulkEmail = ConsentValue(candidate.DoNotBulkEmail, candidate.IsReturningToTeaching());
+            candidate.DoNotEmail = ConsentValue(candidate.DoNotEmail, false);
+            candidate.DoNotBulkPostalMail = ConsentValue(candidate.DoNotBulkPostalMail, candidate.IsReturningToTeaching());
+            candidate.DoNotPostalMail = ConsentValue(candidate.DoNotPostalMail, candidate.IsReturningToTeaching());
+            candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, candidate.IsReturningToTeaching());
+        }
+
+        private static bool ConsentValue(bool? currentValue, bool desiredValue)
+        {
+            // Never opt out if already consented.
+            if (currentValue == false)
+            {
+                return false;
+            }
+
+            return desiredValue;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -116,23 +116,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
 
             candidate.HasMailingListSubscription.Should().BeTrue();
-            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
-            candidate.MailingListSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.MailingListSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotEmail.Should().BeFalse();
-
             candidate.HasEventsSubscription.Should().BeTrue();
-            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
-            candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
-            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
 
             candidate.Qualifications.First().DegreeStatusId.Should().Be(request.DegreeStatusId);
             candidate.Qualifications.First().TypeId.Should().Be((int)CandidateQualification.DegreeType.Degree);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -261,46 +261,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_NotReturningToTeaching_CorrectSubscriptionOptInStatus()
-        {
-            var request = new TeacherTrainingAdviserSignUp()
-            {
-                SubjectTaughtId = null
-            };
-
-            var candidate = request.Candidate;
-
-            candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
-            candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
-        }
-
-        [Fact]
-        public void Candidate_ReturningToTeaching_CorrectSubscriptionOptInStatus()
-        {
-            var request = new TeacherTrainingAdviserSignUp()
-            {
-                SubjectTaughtId = Guid.NewGuid()
-            };
-
-            var candidate = request.Candidate;
-
-            candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
-            candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
-        }
-
-        [Fact]
         public void Candidate_GcseIdIsNull_DefaultsToNotAnswered()
         {
             var request = new TeacherTrainingAdviserSignUp()

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -109,8 +109,8 @@ namespace GetIntoTeachingApiTests.Models
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();
-            candidate.DoNotBulkPostalMail.Should().BeFalse();
-            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
@@ -130,15 +130,6 @@ namespace GetIntoTeachingApiTests.Models
 
         [Fact]
         public void Candidate_SubscribeToMailingListIsFalse_ConsentIsCorrect()
-        {
-            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = "TE7 8KJ" };
-
-            request.Candidate.DoNotBulkPostalMail.Should().BeTrue();
-            request.Candidate.DoNotPostalMail.Should().BeTrue();
-        }
-
-        [Fact]
-        public void Candidate_SubscribeToMailingListAndEventsAreFalse_ConsentIsCorrect()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = null };
 
@@ -175,18 +166,6 @@ namespace GetIntoTeachingApiTests.Models
             var request = new TeachingEventAddAttendee() { AddressPostcode = null };
 
             request.Candidate.HasEventsSubscription.Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData(false, null, false)]
-        [InlineData(false, "TE7 8JR", false)]
-        [InlineData(true, null, false)]
-        [InlineData(true, "TE7 8JR", true)]
-        public void SubscribeToEvents_ReturnsCorrectly(bool SubscribeToMailingList, string AddressPostcode, bool expectedOutcome)
-        {
-            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = SubscribeToMailingList, AddressPostcode = AddressPostcode };
-
-            request.SubscribeToEvents.Should().Be(expectedOutcome);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -129,60 +129,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_SubscribeToMailingListIsTrueAndProvidesAddressPostCode_CorrectSubscription()
-        {
-            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, AddressPostcode = "TE7 8KJ" };
-
-            var candidate = request.Candidate;
-
-            candidate.HasMailingListSubscription.Should().BeTrue();
-            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
-            candidate.MailingListSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.MailingListSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotEmail.Should().BeFalse();
-
-            candidate.HasEventsSubscription.Should().BeTrue();
-            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
-            candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
-            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
-        }
-
-        [Fact]
-        public void Candidate_SubscribeToMailingListIsTrueAndDoesNotProvideAddressPostCode_CorrectSubscription()
-        {
-            var request = new TeachingEventAddAttendee() { SubscribeToMailingList = true, AddressPostcode = null };
-
-            var candidate = request.Candidate;
-
-            candidate.HasMailingListSubscription.Should().BeTrue();
-            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
-            candidate.MailingListSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.MailingListSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.MailingListSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.MailingListSubscriptionDoNotEmail.Should().BeFalse();
-
-            candidate.HasEventsSubscription.Should().BeTrue();
-            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
-            candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
-            candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
-            candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
-            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
-        }
-
-        [Fact]
         public void Candidate_SubscribeToMailingListIsFalse_ConsentIsCorrect()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = "TE7 8KJ" };

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -37,6 +37,32 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void SubscribeToMailingList_NewCandidate_CorrectConsent()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToMailingList(candidate);
+
+            candidate.OptOutOfSms.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SubscribeToMailingList_ExistingCandidate_DoesNotOptOutIfAlreadyConsented()
+        {
+            var candidate = new Candidate() { DoNotBulkPostalMail = false, DoNotPostalMail = false };
+
+            SubscriptionManager.SubscribeToMailingList(candidate);
+
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
+        }
+
+        [Fact]
         public void SubscribeToEvents_CandidateHasAddressPostcodeAndDefaultChannel_CorrectSubscription()
         {
             var candidate = new Candidate() { AddressPostcode = "TE5 7IN" };
@@ -63,6 +89,32 @@ namespace GetIntoTeachingApiTests.Services
 
             candidate.EventsSubscriptionChannelId.Should().Be(123);
             candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
+        }
+
+        [Fact]
+        public void SubscribeToEvents_NewCandidate_CorrectConsent()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToEvents(candidate);
+
+            candidate.OptOutOfSms.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeTrue();
+        }
+
+        [Fact]
+        public void SubscribeToEvents_ExistingCandidate_DoesNotOptOutIfAlreadyConsented()
+        {
+            var candidate = new Candidate() { DoNotBulkPostalMail = false, DoNotPostalMail = false };
+
+            SubscriptionManager.SubscribeToEvents(candidate);
+
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
         }
 
         [Fact]
@@ -98,6 +150,58 @@ namespace GetIntoTeachingApiTests.Services
             candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_NewNonReturnerCandidate_CorrectConsent()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+
+            candidate.OptOutOfSms.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotSendMm.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_NewReturnerCandidate_CorrectConsent()
+        {
+            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
+            var candidate = new Candidate() { PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position } };
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+
+            candidate.OptOutOfSms.Should().BeFalse();
+            candidate.DoNotBulkEmail.Should().BeTrue();
+            candidate.DoNotEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
+            candidate.DoNotSendMm.Should().BeTrue();
+        }
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_ExistingCandidate_DoesNotOptOutIfAlreadyConsented()
+        {
+            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
+            var candidate = new Candidate()
+            {
+                DoNotBulkEmail = false,
+                DoNotBulkPostalMail = false,
+                DoNotPostalMail = false,
+                DoNotSendMm = false,
+                PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position },
+            };
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+
+            candidate.DoNotBulkEmail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeFalse();
+            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotSendMm.Should().BeFalse();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class SubscriptionManagerTests
+    {
+        [Fact]
+        public void SubscribeToMailingList_DefaultChannel_CorrectSubscription()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToMailingList(candidate);
+
+            candidate.HasMailingListSubscription.Should().BeTrue();
+            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
+            candidate.MailingListSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            candidate.MailingListSubscriptionDoNotBulkEmail.Should().BeFalse();
+            candidate.MailingListSubscriptionDoNotBulkPostalMail.Should().BeTrue();
+            candidate.MailingListSubscriptionDoNotPostalMail.Should().BeTrue();
+            candidate.MailingListSubscriptionDoNotSendMm.Should().BeFalse();
+            candidate.MailingListSubscriptionDoNotEmail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SubscribeToMailingList_CustomChannel_CorrectSubscription()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToMailingList(candidate, 123);
+
+            candidate.MailingListSubscriptionChannelId.Should().Be(123);
+        }
+
+        [Fact]
+        public void SubscribeToEvents_CandidateHasAddressPostcodeAndDefaultChannel_CorrectSubscription()
+        {
+            var candidate = new Candidate() { AddressPostcode = "TE5 7IN" };
+
+            SubscriptionManager.SubscribeToEvents(candidate);
+
+            candidate.HasEventsSubscription.Should().BeTrue();
+            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
+            candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
+            candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
+            candidate.EventsSubscriptionDoNotPostalMail.Should().BeTrue();
+            candidate.EventsSubscriptionDoNotSendMm.Should().BeFalse();
+            candidate.EventsSubscriptionDoNotEmail.Should().BeFalse();
+            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
+        }
+
+        [Fact]
+        public void SubscribeToEvents_CandidateHasNoAddressPostcodeAndCustomChannel_CorrectSubscription()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToEvents(candidate, 123);
+
+            candidate.EventsSubscriptionChannelId.Should().Be(123);
+            candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
+        }
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_NotReturningToTeaching_CorrectSubscription()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+
+            candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
+            candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeFalse();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeFalse();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeFalse();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeFalse();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_ReturningToTeaching_CorrectSubscription()
+        {
+            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
+            var candidate = new Candidate() { PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position } };
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+
+            candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
+            candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
- Extract subscription management logic from request models

Currently the request models handle configuring the various subscription attributes against a candidate. There is some duplication here between the mailing list and events sign up (as you sign up for events on mailing list sign up and vice-versa).

This extracts the subscription logic into a new `SubscriptionManager` service that is responsible for configuring the correct subscription consent, channels, etc based on the given `Candidate`.

- Extract candidate consent into SubscriptionManager

When a candidate signs up for a service they get a particular level of consent. To clean up the request models this logic has been extracted into the new `SubscriptionManager` class.

In addition, after talking to the CRM team we are also going to opt-out of bulk postal mail/postal mail for event and mailing list candidates. Also, if a candidate has already consented to something we will no longer opt them out due to their latest subscription choice.

Draws on the approach in #429, with the addition of migrating candidate-level consent to the `SubscriptionManager`, simplifying some of the consent logic and adding test coverage independent of the request models.