### PR TITLE
Expire magic link tokens after 48hrs/first use

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -116,6 +116,11 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(new { Message = "Magic link token has expired.", Status = "Expired" });
             }
 
+            if (candidate.MagicLinkTokenAlreadyExchanged())
+            {
+                return BadRequest(new { Message = "Magic link token has already been exchanged.", Status = "AlreadyExchanged" });
+            }
+
             return Ok(new MailingListAddMember(candidate));
         }
     }

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -108,7 +108,12 @@ namespace GetIntoTeachingApi.Controllers
 
             if (candidate == null)
             {
-                return Unauthorized();
+                return BadRequest(new { Message = "Magic link token is not valid.", Status = "Invalid" });
+            }
+
+            if (candidate.MagicLinkTokenExpired())
+            {
+                return BadRequest(new { Message = "Magic link token has expired.", Status = "Expired" });
             }
 
             return Ok(new MailingListAddMember(candidate));

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -97,31 +97,21 @@ namespace GetIntoTeachingApi.Controllers
             Description = @"
                 Retrieves a pre-populated MailingListAddMember for the candidate. The `magicLinkToken` is obtained from a 
                 `POST /candidates/magic_link_tokens` request.",
-            OperationId = "ExchangeMailingListTokenForMailingListAddMember",
+            OperationId = "ExchangeMagicLinkTokenForMailingListAddMember",
             Tags = new[] { "Mailing List" })]
         [ProducesResponseType(typeof(MailingListAddMember), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(CandidateMagicLinkExchangeResult), 401)]
         public IActionResult ExchangeMagicLinkTokenForMember(
             [FromRoute, SwaggerParameter("Magic link token.", Required = true)] string magicLinkToken)
         {
-            var candidate = _magicLinkTokenService.Exchange(magicLinkToken);
+            var result = _magicLinkTokenService.Exchange(magicLinkToken);
 
-            if (candidate == null)
+            if (!result.Success)
             {
-                return BadRequest(new { Message = "Magic link token is not valid.", Status = "Invalid" });
+                return Unauthorized(result);
             }
 
-            if (candidate.MagicLinkTokenExpired())
-            {
-                return BadRequest(new { Message = "Magic link token has expired.", Status = "Expired" });
-            }
-
-            if (candidate.MagicLinkTokenAlreadyExchanged())
-            {
-                return BadRequest(new { Message = "Magic link token has already been exchanged.", Status = "AlreadyExchanged" });
-            }
-
-            return Ok(new MailingListAddMember(candidate));
+            return Ok(new MailingListAddMember(result.Candidate));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -170,7 +170,7 @@ namespace GetIntoTeachingApi.Models
         public bool IsNewRegistrant { get; set; }
         [EntityField("dfe_websitemltoken", null, null, true)]
         public string MagicLinkToken { get; set; }
-        public DateTime? MagicLinkTokenCreatedAt { get; set; }
+        public DateTime? MagicLinkTokenExpiresAt { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }
@@ -267,6 +267,8 @@ namespace GetIntoTeachingApi.Models
         {
             return new[] { PlanningToRetakeGcseMathsId, PlanningToRetakeGcseEnglishId }.All(g => g == (int)GcseStatus.HasOrIsPlanningOnRetaking);
         }
+
+        public bool MagicLinkTokenExpired() => MagicLinkTokenExpiresAt == null || MagicLinkTokenExpiresAt < DateTime.UtcNow;
 
         protected override bool ShouldMap(ICrmService crm)
         {

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -87,6 +87,13 @@ namespace GetIntoTeachingApi.Models
             NotAnswered = 222750001,
         }
 
+        public enum MagicLinkTokenStatus
+        {
+            Pending = 222750002,
+            Generated = 222750003,
+            Exchanged = 222750004,
+        }
+
         public string FullName => $"{this.FirstName} {this.LastName}";
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
@@ -128,6 +135,8 @@ namespace GetIntoTeachingApi.Models
         public int? PreferredContactMethodId { get; set; } = (int)ContactMethod.Any;
         [EntityField("msgdpr_gdprconsent", typeof(OptionSetValue))]
         public int? GdprConsentId { get; set; } = (int)GdprConsent.Consent;
+        [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue), null, true)]
+        public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("emailaddress1")]
@@ -170,6 +179,7 @@ namespace GetIntoTeachingApi.Models
         public bool IsNewRegistrant { get; set; }
         [EntityField("dfe_websitemltoken", null, null, true)]
         public string MagicLinkToken { get; set; }
+        [EntityField("dfe_websitemltokenexpirydate", null, null, true)]
         public DateTime? MagicLinkTokenExpiresAt { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]
