### PR TITLE
Add test coverage to client-level rate limits

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -10,8 +10,12 @@ namespace GetIntoTeachingApi.Adapters
 
         public CdsServiceClientWrapper(IEnv env)
         {
-            CdsServiceClient = new CdsServiceClient(ConnectionString(env));
-            CdsServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+            // We don't want to try and connect to Dynamics when integration testing.
+            if (!env.IsTest)
+            {
+                CdsServiceClient = new CdsServiceClient(ConnectionString(env));
+                CdsServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+            }
         }
 
         private static string ConnectionString(IEnv env)

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,9 +1,5 @@
 using System.Threading.Tasks;
-using AspNetCoreRateLimit;
-using GetIntoTeachingApi.Database;
-using GetIntoTeachingApi.Utils;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace GetIntoTeachingApi
@@ -13,21 +9,6 @@ namespace GetIntoTeachingApi
         public static async Task Main(string[] args)
         {
             var webHost = CreateHostBuilder(args).Build();
-
-            using var scope = webHost.Services.CreateScope();
-
-            // Configure rate limiting.
-            var clientPolicyStore = scope.ServiceProvider.GetRequiredService<IClientPolicyStore>();
-            await clientPolicyStore.SeedAsync();
-
-            // Configure the database.
-            var dbConfiguration = scope.ServiceProvider.GetRequiredService<DbConfiguration>();
-            var env = scope.ServiceProvider.GetRequiredService<IEnv>();
-
-            if (env.IsMasterInstance)
-            {
-                dbConfiguration.Migrate();
-            }
 
             await webHost.RunAsync();
         }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -57,8 +57,9 @@ namespace GetIntoTeachingApi
             }
 
             services.AddSingleton<CdsServiceClientWrapper, CdsServiceClientWrapper>();
-            services.AddTransient<IOrganizationService>(sp => sp.GetService<CdsServiceClientWrapper>().CdsServiceClient.Clone());
+            services.AddTransient<IOrganizationService>(sp => sp.GetService<CdsServiceClientWrapper>().CdsServiceClient?.Clone());
             services.AddTransient<IOrganizationServiceAdapter, OrganizationServiceAdapter>();
+
             services.AddTransient<ICrmService, CrmService>();
 
             services.AddScoped<IStore, Store>();
@@ -77,11 +78,8 @@ namespace GetIntoTeachingApi
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IEnv>(env);
 
-            if (!env.IsTest)
-            {
-                var connectionString = DbConfiguration.DatabaseConnectionString(env);
-                services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
-            }
+            var connectionString = DbConfiguration.DatabaseConnectionString(env);
+            services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
 
             services.AddAuthentication("ApiClientHandler")
                 .AddScheme<ApiClientSchemaOptions, ApiClientHandler>("ApiClientHandler", op => { });
@@ -277,6 +275,18 @@ The GIT API aims to provide:
                 {
                     RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
                 }
