### PR TITLE
Add GiT services as API clients

### DIFF
--- a/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
+++ b/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
@@ -11,7 +11,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/callback_booking_quotas")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,GetAnAdviser")]
     public class CallbackBookingQuotasController : ControllerBase
     {
         private readonly ICallbackBookingService _callbackBookingService;

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/candidates")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/mailing_list")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,GetIntoTeaching")]
     public class MailingListController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
     [Route("api/teacher_training_adviser/candidates")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,GetAnAdviser")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/teaching_events")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,GetIntoTeaching")]
     public class TeachingEventsController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -10,3 +10,13 @@
   description: "A super-user client for Development convenience and (securely) debugging in production"
   api_key_prefix: ADMIN
   role: Admin
+-
+  name: Get into Teaching
+  description: "A service to support potential teachers on their journey into teaching"
+  api_key_prefix: GIT
+  role: GetIntoTeaching
+-
+  name: Get an Adviser
+  description: "A service to enable candidates to sign up for a Teacher Training Adviser (TTA)"
+  api_key_prefix: TTA
+  role: GetAnAdviser

--- a/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CallbackBookingQuotasControllerTests.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CallbackBookingQuotasController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles.Contains("Admin"));
+            typeof(CallbackBookingQuotasController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -30,7 +30,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles.Contains("Admin"));
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(MailingListController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles.Contains("Admin"));
+            typeof(MailingListController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles.Contains("Admin"));
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -45,7 +45,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(TeachingEventsController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles.Contains("Admin"));
+            typeof(TeachingEventsController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching");
         }
 
         [Fact]


### PR DESCRIPTION
- Add GiT services as API clients

Adds the Get into Teaching services to the `clients.yml`. We can merge this and the two apps will continue to use the legacy secrets until we set up the new secrets in Azure and transition them over.

- Assign GiT API client roles

Assigns roles for the GiT API clients. This will limit access to only the controllers/actions required by the service.