### PR TITLE
Initial support for magic link tokens

### DIFF
--- a/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
@@ -9,12 +9,14 @@ namespace GetIntoTeachingApi.Attributes
         public string Name { get; }
         public Type Type { get; }
         public string Reference { get; }
+        public bool Transient { get; }
 
-        public EntityFieldAttribute(string name, Type type = null, string reference = null)
+        public EntityFieldAttribute(string name, Type type = null, string reference = null, bool transient = false)
         {
             Name = name;
             Type = type;
             Reference = reference;
+            Transient = transient;
         }
 
         public IDictionary<string, string> ToDictionary()

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -15,18 +18,26 @@ namespace GetIntoTeachingApi.Controllers
     [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser")]
     public class CandidatesController : ControllerBase
     {
-        private readonly ICandidateAccessTokenService _tokenService;
+        private const int MaximumMagicLinkTokensPerBatch = 25;
+
+        private readonly ICandidateAccessTokenService _accessTokenService;
+        private readonly ICandidateMagicLinkTokenService _magicLinkTokenService;
         private readonly INotifyService _notifyService;
         private readonly ICrmService _crm;
+        private readonly IBackgroundJobClient _jobClient;
 
         public CandidatesController(
-            ICandidateAccessTokenService tokenService,
+            ICandidateAccessTokenService accessTokenService,
+            ICandidateMagicLinkTokenService magicLinkTokenService,
             INotifyService notifyService,
-            ICrmService crm)
+            ICrmService crm,
+            IBackgroundJobClient jobClient)
         {
-            _tokenService = tokenService;
+            _accessTokenService = accessTokenService;
+            _magicLinkTokenService = magicLinkTokenService;
             _notifyService = notifyService;
             _crm = crm;
+            _jobClient = jobClient;
         }
 
         [HttpPost]
@@ -34,9 +45,9 @@ namespace GetIntoTeachingApi.Controllers
         [SwaggerOperation(
             Summary = "Creates a candidate access token.",
             Description = @"
-Finds a candidate matching at least 3 of the provided CandidateAccessTokenRequest attributes (including email). 
-If a candidate is found, an access token (PIN code) will be sent to the candidate email address 
-that can then be used for verification.",
+                Finds a candidate matching at least 3 of the provided CandidateAccessTokenRequest attributes (including email). 
+                If a candidate is found, an access token (PIN code) will be sent to the candidate email address 
+                that can then be used for verification.",
             OperationId = "CreateCandidateAccessToken",
             Tags = new[] { "Candidates" })]
         [ProducesResponseType(204)]
@@ -55,11 +66,46 @@ that can then be used for verification.",
                 return NotFound();
             }
 
-            var token = _tokenService.GenerateToken(request, (Guid)candidate.Id);
+            var token = _accessTokenService.GenerateToken(request, (Guid)candidate.Id);
             var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
 
             // We respond immediately/assume this will be successful.
             _notifyService.SendEmailAsync(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);
+
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("magic_link_tokens")]
+        [SwaggerOperation(
+            Summary = "Creates a token for use in a magic link.",
+            Description = @"Creates a long-lived magic link token that can be exchanged for candidate information for up to 48 hours.
+                Magic link tokens are stored against the contact in Dynamics CRM and are issued to candidates by email.",
+            OperationId = "CreateCandidateMagicLinkToken",
+            Tags = new[] { "Candidates" })]
+        [ProducesResponseType(204)]
+        [ProducesResponseType(400)]
+        public IActionResult CreateMagicLinkToken([FromBody, SwaggerRequestBody("Candidate identifiers.", Required = true)] IEnumerable<Guid> candidateIds)
+        {
+            if (candidateIds.Count() > MaximumMagicLinkTokensPerBatch)
+            {
+                return BadRequest($"You can only generate {MaximumMagicLinkTokensPerBatch} magic link tokens per request.");
+            }
+
+            var candidates = _crm.GetCandidates(candidateIds);
+
+            if (candidates.Count() != candidateIds.Count())
+            {
+                var missingCandidateIds = candidateIds.Except(candidates.Select(c => (Guid)c.Id));
+
+                return BadRequest(new { message = "Candidate IDs could not be found.", missingCandidateIds });
+            }
+
+            foreach (var candidate in candidates)
+            {
+                _magicLinkTokenService.GenerateToken(candidate);
+                _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(candidate, null));
+            }
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -39,7 +39,7 @@ namespace GetIntoTeachingApi.Models
         public static EntityFieldAttribute EntityFieldAttribute(ICustomAttributeProvider property)
         {
             return (EntityFieldAttribute)property.GetCustomAttributes(false)
-                .FirstOrDefault(a => a.GetType() == typeof(EntityFieldAttribute));
+                .FirstOrDefault(a => a.GetType() == typeof(EntityFieldAttribute) && !((EntityFieldAttribute)a).Transient);
         }
 
         public static EntityRelationshipAttribute EntityRelationshipAttribute(ICustomAttributeProvider property)

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -168,6 +168,9 @@ namespace GetIntoTeachingApi.Models
         public bool? OptOutOfGdpr { get; set; } = false;
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
+        [EntityField("dfe_websitemltoken", null, null, true)]
+        public string MagicLinkToken { get; set; }
+        public DateTime? MagicLinkTokenCreatedAt { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }

--- a/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CandidateMagicLinkTokenService : ICandidateMagicLinkTokenService
+    {
+        private readonly ICrmService _crm;
+        private readonly RNGCryptoServiceProvider _cryptoService;
+
+        public CandidateMagicLinkTokenService(ICrmService crm)
+        {
+            _cryptoService = new RNGCryptoServiceProvider();
+            _crm = crm;
+        }
+
+        public void GenerateToken(Candidate candidate)
+        {
+            candidate.MagicLinkToken = CreateToken();
+            candidate.MagicLinkTokenCreatedAt = DateTime.UtcNow;
+        }
+
+        public Candidate Exchange(string token)
+        {
+            var matchingCandidates = _crm.MatchCandidates(token);
+
+            // Return null if there are no matches and also in the very
+            // unlikely case a token has been duplicated.
+            if (matchingCandidates.Count() != 1)
+            {
+                return null;
+            }
+
+            return matchingCandidates.First();
+        }
+
+        private string CreateToken()
+        {
+            byte[] bytes = new byte[16];
+            _cryptoService.GetBytes(bytes);
+
+            return BitConverter.ToString(bytes).Replace("-", string.Empty);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/ICandidateMagicLinkTokenService.cs
@@ -1,0 +1,10 @@
+﻿using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICandidateMagicLinkTokenService
+    {
+        void GenerateToken(Candidate candidate);
+        Candidate Exchange(string token);
+    }
+}

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -13,7 +13,9 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PickListItem> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
+        IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
+        IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);
         IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -67,6 +67,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<INotificationClientAdapter, NotificationClientAdapter>();
             services.AddSingleton<IGeocodeClientAdapter, GeocodeClientAdapter>();
             services.AddSingleton<ICandidateAccessTokenService, CandidateAccessTokenService>();
+            services.AddSingleton<ICandidateMagicLinkTokenService, CandidateMagicLinkTokenService>();
             services.AddSingleton<INotifyService, NotifyService>();
             services.AddSingleton<IClientManager, ClientManager>();
             services.AddSingleton<IHangfireService, HangfireService>();

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -9,22 +9,36 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using GetIntoTeachingApi.Attributes;
 using System;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using GetIntoTeachingApi.Jobs;