+            }
+
+            // Configure rate limiting.
+            var clientPolicyStore = serviceScope.ServiceProvider.GetRequiredService<IClientPolicyStore>();
+            clientPolicyStore.SeedAsync().GetAwaiter().GetResult();
+
+            // Configure the database.
+            var dbConfiguration = serviceScope.ServiceProvider.GetRequiredService<DbConfiguration>();
+
+            if (env.IsMasterInstance)
+            {
+                dbConfiguration.Migrate();
             }
 
             app.UseEndpoints(endpoints =>

--- a/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Database;
+﻿using System;
+using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 
 namespace GetIntoTeachingApiTests.Helpers
@@ -13,6 +14,13 @@ namespace GetIntoTeachingApiTests.Helpers
         {
             TemplateDatabaseName = $"gis_test";
             ConnectionString = $"Host=localhost;Database={TemplateDatabaseName};Username=docker;Password=docker";
+
+            // Set environment for integration tests using the database.
+            Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", TemplateDatabaseName);
+            Environment.SetEnvironmentVariable("VCAP_SERVICES",
+                $"{{\"postgres\": [{{\"instance_name\": \"{TemplateDatabaseName}\",\"credentials\": {{\"host\": \"localhost\"," +
+                $"\"name\": \"{TemplateDatabaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}}}]," +
+                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
 
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
             DbConfiguration.ConfigPostgres(ConnectionString, builder);

--- a/GetIntoTeachingApiTests/Helpers/GitWebApplicationFactory.cs
+++ b/GetIntoTeachingApiTests/Helpers/GitWebApplicationFactory.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public class GitWebApplicationFactory<TStartup>
+        : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Use in-memory rate limit counters for tests.
+                services.Remove(services.First(d => d.ServiceType == typeof(IRateLimitCounterStore)));
+                var descriptor = new ServiceDescriptor(typeof(IRateLimitCounterStore), typeof(MemoryCacheRateLimitCounterStore), ServiceLifetime.Singleton);
+                services.Add(descriptor);
+            });
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GetIntoTeachingApi;
+using GetIntoTeachingApiTests.Helpers;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Integration
+{
+    [Collection("Database")]
+    public class RateLimitTests : IClassFixture<GitWebApplicationFactory<Startup>>
+    {
+        private readonly GitWebApplicationFactory<Startup> _factory;
+        private readonly HttpClient _httpClient;
+        private readonly StringContent _emptyBody;
+
+        public RateLimitTests(GitWebApplicationFactory<Startup> factory)
+        {
+            Environment.SetEnvironmentVariable($"GIT_API_KEY", "git-secret");
+            Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
+            Environment.SetEnvironmentVariable($"TTA_API_KEY", "tta-secret");
+
+            _factory = factory;
+
+            _httpClient = _factory.CreateClient();
+            _emptyBody = new StringContent("{}", Encoding.UTF8, "application/json");
+        }
+
+        [Theory]
+        [InlineData("/api/candidates/access_tokens", "GIT", 500)]
+        [InlineData("/api/mailing_list/members", "GIT", 250)]
+        [InlineData("/api/teaching_events/attendees", "GIT", 250)]
+        [InlineData("/api/candidates/access_tokens", "TTA", 500)]
+        [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
+        public async Task Post_Endpoint_AppliesRateLimit(string path, string client, int limit)
+        {
+            var apiKey = $"{client.ToLower()}-secret";
+
+            _httpClient.DefaultRequestHeaders.Add("Authorization", apiKey);
+
+            HttpResponseMessage response = null;
+
+            for (var i = 0; i < limit; i++)
+            {
+                response = await _httpClient.PostAsync(path, _emptyBody);
+            }
+
+            response.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests);
+
+            response = await _httpClient.PostAsync(path, _emptyBody);
+
+            response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        }
+    }
+}


### PR DESCRIPTION
- Update Startup to enable app to boot in test env

When trying to boot the application in the test environment there were a few things preventing the application from successfully starting (which we need to be able to do integration testing):

1. The `CdsServiceClient` is unable to connect (we now support running without the client, though it will crash if mocking is absent).
2. The database was not being configured for test (we can now connect to the test DB running in docker).
3. `Program` is not ran by `WebApplicationFactory` (code now shifted to be in the `Startup.Configure` instead, which gets run).

- Add WebApplicationFactory to run app in test env

The WebApplicationFactory allows us to boot an instance of the application running in the test environment and re-configure services that need to run differently for tests.

The only change we make currently is to run the rate limit counters against an in-memory store instead of Redis so that they are isolated between test runs.

- Support isolated integration tests against a Postgres DB

We already have the `DatabaseFixture` class to support unit testing against an isolated Postgres DB (running in Docker). This commit updates the `Environment` so that any integration tests using `DatabaseFixture` will also hit an isolated test database in docker.

- Add integration tests for rate limit behaviour