### PR TITLE
Better Release Body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,12 @@ jobs:
          uses: DFE-Digital/github-actions/GenerateReleaseFromSHA@master
          with:
            sha: ${{github.sha}}
-
+      
+       - name: Create Temporary Release File
+         if: steps.tag_version.outputs.pr_found == 1
+         run: 
+             echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+          
        - name: Create a GitHub Release
          if:   steps.tag_version.outputs.pr_found == 1
          uses: actions/create-release@v1
@@ -147,8 +152,8 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          with:
             tag_name: ${{ steps.tag_version.outputs.pr_number }}
-            release_name: Release ${{ steps.tag_version.outputs.pr_number }}
-            body: ${{ steps.tag_version.outputs.pr_text }}
+            release_name: GiT Content API Release ${{ steps.tag_version.outputs.pr_number }}
+            body_path: ${PWD}/temp.md
             commitish: ${{github.sha}}
             prerelease: false
             draft:      true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,7 @@ jobs:
       
        - name: Create Temporary Release File
          if: steps.tag_version.outputs.pr_found == 1
-         run: 
-             echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+         run: echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
           
        - name: Create a GitHub Release
          if:   steps.tag_version.outputs.pr_found == 1


### PR DESCRIPTION
### Trello card
https://trello.com/c/Ueda1EDd/640-release-notes-are-only-first-line

### Context
The release is only created with the first line of the PR, I want to improve this to provide the full PR Body

### Changes proposed in this pull request
Create a MD file and use that to create the release

### Guidance to review
This will not effect the product
This should not make any effect to the SLACK output, that will come later