@@ -269,6 +279,7 @@ namespace GetIntoTeachingApi.Models
         }
 
         public bool MagicLinkTokenExpired() => MagicLinkTokenExpiresAt == null || MagicLinkTokenExpiresAt < DateTime.UtcNow;
+        public bool MagicLinkTokenAlreadyExchanged() => MagicLinkTokenStatusId == (int)MagicLinkTokenStatus.Exchanged;
 
         protected override bool ShouldMap(ICrmService crm)
         {

--- a/GetIntoTeachingApi/Models/CandidateMagicLinkExchangeResult.cs
+++ b/GetIntoTeachingApi/Models/CandidateMagicLinkExchangeResult.cs
@@ -1,0 +1,42 @@
+﻿using System.Text.Json.Serialization;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateMagicLinkExchangeResult
+    {
+        public enum ExchangeStatus
+        {
+            Valid,
+            Invalid,
+            Expired,
+            AlreadyExchanged,
+        }
+
+        public bool Success => Status == ExchangeStatus.Valid;
+        [JsonIgnore]
+        public Candidate Candidate { get; }
+        public ExchangeStatus Status { get; }
+
+        public CandidateMagicLinkExchangeResult(Candidate candidate)
+        {
+            Candidate = candidate;
+
+            if (Candidate == null)
+            {
+                Status = ExchangeStatus.Invalid;
+            }
+            else if (Candidate.MagicLinkTokenAlreadyExchanged())
+            {
+                Status = ExchangeStatus.AlreadyExchanged;
+            }
+            else if (Candidate.MagicLinkTokenExpired())
+            {
+                Status = ExchangeStatus.Expired;
+            }
+            else
+            {
+                Status = ExchangeStatus.Valid;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/OperationFilters/AuthOperationFilter.cs
+++ b/GetIntoTeachingApi/OperationFilters/AuthOperationFilter.cs
@@ -18,6 +18,13 @@ namespace GetIntoTeachingApi.OperationFilters
                 return;
             }
 
+            var authAttributeAlreadyPresent = operation.Responses.Any(r => r.Key == "401");
+
+            if (authAttributeAlreadyPresent)
+            {
+                return;
+            }
+
             operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
             operation.Security = new List<OpenApiSecurityRequirement>
             {

--- a/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
@@ -7,6 +7,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class CandidateMagicLinkTokenService : ICandidateMagicLinkTokenService
     {
+        public static readonly TimeSpan TokenTimeSpan = new TimeSpan(48, 0, 0);
         private readonly ICrmService _crm;
         private readonly RNGCryptoServiceProvider _cryptoService;
 
@@ -19,7 +20,7 @@ namespace GetIntoTeachingApi.Services
         public void GenerateToken(Candidate candidate)
         {
             candidate.MagicLinkToken = CreateToken();
-            candidate.MagicLinkTokenCreatedAt = DateTime.UtcNow;
+            candidate.MagicLinkTokenExpiresAt = DateTime.UtcNow.AddHours(TokenTimeSpan.TotalHours);
         }
 
         public Candidate Exchange(string token)

--- a/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
@@ -24,7 +24,7 @@ namespace GetIntoTeachingApi.Services
             candidate.MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Generated;
         }
 
-        public Candidate Exchange(string token)
+        public CandidateMagicLinkExchangeResult Exchange(string token)
         {
             var matchingCandidates = _crm.MatchCandidates(token);
 
@@ -32,14 +32,15 @@ namespace GetIntoTeachingApi.Services
             // unlikely case a token has been duplicated.
             if (matchingCandidates.Count() != 1)
             {
-                return null;
+                return new CandidateMagicLinkExchangeResult(null);
             }
 
             var candidate = matchingCandidates.First();
+            var result = new CandidateMagicLinkExchangeResult(candidate);
 
             candidate.MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Exchanged;
 
-            return candidate;
+            return result;
         }
 
         private string CreateToken()

--- a/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
@@ -21,6 +21,7 @@ namespace GetIntoTeachingApi.Services
         {
             candidate.MagicLinkToken = CreateToken();
             candidate.MagicLinkTokenExpiresAt = DateTime.UtcNow.AddHours(TokenTimeSpan.TotalHours);
+            candidate.MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Generated;
         }
 
         public Candidate Exchange(string token)
@@ -34,7 +35,11 @@ namespace GetIntoTeachingApi.Services
                 return null;
             }
 
-            return matchingCandidates.First();
+            var candidate = matchingCandidates.First();
+
+            candidate.MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Exchanged;
+
+            return candidate;
         }
 
         private string CreateToken()

--- a/GetIntoTeachingApi/Services/ICandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/ICandidateMagicLinkTokenService.cs
@@ -5,6 +5,6 @@ namespace GetIntoTeachingApi.Services
     public interface ICandidateMagicLinkTokenService
     {
         void GenerateToken(Candidate candidate);
-        Candidate Exchange(string token);
+        CandidateMagicLinkExchangeResult Exchange(string token);
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -124,6 +124,24 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public void ExchangeMagicLinkTokenForMember_TokenAlreadyExchanged_RespondsWithBadRequest()
+        {
+            var candidate = new Candidate
+            {
+                Id = Guid.NewGuid(),
+                MagicLinkToken = Guid.NewGuid().ToString(),
+                MagicLinkTokenExpiresAt = DateTime.UtcNow.AddMinutes(1),
+                MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Exchanged
+            };
+            _mockMagicLinkTokenService.Setup(m => m.Exchange(candidate.MagicLinkToken)).Returns(candidate);
+
+            var response = _controller.ExchangeMagicLinkTokenForMember(candidate.MagicLinkToken);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            badRequest.Value.Should().BeEquivalentTo(new { Message = "Magic link token has already been exchanged.", Status = "AlreadyExchanged" });
+        }
+
+        [Fact]
         public void AddMember_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new MailingListAddMember() { FirstName = null };

--- a/GetIntoTeachingApiTests/Models/CandidateMagicLinkExchangeResultTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateMagicLinkExchangeResultTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Xunit;
+using static GetIntoTeachingApi.Models.CandidateMagicLinkExchangeResult;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateMagicLinkExchangeResultTests
+    {
+        [Fact]
+        public void Status_WithNullCandidate_ReturnsInvalid()
+        {
+            var result = new CandidateMagicLinkExchangeResult(null);
+
+            result.Status.Should().Be(ExchangeStatus.Invalid);
+        }
+
+        [Fact]
+        public void Status_WhenCandidateHasExpiredToken_ReturnsExpired()
+        {
+            var candidate = new Candidate() { MagicLinkTokenExpiresAt = DateTime.UtcNow.AddMinutes(-1) };
+
+            var result = new CandidateMagicLinkExchangeResult(candidate);
+
+            result.Status.Should().Be(ExchangeStatus.Expired);
+        }
+
+        [Fact]
+        public void Status_WhenCandidateHasAlreadyExchangedToken_ReturnsAlreadyExchanged()
+        {
+            var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Exchanged };
+
+            var result = new CandidateMagicLinkExchangeResult(candidate);
+
+            result.Status.Should().Be(ExchangeStatus.AlreadyExchanged);
+        }
+
+        [Fact]
+        public void Status_WhenCandidateHasValidToken_ReturnsValid()
+        {
+            var candidate = new Candidate() { MagicLinkTokenExpiresAt = DateTime.UtcNow.AddMinutes(1) };
+
+            var result = new CandidateMagicLinkExchangeResult(candidate);
+
+            result.Status.Should().Be(ExchangeStatus.Valid);
+        }
+
+        [Fact]
+        public void Success_WhenCandidateHasValidToken_ReturnsTrue()
+        {
+            var candidate = new Candidate() { MagicLinkTokenExpiresAt = DateTime.UtcNow.AddMinutes(1) };
+
+            var result = new CandidateMagicLinkExchangeResult(candidate);
+
+            result.Success.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Success_WhenCandidateHasInvalidToken_ReturnsFalse()
+        {
+            var result = new CandidateMagicLinkExchangeResult(null);
+
+            result.Success.Should().BeFalse();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -414,5 +414,38 @@ namespace GetIntoTeachingApiTests.Models
 
             candidate.IsReturningToTeaching().Should().BeFalse();
         }
+
+        [Fact]
+        public void MagicLinkTokenExpired_WhenNull_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                MagicLinkTokenExpiresAt = null
+            };
+
+            candidate.MagicLinkTokenExpired().Should().BeTrue();
+        }
+
+        [Fact]
+        public void MagicLinkTokenExpired_WhenExpiredInPast_ReturnsTrue()
+        {
+            var candidate = new Candidate
+            {
+                MagicLinkTokenExpiresAt = DateTime.UtcNow.AddSeconds(-5)
+            };
+
+            candidate.MagicLinkTokenExpired().Should().BeTrue();
+        }
+
+        [Fact]
+        public void MagicLinkTokenExpired_WhenExpiredInFuture_ReturnsFalse()
+        {
+            var candidate = new Candidate
+            {
+                MagicLinkTokenExpiresAt = DateTime.UtcNow.AddSeconds(5)
+            };
+
+            candidate.MagicLinkTokenExpired().Should().BeFalse();
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -60,6 +60,9 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_isadvisorrequiredos" && a.Type == typeof(OptionSetValue));
             type.GetProperty("GdprConsentId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue) && a.Transient);
+            
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
@@ -89,6 +92,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
             type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken" && a.Transient);
+            type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate" && a.Transient);
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));
@@ -446,6 +450,20 @@ namespace GetIntoTeachingApiTests.Models
             };
 
             candidate.MagicLinkTokenExpired().Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(Candidate.MagicLinkTokenStatus.Exchanged, true)]
