### PR TITLE
Add Client model/validations

### DIFF
--- a/GetIntoTeachingApi/Models/Client.cs
+++ b/GetIntoTeachingApi/Models/Client.cs
@@ -1,0 +1,11 @@
+﻿namespace GetIntoTeachingApi.Models
+{
+    public class Client
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Role { get; set; }
+        public string ApiKeyPrefix { get; set; }
+        public string ApiKey { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/ClientValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ClientValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class ClientValidator : AbstractValidator<Client>
+    {
+        private const string ApiKeyPrefixRegex = "\\A[A-Z][A-Z_]+[A-Z]\\z";
+        private const string RoleRegex = "\\A([A-Z][a-z0-9]+)+\\z";
+
+        public ClientValidator()
+        {
+            RuleFor(client => client.Name).NotEmpty();
+            RuleFor(client => client.Description).NotEmpty();
+            RuleFor(client => client.ApiKeyPrefix).NotEmpty().Matches(ApiKeyPrefixRegex);
+            RuleFor(client => client.Role).NotEmpty().Matches(RoleRegex);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/ClientTests.cs
+++ b/GetIntoTeachingApiTests/Models/ClientTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GetIntoTeachingApiTests.Models
+{
+    public class ClientTests
+    {
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/ClientValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ClientValidatorTests.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class ClientValidatorTests
+    {
+        private readonly ClientValidator _validator;
+
+        public ClientValidatorTests()
+        {
+            _validator = new ClientValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var client = new Client()
+            {
+                Name = "Get an Adviser",
+                Description = "A Rails application that enables candidates to sign up for a teacher training adviser.",
+                Role = "GetAnAdvisor",
+                ApiKeyPrefix = "GET_AN_ADVISOR",
+            };
+
+            var result = _validator.Validate(client);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("key")]
+        [InlineData("ke y")]
+        [InlineData("KE Y")]
+        [InlineData("KE _Y")]
+        [InlineData("_KEY")]
+        [InlineData("KEY_")]
+        public void Validate_ApiKeyPrefixInvalidFormat_HasErrors(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
+        }
+
+        [Theory]
+        [InlineData("KEY")]
+        [InlineData("KE_Y")]
+        [InlineData("KEY_KEY_KEY")]
+        public void Validate_ApiKeyPrefixValidFormat_HasNoErrors(string value)
+        {
+            _validator.ShouldNotHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
+        }
+
+        [Theory]
+        [InlineData("role")]
+        [InlineData("roleAdmin")]
+        [InlineData("Admin Role")]
+        [InlineData("Admin_Role")]
+        [InlineData("admin_role")]
+        public void Validate_RoleInvalidFormat_HasErrors(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.Role, value);
+        }
+
+        [Theory]
+        [InlineData("Admin")]
+        [InlineData("AdminRole")]
+        public void Validate_RoleValidFormat_HasNoErrors(string value)
+        {
+            _validator.ShouldNotHaveValidationErrorFor(client => client.Role, value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void Validate_InvalidName_HasError(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.Name, value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void Validate_InvalidDescription_HasError(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.Description, value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void Validate_InvalidApiKeyPrefixHasError(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void Validate_InvalidRole_HasError(string value)
+        {
+            _validator.ShouldHaveValidationErrorFor(client => client.Role, value);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-789](https://trello.com/c/h8Dxra2B/789-implement-way-to-manage-multiple-client-keys-in-the-api-with-varying-permissions)

This PR is the first step towards supporting multiple, independent clients with their own API keys and roles:

- [x] Add client modelling/validation
- [ ] Load client definitions from YAML
- [ ] Add new authentication handler
- [ ] Scope controller/actions to roles
- [ ] Support rate limiting per client
- [ ] Update README
- [ ] Transition GiT/TTA to the new auth method

----

- Introduce a `Client` model that will represent a consumer of the API. A `Client` consists of:

```
- Name
- Description
- Role
- ApiKeyPrefix
- ApiKey
```

The `ApiKeyPrefix` will be used to construct the name of the environment variable that will contain the client's `ApiKey`, in the format:

```
<api_key_prefix>_API_KEY_<environment>
```

For example, `GET_INTO_TEACHING_API_KEY_PRODUCTION`.

The `Role` attribute will be used to scope access to controllers/actions for this particular client. A `Role` could be applied to multiple clients.