### PR TITLE
Refactor actions to exchange access tokens for candidate data

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -86,5 +86,31 @@ exchanged for your token matches the request payload here).",
 
             return Ok(new MailingListAddMember(candidate));
         }
+
+        [HttpPost]
+        [Route("members/exchange_access_token/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated MailingListAddMember for the candidate.",
+            Description = @"
+                Retrieves a pre-populated MailingListAddMember for the candidate. The `accessToken` is obtained from a 
+                `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+                exchanged for your token matches the request payload here).",
+            OperationId = "ExchangeAccessTokenForMailingListAddMember",
+            Tags = new[] { "Mailing List" })]
+        [ProducesResponseType(typeof(MailingListAddMember), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult ExchangeAccessTokenForMember(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new MailingListAddMember(candidate));
+        }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -82,5 +82,31 @@ exchanged for your token matches the request payload here).",
 
             return Ok(new TeacherTrainingAdviserSignUp(candidate));
         }
+
+        [HttpPost]
+        [Route("exchange_access_token/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate.",
+            Description = @"
+                Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate. The `accessToken` is obtained from a 
+                `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+                exchanged for your token matches the request payload here).",
+            OperationId = "ExchangeAccessTokenForTeacherTrainingAdviserSignUp",
+            Tags = new[] { "Teacher Training Adviser" })]
+        [ProducesResponseType(typeof(TeacherTrainingAdviserSignUp), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult ExchangeAccessToken(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new TeacherTrainingAdviserSignUp(candidate));
+        }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -148,6 +148,32 @@ exchanged for your token matches the request payload here).",
             return Ok(new TeachingEventAddAttendee(candidate));
         }
 
+        [HttpPost]
+        [Route("attendees/exchange_access_token/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated TeachingEventAddAttendee for the candidate.",
+            Description = @"
+                Retrieves a pre-populated TeachingEventAddAttendee for the candidate. The `accessToken` is obtained from a 
+                `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+                exchanged for your token matches the request payload here).",
+            OperationId = "ExchangeAccessTokenForTeachingEventAddAttendee",
+            Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(TeachingEventAddAttendee), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult ExchangeAccessTokenForAttendee(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new TeachingEventAddAttendee(candidate));
+        }
+
         private static IEnumerable<TeachingEventsByType> GroupTeachingEventsByType(
             IEnumerable<TeachingEvent> teachingEvents,
             int quantityPerType)

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -71,6 +71,42 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void ExchangeAccessTokenForMember_MissingCandidate_RespondsWithUnauthorized()
+        {
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.ExchangeAccessTokenForMember("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessTokenForMember_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
+
+            var response = _controller.ExchangeAccessTokenForMember("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessTokenForMember_ValidToken_RespondsWithMailingListAddMember()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.ExchangeAccessTokenForMember("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as MailingListAddMember;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
         public void GetMember_MissingCandidate_RespondsWithUnauthorized()
         {
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -81,6 +81,42 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
+        public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_ValidToken_RespondsWithTeacherTrainingAdviserSignUp()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as TeacherTrainingAdviserSignUp;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_MissingCandidate_RespondsWithUnauthorized()
+        {
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
         public void SignUp_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new TeacherTrainingAdviserSignUp { Email = "invalid-email@" };

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -191,6 +191,42 @@ namespace GetIntoTeachingApiTests.Controllers
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
+        [Fact]
+        public void ExchangeAccessTokenForAttendee_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
+
+            var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessTokenForAttendee_ValidToken_RespondsWithTeachingEventAddAttendee()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as TeachingEventAddAttendee;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void ExchangeAccessTokenForAttendee_MissingCandidate_RespondsWithUnauthorized()
+        {
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
         private static IEnumerable<TeachingEvent> MockEvents()
         {
             var event1 = new TeachingEvent() { Name = "Event 1", TypeId = 123 };


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the first step of migrating existing candidates onto the new privacy policy via a mailing list sign up in the GiT app:

- [x] Refactor existing endpoints to exchange access tokens for candidate data
- [ ] Add new magic link token endpoints (creating tokens and exchanging for mailing list candidate data)
- [ ] Expire magic link tokens after 48 hours and ensure they are only single-use tokens. Write to field indicating when token is required/set.
- [ ] Add an API client for the CRM with access to the magic link generation endpoint
- [ ] Update the GiT app to handle mailing list sign up via magic links
- [ ] Handle scenario where a user clicks on an expired magic link

---

We currently only have one way of the API clients obtaining candidate data, which is by exchanging a user-generated access token for a resource (pre-filled mailing list/tta/event sign up):

```
POST /path/to/resource/{accessToken}
```

Going forward we are also going to support 'magic links' as a way of authenticating users. To that end, the endpoints are being refactored so we will ultimately be left with:

```
POST /path/to/resource/exchange_access_token/{accessToken}
POST /path/to/resource/exchange_magic_link_token/{magicLinkToken}
```

This PR adds in the `/path/to/resource/exchange_access_token/{accessToken}` endpoint and leaves the current endpoint in for backwards-compatibility. Once this is merged down the clients can be updated and the original endpoint removed.