### PR TITLE
Load API client definitions from YAML

### DIFF
--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -1,0 +1,12 @@
+﻿# List of active API clients in the format:
+#
+# name: name of the client service
+# description: description of the client service
+# api_key_prefix: forms part of environment varibale name containing the API key for this service: <api_key_prefix>_API_KEY_<environment>
+# role: used to scope the available endpoints to only those required by the service
+
+-
+  name: Administrator
+  description: "A super-user client for Development convenience and (securely) debugging in production"
+  api_key_prefix: ADMIN
+  role: Admin

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -42,10 +42,17 @@
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="2.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.0" />
+		<PackageReference Include="YamlDotNet" Version="9.1.4" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="Redis\" />
 	  <Folder Include="Validators\" />
+	  <Folder Include="Fixtures\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="Fixtures\clients.yml">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
 	</ItemGroup>
 </Project>

--- a/GetIntoTeachingApi/Services/ClientManager.cs
+++ b/GetIntoTeachingApi/Services/ClientManager.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Utils;
+using MoreLinq;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class ClientManager : IClientManager
+    {
+        public virtual IEnumerable<Client> Clients { get; }
+        private const string ClientsFile = "./Fixtures/clients.yml";
+        private readonly IEnv _env;
+
+        public ClientManager(IEnv env)
+        {
+            _env = env;
+            Clients = LoadClients();
+        }
+
+        public Client GetClient(string apiKey)
+        {
+            return Clients.FirstOrDefault(c => c.ApiKey == apiKey);
+        }
+
+        private IEnumerable<Client> LoadClients()
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build();
+            var yaml = File.ReadAllText(ClientsFile);
+            var clients = deserializer.Deserialize<List<Client>>(yaml);
+
+            clients.ForEach(c => PopulateApiKey(c));
+
+            return clients;
+        }
+
+        private void PopulateApiKey(Client client)
+        {
+            var environmentName = _env.EnvironmentName.ToUpper();
+            client.ApiKey = _env.Get($"{client.ApiKeyPrefix}_API_KEY_{environmentName}");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/IClientManager.cs
+++ b/GetIntoTeachingApi/Services/IClientManager.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface IClientManager
+    {
+        IEnumerable<Client> Clients { get; }
+        Client GetClient(string apiKey);
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -67,6 +67,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IGeocodeClientAdapter, GeocodeClientAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
             services.AddSingleton<INotifyService, NotifyService>();
+            services.AddSingleton<IClientManager, ClientManager>();
             services.AddSingleton<IHangfireService, HangfireService>();
             services.AddSingleton<IRedisService, RedisService>();
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -7,12 +7,11 @@ namespace GetIntoTeachingApi.Utils
         public bool IsDevelopment => EnvironmentName == "Development";
         public bool IsProduction => EnvironmentName == "Production";
         public bool IsStaging => EnvironmentName == "Staging";
-        public bool IsTest => EnvironmentName == null;
+        public bool IsTest => EnvironmentName == "Test";
         public string GitCommitSha => Environment.GetEnvironmentVariable("GIT_COMMIT_SHA");
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
-        public string EnvironmentName => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");
         public string CrmServiceUrl => Environment.GetEnvironmentVariable("CRM_SERVICE_URL");
@@ -32,6 +31,20 @@ namespace GetIntoTeachingApi.Utils
 
                 return !success || value == 0;
             }
+        }
+
+        public string EnvironmentName
+        {
+            get
+            {
+                var name = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+                return name ?? "Test";
+            }
+        }
+
+        public string Get(string variable)
+        {
+            return Environment.GetEnvironmentVariable(variable);
         }
     }
 }

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -20,5 +20,7 @@
         string SharedSecret { get; }
         string GoogleApiKey { get; }
         bool IsMasterInstance { get; }
+
+        string Get(string variable);
     }
 }

