### PR TITLE
Serialize enums as strings

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
 using dotenv.net;
 using FluentValidation.AspNetCore;
@@ -92,6 +93,10 @@ namespace GetIntoTeachingApi
             .AddFluentValidation(c =>
             {
                 c.RegisterValidatorsFromAssemblyContaining<Startup>();
+            })
+            .AddJsonOptions(o =>
+            {
+                o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
             });
 
             services.Configure<KestrelServerOptions>(options =>


### PR DESCRIPTION
Currently when an enum is returned the integer value is used. This seems to cause an issue with swagger-codegen spitting out invalid Ruby code, for example:

```
0 = 0.freeze
```

By serializing enums as string values I'm hoping it fixes the code generator.

We don't use enums in either of the client apps yet, so this change isn't breaking.