+using System.Linq;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
     public class CandidatesControllerTests
     {
-        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<ICandidateAccessTokenService> _mockAccessTokenService;
+        private readonly Mock<ICandidateMagicLinkTokenService> _mockMagicLinkTokenService;
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly CandidatesController _controller;
 
         public CandidatesControllerTests()
         {
-            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockAccessTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockMagicLinkTokenService = new Mock<ICandidateMagicLinkTokenService>() { CallBase = true };
             _mockNotifyService = new Mock<INotifyService>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockCrm = new Mock<ICrmService>();
-            _controller = new CandidatesController(_mockTokenService.Object, _mockNotifyService.Object, _mockCrm.Object);
+            _controller = new CandidatesController(
+                _mockAccessTokenService.Object,
+                _mockMagicLinkTokenService.Object,
+                _mockNotifyService.Object,
+                _mockCrm.Object,
+                _mockJobClient.Object);
         }
 
         [Fact]
@@ -57,7 +71,7 @@ namespace GetIntoTeachingApiTests.Controllers
         {
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             var candidate = new Candidate { Id = Guid.NewGuid(), Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
-            _mockTokenService.Setup(mock => mock.GenerateToken(request, (Guid)candidate.Id)).Returns("123456");
+            _mockAccessTokenService.Setup(mock => mock.GenerateToken(request, (Guid)candidate.Id)).Returns("123456");
             _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns(candidate);
 
             var response = _controller.CreateAccessToken(request);
@@ -86,6 +100,53 @@ namespace GetIntoTeachingApiTests.Controllers
                 mock.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>()),
                 Times.Never()
             );
+        }
+
+        [Fact]
+        public void CreateMagicLinkToken_TooManyCandidates_RespondsWithBadRequest()
+        {
+            var candidateIds = new Guid[26];
+
+            var response = _controller.CreateMagicLinkToken(candidateIds);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            badRequest.Value.Should().Be("You can only generate 25 magic link tokens per request.");
+        }
+
+        [Fact]
+        public void CreateMagicLinkToken_MissingCandidateId_RespondsWithBadRequest()
+        {
+            var foundCandidateId = Guid.NewGuid();
+            var missingCandidateId = Guid.NewGuid();
+            var candidates = new List<Candidate>() { new Candidate() { Id = foundCandidateId } };
+            var candidate = candidates.First();
+            var candidateIds = new Guid[] { foundCandidateId, missingCandidateId };
+            _mockCrm.Setup(m => m.GetCandidates(candidateIds)).Returns(candidates);
+
+            var response = _controller.CreateMagicLinkToken(candidateIds);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            badRequest.Value.Should().BeEquivalentTo(new { message = "Candidate IDs could not be found.", missingCandidateIds = new Guid[] { missingCandidateId } });
+        }
+
+        [Fact]
+        public void CreateMagicLinkToken_WithValidCandidateIds_GeneratesMagicLinkTokensAndUpdatesCandidate()
+        {
+            var candidates = new List<Candidate>() { new Candidate() { Id = Guid.NewGuid() } };
+            var candidate = candidates.First();
+            var candidateIds = candidates.Select(c => (Guid)c.Id);
+            _mockCrm.Setup(m => m.GetCandidates(candidateIds)).Returns(candidates);
+
+            var response = _controller.CreateMagicLinkToken(candidateIds);
+
+            response.Should().BeOfType<NoContentResult>();
+
+            _mockMagicLinkTokenService.Verify(m => m.GenerateToken(candidate));
+
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                candidate == (Candidate)job.Args[0]),
+                It.IsAny<EnqueuedState>()));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Mocks/Models.cs
+++ b/GetIntoTeachingApiTests/Mocks/Models.cs
@@ -16,6 +16,8 @@ namespace GetIntoTeachingApiTests.Mocks
         public int? Field2 { get; set; }
         [EntityField("dfe_field3")]
         public string Field3 { get; set; }
+        [EntityField("dfe_field4", null, null, true)]
+        public string Field4 { get; set; }
         [EntityRelationship("dfe_mock_dfe_relatedmock_mock", typeof(MockRelatedModel))]
         public MockRelatedModel RelatedMock { get; set; }
         [EntityRelationship("dfe_mock_dfe_relatedmock_mocks", typeof(MockRelatedModel))]

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -37,6 +37,13 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void EntityFieldAttribute_OnPropertyWithTransientAttribute_ReturnsNull()
+        {
+            var property = typeof(MockModel).GetProperty("Field4");
+            BaseModel.EntityFieldAttribute(property).Should().BeNull();
+        }
+
+        [Fact]
         public void EntityFieldAttribute_OnPropertyWithoutAttribute_ReturnsNull()
         {
             var property = typeof(MockModel).GetProperty("RelatedMock");

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -88,6 +88,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TeacherId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_dfesnumber");
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
+            type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken" && a.Transient);
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));

