### PR TITLE
Add API client for the Dynamics CRM

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/candidates")]
     [ApiController]
     [LogRequests]
-    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser")]
+    [Authorize]
     public class CandidatesController : ControllerBase
     {
         private const int MaximumMagicLinkTokensPerBatch = 25;
@@ -42,6 +42,7 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpPost]
         [Route("access_tokens")]
+        [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser")]
         [SwaggerOperation(
             Summary = "Creates a candidate access token.",
             Description = @"
@@ -77,6 +78,7 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpPost]
         [Route("magic_link_tokens")]
+        [Authorize(Roles = "Admin,Crm")]
         [SwaggerOperation(
             Summary = "Creates a token for use in a magic link.",
             Description = @"Creates a long-lived magic link token that can be exchanged for candidate information for up to 48 hours.

--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -20,3 +20,8 @@
   description: "A service to enable candidates to sign up for a Teacher Training Adviser (TTA)"
   api_key_prefix: TTA
   role: GetAnAdviser
+-
+  name: CRM
+  description: "The Get into Teaching Dynamics CRM"
+  api_key_prefix: CRM
+  role: Crm

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -30,6 +30,7 @@
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
+        "CRM_API_KEY": "secret-crm",
         "TOTP_SECRET_KEY": "def456"
       }
     }

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -44,7 +44,10 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser");
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+
+            typeof(CandidatesController).GetMethod("CreateAccessToken").Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser");
+            typeof(CandidatesController).GetMethod("CreateMagicLinkToken").Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,Crm");
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the fourth step of migrating existing candidates onto the new privacy policy via a mailing list sign up in the GiT app:

- [x] Refactor existing endpoints to exchange access tokens for candidate data
- [x] Add new magic link token endpoints (creating tokens and exchanging for mailing list candidate data)
- [x] Expire magic link tokens after 48 hours and ensure they are only single-use tokens. Write to field indicating when token is generated/used.
- [x] Add CRM client and restrict access to magic link generation endpoint. 
- [ ] Add job to process pending magic link generations. Connect models to CRM attributes (need CRM changes in prod first)
- [ ] Update the GiT app to handle mailing list sign up via magic links
- [ ] Handle scenario where a user clicks on an expired magic link

---

- Add API client for the Dynamics CRM

We want the Dynamics CRM to be able to generate magic link tokens against candidates by calling:

```
POST /api/candidates/magic_link_tokens
```

This commit adds a new client for the CRM and restricts access to the `magic_link_endpoints` to the Admin/CRM clients.

Azure has already been updated to include the API keys for the CRM (and I've passed them along to the team).