### PR TITLE
Abstract master index check from DbConfiguration

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -29,14 +29,9 @@ namespace GetIntoTeachingApi.Database
             builder.UseNpgsql(connetionString, x => x.UseNetTopologySuite());
         }
 
-        public void Configure(int instanceIndex = 0)
+        public void Migrate()
         {
-            var firstInstance = instanceIndex == 0;
-
-            if (firstInstance)
-            {
-                _dbContext.Database.Migrate();
-            }
+            _dbContext.Database.Migrate();
         }
 
         private static string GenerateConnectionString(IEnv env, string instanceName)

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -16,16 +16,18 @@ namespace GetIntoTeachingApi
 
             using var scope = webHost.Services.CreateScope();
 
-            // Get the ClientPolicyStore instance.
+            // Configure rate limiting.
             var clientPolicyStore = scope.ServiceProvider.GetRequiredService<IClientPolicyStore>();
-
-            // Seed client data from appsettings.
             await clientPolicyStore.SeedAsync();
 
             // Configure the database.
             var dbConfiguration = scope.ServiceProvider.GetRequiredService<DbConfiguration>();
             var env = scope.ServiceProvider.GetRequiredService<IEnv>();
-            dbConfiguration.Configure(env.InstanceIndex);
+
+            if (env.IsMasterInstance)
+            {
+                dbConfiguration.Migrate();
+            }
 
             await webHost.RunAsync();
         }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -21,18 +21,16 @@ namespace GetIntoTeachingApi.Utils
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
-        public int InstanceIndex
+
+        // The master instance boots first on deploy.
+        public bool IsMasterInstance
         {
             get
             {
                 var index = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
+                var success = int.TryParse(index, out int value);
 
-                if (string.IsNullOrWhiteSpace(index))
-                {
-                    return 0;
-                }
-
-                return int.Parse(index);
+                return !success || value == 0;
             }
         }
     }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -19,6 +19,6 @@
         string NotifyApiKey { get; }
         string SharedSecret { get; }
         string GoogleApiKey { get; }
-        int InstanceIndex { get; }
+        bool IsMasterInstance { get; }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -204,24 +204,18 @@ namespace GetIntoTeachingApiTests.Utils
             Environment.SetEnvironmentVariable("GOOGLE_API_KEY", previous);
         }
 
-        [Fact]
-        public void InstanceIndex_ReturnsCorrectly()
+        [Theory]
+        [InlineData("0", true)]
+        [InlineData(null, true)]
+        [InlineData("invalid", true)]
+        [InlineData("1", false)]
+        [InlineData("-1", false)]
+        public void IsMasterInstance_ReturnsCorrectly(string index, bool expectedOutcome)
         {
             var previous = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
-            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", "0");
+            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", index);
 
-            _env.InstanceIndex.Should().Be(0);
-
-            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", previous);
-        }
-
-        [Fact]
-        public void InstanceIndex_DefaultsToZero()
-        {
-            var previous = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
-            Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", null);
-
-            _env.InstanceIndex.Should().Be(0);
+            _env.IsMasterInstance.Should().Be(expectedOutcome);
 
             Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", previous);
         }


### PR DESCRIPTION
The `DbConfiguration` shouldn't care about the instance index; instead this check can be encapsulated in `IEnv` and exposed as `IsMasterInstance` to de-clutter and better encapsulate `DbConfiguration`.