--- a/GetIntoTeachingApiTests/Models/MappingInfoTests.cs
+++ b/GetIntoTeachingApiTests/Models/MappingInfoTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class CandidateMagicLinkTokenServiceTests
+    {
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly CandidateMagicLinkTokenService _service;
+
+        public CandidateMagicLinkTokenServiceTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _service = new CandidateMagicLinkTokenService(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void GenerateTokens_WithCandidates_SetsTokenAndCreatedAt()
+        {
+            var candidate = new Candidate();
+
+            _service.GenerateToken(candidate);
+
+            candidate.MagicLinkToken.Should().NotBeNull();
+            candidate.MagicLinkToken.Length.Should().Be(32);
+            candidate.MagicLinkTokenCreatedAt.Should().BeCloseTo(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void GenerateTokens_WhenCalledMultipleTimes_CreatesUniqueTokens()
+        {
+            var candidate = new Candidate();
+            var tokens = new List<string>();
+
+            _service.GenerateToken(candidate);
+            tokens.Add(candidate.MagicLinkToken);
+            _service.GenerateToken(candidate);
+            tokens.Add(candidate.MagicLinkToken);
+            _service.GenerateToken(candidate);
+            tokens.Add(candidate.MagicLinkToken);
+
+            tokens.Should().OnlyHaveUniqueItems();
+        }
+
+        [Fact]
+        public void Exchange_WithValidToken_ReturnsCandidate()
+        {
+            var candidate = new Candidate();
+            var token = Guid.NewGuid().ToString();
+            _mockCrm.Setup(m => m.MatchCandidates(token)).Returns(new Candidate[] { candidate });
+
+            var result = _service.Exchange(token);
+
+            result.Should().Be(candidate);
+        }
+
+        [Fact]
+        public void Exchange_WhenTokenMatchesMultipleCandidates_ReturnsNull()
+        {
+            var candidates = new List<Candidate>() { new Candidate(), new Candidate() };
+            var token = Guid.NewGuid().ToString();
+            _mockCrm.Setup(m => m.MatchCandidates(token)).Returns(candidates);
+
+            var result = _service.Exchange(token);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void Exchange_WhenTokenDoesNotMatch_ReturnsNull()
+        {
+            var token = Guid.NewGuid().ToString();
+            _mockCrm.Setup(m => m.MatchCandidates(token)).Returns(new Candidate[0]);
+
+            var result = _service.Exchange(token);
+
+            result.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the second step of migrating existing candidates onto the new privacy policy via a mailing list sign up in the GiT app:

- [x] Refactor existing endpoints to exchange access tokens for candidate data
- [x] Add new magic link token endpoints (creating tokens and exchanging for mailing list candidate data)
- [ ] Expire magic link tokens after 48 hours and ensure they are only single-use tokens. Write to field indicating when token is generated/used.
- [ ] Add CRM client and restrict access to magic link generation endpoint. 
- [ ] Add job to process pending magic link generations. Connect models to CRM attributes (need CRM changes in prod first)
- [ ] Update the GiT app to handle mailing list sign up via magic links
- [ ] Handle scenario where a user clicks on an expired magic link

---

- Add magic link token fields to candidate

Add a field to store a magic link token against a candidate and the datetime that the token was created, so that we can enforce token expiry.

Only the token field itself is mapped to the CRM for now; the others will be mapped later on.

So that we can deploy this to production the `EntityFieldAttribute` has been updated with an `Transient` option. If set, the `BaseModel` will not map the fields to/from CRM `Entity` objects. This means we can safely deploy without the CRM having been updated to include the new field.

- Update CrmService to support magic links

We need to be able to query multiple candidates by their id from the CRM, so that we can bulk-process the magic link token generation (the CRM will be sending emails to thousands of candidates).

In addition, we need to be able to take a magic link from a request and find the corresponding candidate record. This method returns a collection of candidates in the edge case that a magic link has been duplicated during generation or when a contact record has been copied in the CRM. It has a null/empty string guard statement to ensure potentially expensive queries are avoided (most contacts _won't_ have a magic link token set).

- Add magic link token generator service

Add a service to generate secure, random 128 bit magic link tokens. It also has a method that will exchange a valid token for the associated `Candidate` record.

In the unlikely event that two candidates have been assigned the same magic link token, the service will return `null` (ultimately forcing a re-generation of the token for that candidate).

- Add endpoint to generate candidate magic link tokens

Introduce a new endpoint that will enable the CRM to batch-generate magic links for candidates.

- Exchange magic link token for a prefilled MailingListAddMember

Adds an endpoint that accepts a valid magic link token and returns a pre-filled `MailingListAddMember` model.