### PR TITLE
Ignore model attribute mappings by environment

### DIFF
--- a/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Utils;
 
 namespace GetIntoTeachingApi.Attributes
 {
@@ -9,14 +11,22 @@ namespace GetIntoTeachingApi.Attributes
         public string Name { get; }
         public Type Type { get; }
         public string Reference { get; }
-        public bool Transient { get; }
+        public string[] IgnoreInEnvironments { get; }
 
-        public EntityFieldAttribute(string name, Type type = null, string reference = null, bool transient = false)
+        public bool Ignored
+        {
+            get
+            {
+                return IgnoreInEnvironments?.Contains(new Env().EnvironmentName) == true;
+            }
+        }
+
+        public EntityFieldAttribute(string name, Type type = null, string reference = null, string[] ignoreInEnvironments = null)
         {
             Name = name;
             Type = type;
             Reference = reference;
-            Transient = transient;
+            IgnoreInEnvironments = ignoreInEnvironments;
         }
 
         public IDictionary<string, string> ToDictionary()

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -39,7 +39,7 @@ namespace GetIntoTeachingApi.Models
         public static EntityFieldAttribute EntityFieldAttribute(ICustomAttributeProvider property)
         {
             return (EntityFieldAttribute)property.GetCustomAttributes(false)
-                .FirstOrDefault(a => a.GetType() == typeof(EntityFieldAttribute) && !((EntityFieldAttribute)a).Transient);
+                .FirstOrDefault(a => a.GetType() == typeof(EntityFieldAttribute) && !((EntityFieldAttribute)a).Ignored);
         }
 
         public static EntityRelationshipAttribute EntityRelationshipAttribute(ICustomAttributeProvider property)

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -135,7 +135,7 @@ namespace GetIntoTeachingApi.Models
         public int? PreferredContactMethodId { get; set; } = (int)ContactMethod.Any;
         [EntityField("msgdpr_gdprconsent", typeof(OptionSetValue))]
         public int? GdprConsentId { get; set; } = (int)GdprConsent.Consent;
-        [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue), null, true)]
+        [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue), null, new string[] { "Production" })]
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
@@ -177,9 +177,9 @@ namespace GetIntoTeachingApi.Models
         public bool? OptOutOfGdpr { get; set; } = false;
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
-        [EntityField("dfe_websitemltoken", null, null, true)]
+        [EntityField("dfe_websitemltoken", null, null, new string[] { "Production" })]
         public string MagicLinkToken { get; set; }
-        [EntityField("dfe_websitemltokenexpirydate", null, null, true)]
+        [EntityField("dfe_websitemltokenexpirydate", null, null, new string[] { "Production" })]
         public DateTime? MagicLinkTokenExpiresAt { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]

--- a/GetIntoTeachingApiTests/Mocks/Models.cs
+++ b/GetIntoTeachingApiTests/Mocks/Models.cs
@@ -16,7 +16,7 @@ namespace GetIntoTeachingApiTests.Mocks
         public int? Field2 { get; set; }
         [EntityField("dfe_field3")]
         public string Field3 { get; set; }
-        [EntityField("dfe_field4", null, null, true)]
+        [EntityField("dfe_field4", null, null, new string[] { "Test" })]
         public string Field4 { get; set; }
         [EntityRelationship("dfe_mock_dfe_relatedmock_mock", typeof(MockRelatedModel))]
         public MockRelatedModel RelatedMock { get; set; }

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void EntityFieldAttribute_OnPropertyWithTransientAttribute_ReturnsNull()
+        public void EntityFieldAttribute_OnPropertyWithIgnoreInEnvironmentAttribute_ReturnsNull()
         {
             var property = typeof(MockModel).GetProperty("Field4");
             BaseModel.EntityFieldAttribute(property).Should().BeNull();

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Attributes;
@@ -61,7 +62,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("GdprConsentId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
             type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue) && a.Transient);
+                a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue) && a.IgnoreInEnvironments.Contains("Production"));
             
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
@@ -91,8 +92,8 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TeacherId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_dfesnumber");
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
-            type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken" && a.Transient);
-            type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate" && a.Transient);
+            type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken" && a.IgnoreInEnvironments.Contains("Production"));
+            type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate" && a.IgnoreInEnvironments.Contains("Production"));
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));


### PR DESCRIPTION
We currently have a number of new fields that are available in the dev/test CRM environment but not production. In order to be able to deploy the code all the way to production before the attributes are available we need to ignore them from the mapping process.

Adds ability to exclude certain attributes from the mapping process depending on environment.

Excludes magic link attributes from being mapped in production (as they are not yet available).