### PR TITLE
Remove legacy shared secret authentication method

### DIFF
--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -27,7 +27,6 @@
         "DATABASE_INSTANCE_NAME": "gis",
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}]}",
-        "SHARED_SECRET": "abc123",
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -18,7 +18,6 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientId => Environment.GetEnvironmentVariable("CRM_CLIENT_ID");
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
-        public string SharedSecret => Environment.GetEnvironmentVariable("SHARED_SECRET");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
 
         // The master instance boots first on deploy.

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -17,7 +17,6 @@
         string CrmClientId { get; }
         string CrmClientSecret { get; }
         string NotifyApiKey { get; }
-        string SharedSecret { get; }
         string GoogleApiKey { get; }
         bool IsMasterInstance { get; }
 

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -183,17 +183,6 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void SharedSecret_ReturnsCorrectly()
-        {
-            var previous = Environment.GetEnvironmentVariable("SHARED_SECRET");
-            Environment.SetEnvironmentVariable("SHARED_SECRET", "shared-secret");
-
-            _env.SharedSecret.Should().Be("shared-secret");
-
-            Environment.SetEnvironmentVariable("SHARED_SECRET", previous);
-        }
-
-        [Fact]
         public void GoogleApiKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");


### PR DESCRIPTION
The two API clients now use the new authentication method and the legacy `SHARED_SECRET` environment variable is no longer used. This commit removes the associated authentication code.