+        [InlineData(Candidate.MagicLinkTokenStatus.Generated, false)]
+        [InlineData(null, false)]
+        public void MagicLinkTokenAlreadyExchanged_ReturnsCorrectly(Candidate.MagicLinkTokenStatus? status, bool expected)
+        {
+            var candidate = new Candidate
+            {
+                MagicLinkTokenStatusId = (int?)status,
+            };
+
+            candidate.MagicLinkTokenAlreadyExchanged().Should().Be(expected);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GenerateTokens_WithCandidates_SetsTokenAndExpiresAt()
+        public void GenerateTokens_WithCandidates_SetsTokenDetails()
         {
             var candidate = new Candidate();
 
@@ -29,6 +29,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate.MagicLinkToken.Should().NotBeNull();
             candidate.MagicLinkToken.Length.Should().Be(32);
             candidate.MagicLinkTokenExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddHours(48));
+            candidate.MagicLinkTokenStatusId.Should().Be((int)Candidate.MagicLinkTokenStatus.Generated);
         }
 
         [Fact]
@@ -48,7 +49,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void Exchange_WithValidToken_ReturnsCandidate()
+        public void Exchange_WithValidToken_ReturnsCandidateAndUpdatesStatus()
         {
             var candidate = new Candidate();
             var token = Guid.NewGuid().ToString();
@@ -57,6 +58,7 @@ namespace GetIntoTeachingApiTests.Services
             var result = _service.Exchange(token);
 
             result.Should().Be(candidate);
+            candidate.MagicLinkTokenStatusId.Should().Be((int)Candidate.MagicLinkTokenStatus.Exchanged);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GenerateTokens_WithCandidates_SetsTokenAndCreatedAt()
+        public void GenerateTokens_WithCandidates_SetsTokenAndExpiresAt()
         {
             var candidate = new Candidate();
 
@@ -28,7 +28,7 @@ namespace GetIntoTeachingApiTests.Services
 
             candidate.MagicLinkToken.Should().NotBeNull();
             candidate.MagicLinkToken.Length.Should().Be(32);
-            candidate.MagicLinkTokenCreatedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.MagicLinkTokenExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddHours(48));
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the third step of migrating existing candidates onto the new privacy policy via a mailing list sign up in the GiT app:

- [x] Refactor existing endpoints to exchange access tokens for candidate data
- [x] Add new magic link token endpoints (creating tokens and exchanging for mailing list candidate data)
- [x] Expire magic link tokens after 48 hours and ensure they are only single-use tokens. Write to field indicating when token is generated/used.
- [ ] Add CRM client and restrict access to magic link generation endpoint. 
- [ ] Add job to process pending magic link generations. Connect models to CRM attributes (need CRM changes in prod first)
- [ ] Update the GiT app to handle mailing list sign up via magic links
- [ ] Handle scenario where a user clicks on an expired magic link

---

- Set expiry date on magic link tokens

Change the `createdAt` date to be `expiresAt` and set to 48 hours in the future when creating a magic link token.

Check that the token is valid before responding with a pre-filled `MailingListAddMember` model.

If the magic link could not be matched to a candidate (or if it matches to multiple candidates) we return `BadRequest` with a status of `Invalid`.

If a token was matched to a candidate but the expiry date has passed we return `BadRequest` with a status of `Expired`.

- Prevent multiple use of magic link tokens

Update the `MagicLinkTokenStatusId` on generating and exchanging tokens.

Check that a token has not already been exchanged and return `BadRequest` with a status of `AlreadyExchanged` if it has been used already.

- Encapsulate magic link token exchange into result model

Shifts some of the logic from the controller that determines the state of a magic link token (expired/valid/already exchanged/invalid) into a result model. Change to return `Unauthorized` instead of `BadRequest` with an applicable `status` of `Invalid`, `Expired` or `AlreadyExchanged`.