### PR TITLE
Enable rate limiting per API client service

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCoreRateLimit" Version="3.0.5" />
+		<PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
 		<PackageReference Include="CsvHelper" Version="15.0.5" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -28,7 +28,9 @@
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}]}",
         "SHARED_SECRET": "abc123",
-        "ADMIN_API_KEY": "secret",
+        "ADMIN_API_KEY": "secret-admin",
+        "GIT_API_KEY": "secret-git",
+        "TTA_API_KEY": "secret-tta",
         "TOTP_SECRET_KEY": "def456"
       }
     }

--- a/GetIntoTeachingApi/RateLimiting/ApiClientRateLimitConfiguration.cs
+++ b/GetIntoTeachingApi/RateLimiting/ApiClientRateLimitConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace GetIntoTeachingApi.RateLimiting
+{
+    public class ApiClientRateLimitConfiguration : RateLimitConfiguration
+    {
+        public ApiClientRateLimitConfiguration(
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<IpRateLimitOptions> ipOptions,
+            IOptions<ClientRateLimitOptions> clientOptions)
+            : base(httpContextAccessor, ipOptions, clientOptions)
+        {
+        }
+
+        protected override void RegisterResolvers()
+        {
+            ClientResolvers.Add(new ApiClientResolveContributor(HttpContextAccessor, ClientRateLimitOptions.ClientIdHeader));
+        }
+    }
+}

--- a/GetIntoTeachingApi/RateLimiting/ApiClientResolveContributor.cs
+++ b/GetIntoTeachingApi/RateLimiting/ApiClientResolveContributor.cs
@@ -1,0 +1,34 @@
+﻿using AspNetCoreRateLimit;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Http;
+
+namespace GetIntoTeachingApi.RateLimiting
+{
+    public class ApiClientResolveContributor : IClientResolveContributor
+    {
+        private readonly IClientManager _clientManager;
+        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly string _clientIdHeader;
+
+        public ApiClientResolveContributor(IHttpContextAccessor contextAccessor, string clientIdHeader)
+        {
+            _clientManager = new ClientManager(new Env());
+            _contextAccessor = contextAccessor;
+            _clientIdHeader = clientIdHeader;
+        }
+
+        public string ResolveClient()
+        {
+            string clientId = null;
+
+            if (_contextAccessor.HttpContext.Request.Headers.TryGetValue(_clientIdHeader, out var value))
+            {
+                var apiKey = value.ToString().Replace("Bearer ", string.Empty);
+                clientId = _clientManager.GetClient(apiKey)?.ApiKeyPrefix;
+            }
+
+            return clientId;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -9,6 +9,7 @@ using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.ModelBinders;
 using GetIntoTeachingApi.OperationFilters;
+using GetIntoTeachingApi.RateLimiting;
 using GetIntoTeachingApi.Redis;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -295,7 +296,7 @@ The GIT API aims to provide:
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             // Configuration (resolvers, counter key builders).
-            services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+            services.AddSingleton<IRateLimitConfiguration, ApiClientRateLimitConfiguration>();
         }
     }
 }

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -14,27 +14,66 @@
     "ClientIdHeader": "Authorization",
     "HttpStatusCode": 429,
     "EndpointWhitelist": [ "*:/api/operations/*" ],
-    "ClientWhitelist": [],
+    "ClientWhitelist": [ "ADMIN" ],
     "GeneralRules": [
       {
         "Endpoint": "POST:/api/candidates/access_tokens",
         "Period": "1m",
-        "Limit": 500
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/teacher_training_adviser/candidates",
         "Period": "1m",
-        "Limit": 250
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/mailing_list/members",
         "Period": "1m",
-        "Limit": 250
+        "Limit": 60
       },
       {
         "Endpoint": "POST:/api/teaching_events/attendees",
         "Period": "1m",
-        "Limit": 250
+        "Limit": 60
+      }
+    ]
+  },
+  "ClientRateLimitPolicies": {
+    "ClientRules": [
+      {
+        "ClientId": "GIT",
+        "Rules": [
+          {
+            "Endpoint": "POST:/api/candidates/access_tokens",
+            "Period": "1m",
+            "Limit": 500
+          },
+          {
+            "Endpoint": "POST:/api/mailing_list/members",
+            "Period": "1m",
+            "Limit": 250
+          },
+          {
+            "Endpoint": "POST:/api/teaching_events/attendees",
+            "Period": "1m",
+            "Limit": 250
+          }
+        ]
+      },
+      {
+        "ClientId": "TTA",
+        "Rules": [
+          {
+            "Endpoint": "POST:/api/candidates/access_tokens",
+            "Period": "1m",
+            "Limit": 500
+          },
+          {
+            "Endpoint": "POST:/api/teacher_training_adviser/candidates",
+            "Period": "1m",
+            "Limit": 250
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
[Trello-789](https://trello.com/c/h8Dxra2B/789-implement-way-to-manage-multiple-client-keys-in-the-api-with-varying-permissions)

This PR is the sixth step (support rate limiting per client) towards supporting multiple, independent clients with their own API keys and roles:

- [x] Add client modelling/validation
- [x] Load client definitions from YAML
- [x] Add new authentication handler
- [x] Scope controller/actions to roles
- [x] Transition GiT/TTA to the new auth method
- [x] Support rate limiting per client
- [ ] Update README

----

- Enable per-client rate limit rules

Add a custom `ResolveContributor` that looks up the API client from their API key and sets the `clientId` to the `ApiKeyPrefix`.

Define custom rate limiting rules for `GIT` and `TTA` clients. 

Add development api keys for `GIT`/`TTA` in addition to `ADMIN`.

The `ADMIN` client has been white-listed and a set of default rate limits imposed on potentially exploitable endpoints.

Bumped the `AspNetCoreRateLimit` library.

This PR doesn't have test coverage as I've hit an issue with the integration tests not loading in the client-specific policies for some reason even though they load in the development environment. Oddly the baseline rate limits load fine in the test environment. I've manually verified the client-level rate limits work correctly.