### PR TITLE
Update subscriptions to not opt TTA candidates into post/bulk post

### DIFF
--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -59,15 +59,15 @@ namespace GetIntoTeachingApi.Services
             candidate.TeacherTrainingAdviserSubscriptionStartAt = DateTime.UtcNow;
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = candidate.IsReturningToTeaching();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail = candidate.IsReturningToTeaching();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = true;
+            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail = true;
             candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm = candidate.IsReturningToTeaching();
 
             candidate.OptOutOfSms = ConsentValue(candidate.OptOutOfSms, false);
             candidate.DoNotBulkEmail = ConsentValue(candidate.DoNotBulkEmail, candidate.IsReturningToTeaching());
             candidate.DoNotEmail = ConsentValue(candidate.DoNotEmail, false);
-            candidate.DoNotBulkPostalMail = ConsentValue(candidate.DoNotBulkPostalMail, candidate.IsReturningToTeaching());
-            candidate.DoNotPostalMail = ConsentValue(candidate.DoNotPostalMail, candidate.IsReturningToTeaching());
+            candidate.DoNotBulkPostalMail = ConsentValue(candidate.DoNotBulkPostalMail, true);
+            candidate.DoNotPostalMail = ConsentValue(candidate.DoNotPostalMail, true);
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, candidate.IsReturningToTeaching());
         }
 

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -239,8 +239,6 @@ namespace GetIntoTeachingApiTests.Models
             var candidate = request.Candidate;
 
             candidate.DoNotBulkEmail.Should().BeTrue();
-            candidate.DoNotBulkPostalMail.Should().BeTrue();
-            candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeTrue();
         }
 
@@ -255,8 +253,6 @@ namespace GetIntoTeachingApiTests.Models
             var candidate = request.Candidate;
 
             candidate.DoNotBulkEmail.Should().BeFalse();
-            candidate.DoNotBulkPostalMail.Should().BeFalse();
-            candidate.DoNotPostalMail.Should().BeFalse();
             candidate.DoNotSendMm.Should().BeFalse();
         }
 

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -128,8 +128,8 @@ namespace GetIntoTeachingApiTests.Services
             candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
             candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeFalse();
-            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeFalse();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeTrue();
+            candidate.TeacherTrainingAdviserSubscriptionDoNotPostalMail.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionDoNotSendMm.Should().BeFalse();
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail.Should().BeFalse();
         }
@@ -162,8 +162,8 @@ namespace GetIntoTeachingApiTests.Services
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotEmail.Should().BeFalse();
-            candidate.DoNotBulkPostalMail.Should().BeFalse();
-            candidate.DoNotPostalMail.Should().BeFalse();
+            candidate.DoNotBulkPostalMail.Should().BeTrue();
+            candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
         }
 


### PR DESCRIPTION
Candidates signing up for TTA are currently opted into postal/bulk postal mail if returning to teaching. This is not longer wanted.