### PR TITLE
Rename GovPaas Organisation

### DIFF
--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -45,7 +45,7 @@ variable "environment" {
 }
 
 variable "paas_org_name" {
-  default = "dfe-teacher-services"
+  default = "dfe"
 }
 
 variable "paas_logging_name" {


### PR DESCRIPTION
### Trello card
[Rename GovPaaS Organisation](https://trello.com/c/T6s07KQ9/759-as-the-usage-of-paas-in-dfe-is-growing-and-we-need-to-scale-up-governance-and-tools-it-was-decided-to-move-to-a-simpler-model-wi)
### Context
As the usage of paas in DfE is growing and we need to scale up governance and tools, it was decided to move to a simpler model with a single organisation instead of the 3 we have today. To this effect, dfe-teacher-services will be renamed to dfe and become the single organisation.