--- a/GetIntoTeachingApiTests/Services/ClientManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/ClientManagerTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CSScriptLib;
+using FluentAssertions;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class ClientManagerTests
+    {
+        private readonly Mock<IEnv> _mockEnv;
+
+        public ClientManagerTests()
+        {
+            _mockEnv = new Mock<IEnv>();
+            _mockEnv.Setup(m => m.EnvironmentName).Returns("Test");
+        }
+
+        [Fact]
+        public void Clients_AreAllValid()
+        {
+            _mockEnv.Setup(m => m.Get(It.IsAny<string>())).Returns(null as string);
+            var manager = new ClientManager(_mockEnv.Object);
+
+            var clients = manager.Clients;
+
+            var validator = new ClientValidator();
+            manager.Clients.ForEach(c => validator.Validate(c).IsValid.Should().BeTrue());
+        }
+
+        [Fact]
+        public void Clients_ContainNoDuplicateApiKeyPrefixes()
+        {
+            _mockEnv.Setup(m => m.Get(It.IsAny<string>())).Returns(null as string);
+            var manager = new ClientManager(_mockEnv.Object);
+            var keys = manager.Clients.Select(c => c.ApiKeyPrefix);
+
+            keys.Distinct().Count().Should().Be(keys.Count());
+        }
+
+        [Fact]
+        public void GetClient_WithSecret_ReturnsCorrespondingClient()
+        {
+            _mockEnv.Setup(m => m.Get("ADMIN_API_KEY_TEST")).Returns("admin_secret");
+            var manager = new ClientManager(_mockEnv.Object);
+
+            var client = manager.GetClient("admin_secret");
+
+            client.Name.Should().Be("Administrator");
+            client.ApiKeyPrefix.Should().Be("ADMIN");
+            client.Role.Should().Be("Admin");
+            client.Description.Should().Be("A super-user client for Development convenience and (securely) debugging in production");
+        }
+
+        [Fact]
+        public void GetClient_WithIncorrectSecret_ReturnsNull()
+        {
+            _mockEnv.Setup(m => m.Get("an_invalid_secret")).Returns(null as string);
+            var manager = new ClientManager(_mockEnv.Object);
+
+            var client = manager.GetClient("an_invalid_secret");
+
+            client.Should().BeNull();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -219,5 +219,34 @@ namespace GetIntoTeachingApiTests.Utils
 
             Environment.SetEnvironmentVariable("CF_INSTANCE_INDEX", previous);
         }
+
+        [Theory]
+        [InlineData(null, "Test")]
+        [InlineData("Development", "Development")]
+        [InlineData("Staging", "Staging")]
+        [InlineData("Production", "Production")]
+        public void EnvironmentName_ReturnsCorrectly(string environment, string expected)
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+
+            _env.EnvironmentName.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Get_WithVariable_ReturnsMatchingEnvironmentVariable()
+        {
+            var previous = Environment.GetEnvironmentVariable("AN_ENV_VAR");
+            Environment.SetEnvironmentVariable("AN_ENV_VAR", "test");
+
+            _env.Get("AN_ENV_VAR").Should().Be("test");
+
+            Environment.SetEnvironmentVariable("AN_ENV_VAR", previous);
+        }
+
+        [Fact]
+        public void Get_WhenVariableDoesNotExist_ReturnsNull()
+        {
+            _env.Get("NON_EXISTANT").Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
[Trello-789](https://trello.com/c/h8Dxra2B/789-implement-way-to-manage-multiple-client-keys-in-the-api-with-varying-permissions)

This PR is the second step towards supporting multiple, independent clients with their own API keys and roles:

- [x] Add client modelling/validation
- [x] Load client definitions from YAML
- [ ] Add new authentication handler
- [ ] Scope controller/actions to roles
- [ ] Support rate limiting per client
- [ ] Update README
- [ ] Transition GiT/TTA to the new auth method

----

- Add ClientManager to load API clients from YAML

When a request comes in to the API we need to be able to match the API key against the associated client, so that we can authenticate and authorize the request.

Add `ClientManager` that is responsible for loading a static list of clients from YAML and provides a method to get a client associated with a given API key (which will be used in the authentication handler).

The `Env` class has also been updated to return `Test` as the environment name instead of `null`, which enables us to test matching a client to its environment variable containing the API key.

Initially an `Administrator` client has been added, which will have access to every endpoint (when we add the authorization logic to apply roles) and can be used for testing locally and debugging in production.

Tests ensure that all clients in the YAML file are valid and there are no duplicates.
