### PR TITLE
Moved Service Plan Definitions to Variables

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,6 +1,6 @@
 locals {
   environment_map = { DATABASE_INSTANCE_NAME = cloudfoundry_service_instance.postgres2.name,
-                      HANGFIRE_INSTANCE_NAME = cloudfoundry_service_instance.hangfire.name }
+  HANGFIRE_INSTANCE_NAME = cloudfoundry_service_instance.hangfire.name }
 }
 
 resource "cloudfoundry_app" "api_application" {

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -15,7 +15,7 @@ data azurerm_key_vault_secret monitoring {
 
 locals {
   application_secrets = yamldecode(data.azurerm_key_vault_secret.application.value)
-  monitoring_secrets = yamldecode(data.azurerm_key_vault_secret.monitoring.value)
+  monitoring_secrets  = yamldecode(data.azurerm_key_vault_secret.monitoring.value)
 }
 
 data azurerm_key_vault_secret docker_username {

--- a/terraform/paas/services.tf
+++ b/terraform/paas/services.tf
@@ -14,13 +14,13 @@ data cloudfoundry_service mysql {
 resource "cloudfoundry_service_instance" "hangfire" {
   name         = var.paas_database_1_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.postgres.service_plans["small-11"]
+  service_plan = data.cloudfoundry_service.postgres.service_plans[var.postgres_service_plan]
 }
 
 resource "cloudfoundry_service_instance" "postgres2" {
   name         = var.paas_database_2_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.postgres.service_plans["small-11"]
+  service_plan = data.cloudfoundry_service.postgres.service_plans[var.postgres_service_plan]
   json_params  = "{\"enable_extensions\": [\"postgis\"] }"
 }
 
@@ -34,7 +34,7 @@ resource "cloudfoundry_user_provided_service" "logging" {
 resource "cloudfoundry_service_instance" "redis" {
   name         = var.paas_redis_1_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.redis.service_plans["small-ha-5_x"]
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
   json_params  = "{\"maxmemory_policy\": \"allkeys-lfu\" }"
 }
 

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -29,6 +29,14 @@ variable "application_memory" {
   default = "1024"
 }
 
+variable "postgres_service_plan" {
+  default = "small-11"
+}
+
+variable "redis_service_plan" {
+  default = "small-ha-5_x"
+}
+
 variable "application_disk" {
   default = "1024"
 }

--- a/tests/manual/testAlert.sh
+++ b/tests/manual/testAlert.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+name=$RANDOM
+name=STEVE
+url='https://alertmanager-dev-get-into-teaching.london.cloudapps.digital:/api/v1/alerts'
+
+echo "firing up alert $name" 
+
+# change url o
+curl -XPOST $url -d "[{ 
+	\"status\": \"firing\",
+	\"labels\": {
+		\"severity\":\"medium\"
+	},
+	\"annotations\": {
+		\"summary\": \"This is a test of the alerting system on development, this test can be ignored.\",
+		\"runbook\": \"https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2152595459/Test+Page\",
+		\"dashboard\": \"https://grafana-dev-get-into-teaching.london.cloudapps.digital/d/qZjcqcpGz/csp-violations?orgId=1\",
+		\"description\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\"
+	},
+	\"generatorURL\": \"http://prometheus.int.example.net/${name}\"
+}]"
+


### PR DESCRIPTION
Moved the Service plan definitions to variables, so they can be
overwritten in the environment variable settings if required.

carried out a terraform fmt

Kept the testAlerts.sh test script for future use