### PR TITLE
Remove environment name from API key variable name

### DIFF
--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -28,7 +28,7 @@
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}]}",
         "SHARED_SECRET": "abc123",
-        "ADMIN_API_KEY_DEVELOPMENT": "secret",
+        "ADMIN_API_KEY": "secret",
         "TOTP_SECRET_KEY": "def456"
       }
     }

--- a/GetIntoTeachingApi/Services/ClientManager.cs
+++ b/GetIntoTeachingApi/Services/ClientManager.cs
@@ -41,8 +41,7 @@ namespace GetIntoTeachingApi.Services
 
         private void PopulateApiKey(Client client)
         {
-            var environmentName = _env.EnvironmentName.ToUpper();
-            client.ApiKey = _env.Get($"{client.ApiKeyPrefix}_API_KEY_{environmentName}");
+            client.ApiKey = _env.Get($"{client.ApiKeyPrefix}_API_KEY");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/ClientManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/ClientManagerTests.cs
@@ -45,7 +45,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void GetClient_WithSecret_ReturnsCorrespondingClient()
         {
-            _mockEnv.Setup(m => m.Get("ADMIN_API_KEY_TEST")).Returns("admin_secret");
+            _mockEnv.Setup(m => m.Get("ADMIN_API_KEY")).Returns("admin_secret");
             var manager = new ClientManager(_mockEnv.Object);
 
             var client = manager.GetClient("admin_secret");


### PR DESCRIPTION
I'm not sure why I had it in my head that the environment name had to be in to distinguish the keys 😕 