### PR TITLE
Remove deprecated access token endpoints

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -62,32 +62,6 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpPost]
-        [Route("members/{accessToken}")]
-        [SwaggerOperation(
-            Summary = "Retrieves a pre-populated MailingListAddMember for the candidate.",
-            Description = @"
-Retrieves a pre-populated MailingListAddMember for the candidate. The `accessToken` is obtained from a 
-`POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
-exchanged for your token matches the request payload here).",
-            OperationId = "GetPreFilledMailingListAddMember",
-            Tags = new[] { "Mailing List" })]
-        [ProducesResponseType(typeof(MailingListAddMember), 200)]
-        [ProducesResponseType(404)]
-        public IActionResult GetMember(
-            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
-            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
-        {
-            var candidate = _crm.MatchCandidate(request);
-
-            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
-            {
-                return Unauthorized();
-            }
-
-            return Ok(new MailingListAddMember(candidate));
-        }
-
-        [HttpPost]
         [Route("members/exchange_access_token/{accessToken}")]
         [SwaggerOperation(
             Summary = "Retrieves a pre-populated MailingListAddMember for the candidate.",

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -58,32 +58,6 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         }
 
         [HttpPost]
-        [Route("{accessToken}")]
-        [SwaggerOperation(
-            Summary = "Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate.",
-            Description = @"
-Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate. The `accessToken` is obtained from a 
-`POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
-exchanged for your token matches the request payload here).",
-            OperationId = "GetPreFilledTeacherTrainingAdviserSignUp",
-            Tags = new[] { "Teacher Training Adviser" })]
-        [ProducesResponseType(typeof(TeacherTrainingAdviserSignUp), 200)]
-        [ProducesResponseType(404)]
-        public IActionResult Get(
-            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
-            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
-        {
-            var candidate = _crm.MatchCandidate(request);
-
-            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
-            {
-                return Unauthorized();
-            }
-
-            return Ok(new TeacherTrainingAdviserSignUp(candidate));
-        }
-
-        [HttpPost]
         [Route("exchange_access_token/{accessToken}")]
         [SwaggerOperation(
             Summary = "Retrieves a pre-populated TeacherTrainingAdviserSignUp for the candidate.",

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -123,32 +123,6 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpPost]
-        [Route("attendees/{accessToken}")]
-        [SwaggerOperation(
-            Summary = "Retrieves a pre-populated TeachingEventAddAttendee for the candidate.",
-            Description = @"
-Retrieves a pre-populated TeachingEventAddAttendee for the candidate. The `accessToken` is obtained from a 
-`POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
-exchanged for your token matches the request payload here).",
-            OperationId = "GetPreFilledTeachingEventAddAttendee",
-            Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(TeachingEventAddAttendee), 200)]
-        [ProducesResponseType(404)]
-        public IActionResult GetAttendee(
-            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
-            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
-        {
-            var candidate = _crm.MatchCandidate(request);
-
-            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
-            {
-                return Unauthorized();
-            }
-
-            return Ok(new TeachingEventAddAttendee(candidate));
-        }
-
-        [HttpPost]
         [Route("attendees/exchange_access_token/{accessToken}")]
         [SwaggerOperation(
             Summary = "Retrieves a pre-populated TeachingEventAddAttendee for the candidate.",

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -45,32 +45,6 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetMember_InvalidAccessToken_RespondsWithUnauthorized()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
-
-            var response = _controller.GetMember("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
-        }
-
-        [Fact]
-        public void GetMember_ValidToken_RespondsWithMailingListAddMember()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-
-            var response = _controller.GetMember("000000", _request);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var responseModel = ok.Value as MailingListAddMember;
-            responseModel.CandidateId.Should().Be(candidate.Id);
-        }
-
-        [Fact]
         public void ExchangeAccessTokenForMember_MissingCandidate_RespondsWithUnauthorized()
         {
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
@@ -104,16 +78,6 @@ namespace GetIntoTeachingApiTests.Controllers
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as MailingListAddMember;
             responseModel.CandidateId.Should().Be(candidate.Id);
-        }
-
-        [Fact]
-        public void GetMember_MissingCandidate_RespondsWithUnauthorized()
-        {
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
-
-            var response = _controller.GetMember("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -45,42 +45,6 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Get_InvalidAccessToken_RespondsWithUnauthorized()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
-
-            var response = _controller.Get("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
-        }
-
-        [Fact]
-        public void Get_ValidToken_RespondsWithTeacherTrainingAdviserSignUp()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-
-            var response = _controller.Get("000000", _request);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var responseModel = ok.Value as TeacherTrainingAdviserSignUp;
-            responseModel.CandidateId.Should().Be(candidate.Id);
-        }
-
-        [Fact]
-        public void Get_MissingCandidate_RespondsWithUnauthorized()
-        {
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
-
-            var response = _controller.Get("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
-        }
-
-        [Fact]
         public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -156,42 +156,6 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void GetAttendee_InvalidAccessToken_RespondsWithUnauthorized()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
-
-            var response = _controller.GetAttendee("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
-        }
-
-        [Fact]
-        public void GetAttendee_ValidToken_RespondsWithTeachingEventAddAttendee()
-        {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
-            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
-
-            var response = _controller.GetAttendee("000000", _request);
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            var responseModel = ok.Value as TeachingEventAddAttendee;
-            responseModel.CandidateId.Should().Be(candidate.Id);
-        }
-
-        [Fact]
-        public void GetAttendee_MissingCandidate_RespondsWithUnauthorized()
-        {
-            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
-
-            var response = _controller.GetAttendee("000000", _request);
-
-            response.Should().BeOfType<UnauthorizedResult>();
-        }
-
-        [Fact]
         public void ExchangeAccessTokenForAttendee_InvalidAccessToken_RespondsWithUnauthorized()
         {
             var candidate = new Candidate { Id = Guid.NewGuid() };


### PR DESCRIPTION
These access token endpoints have been replaced with new endpoints in the format `/path/to/resource/exchange_access_token/{accessToken}`. The API clients have been updated so they can safely be removed.