### PR TITLE
Remove endpoint to create magic link tokens

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -114,22 +114,11 @@ namespace GetIntoTeachingApi.Services
 
         public Candidate GetCandidate(Guid id)
         {
-            return GetCandidates(new List<Guid>() { id }).FirstOrDefault();
-        }
+            var entity = _service.CreateQuery("contact", Context())
+                .FirstOrDefault(c => c.GetAttributeValue<EntityReference>("contactid") != null &&
+                c.GetAttributeValue<EntityReference>("contactid").Id == id);
 
-        public IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids)
-        {
-            var query = new QueryExpression("contact");
-            query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(Candidate)));
-
-            var idsCondition = new ConditionExpression("contactid", ConditionOperator.In, ids.ToArray());
-            var filter = new FilterExpression(LogicalOperator.And);
-            filter.Conditions.AddRange(new[] { idsCondition });
-            query.Criteria.AddFilter(filter);
-
-            var entities = _service.RetrieveMultiple(query);
-
-            return entities.Select((entity) => new Candidate(entity, this)).ToList();
+            return entity == null ? null : new Candidate(entity, this);
         }
 
         public bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -15,7 +15,6 @@ namespace GetIntoTeachingApi.Services
         Candidate MatchCandidate(ExistingCandidateRequest request);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
-        IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);
         IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -157,10 +157,8 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void CandidateAlreadyHasLocalEventSubscriptionType_WhenHasLocalEventSubscription_ReturnsTrue()
         {
-            var ids = new Guid[] { JaneDoeGuid };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(candidates);
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates);
 
             var result = _crm.CandidateAlreadyHasLocalEventSubscriptionType(JaneDoeGuid);
 
@@ -170,10 +168,8 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void CandidateAlreadyHasLocalEventSubscriptionType_WhenHasSingleEventSubscription_ReturnsFalse()
         {
-            var ids = new Guid[] { JohnDoeGuid };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(candidates);
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                            .Returns(MockCandidates);
 
             var result = _crm.CandidateAlreadyHasLocalEventSubscriptionType(JohnDoeGuid);
 
@@ -255,10 +251,8 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void GetCandidate_WithId_ReturnsCorrectly()
         {
-            var ids = new Guid[] { JaneDoeGuid };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(candidates);
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates);
 
             var result = _crm.GetCandidate(JaneDoeGuid);
 
@@ -268,64 +262,12 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void GetCandidate_WithNonExistentId_ReturnsNull()
         {
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, new Guid[0])))).Returns(new Entity[0]);
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                          .Returns(MockCandidates);
 
             var result = _crm.GetCandidate(Guid.NewGuid());
 
             result.Should().BeNull();
-        }
-
-        [Fact]
-        public void GetCandidates_ReturnsMatchingCandidates()
-        {
-            var ids = new Guid[] { JaneDoeGuid, JohnDoeGuid };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(candidates);
-
-            var result = _crm.GetCandidates(ids);
-
-            result.First().Id.Should().Be(JaneDoeGuid);
-            result.Last().Id.Should().Be(JohnDoeGuid);
-        }
-
-        [Fact]
-        public void GetCandidates_WithMissingCandidateIds_ReturnsMatchingCandidates()
-        {
-            var ids = new Guid[] { Guid.NewGuid(), JaneDoeGuid };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(candidates);
-
-            var result = _crm.GetCandidates(ids);
-
-            result.Count().Should().Be(1);
-            result.First().Id.Should().Be(JaneDoeGuid);
-        }
-
-        [Fact]
-        public void GetCandidate_WithNoMatches_ReturnsEmpty()
-        {
-            var ids = new Guid[] { Guid.NewGuid() };
-            var candidates = MockCandidates().Where(c => ids.Contains(c.Id));
-            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyCandidatesQueryExpression(q, ids)))).Returns(new Entity[0]);
-
-            var result = _crm.GetCandidates(ids);
-
-            result.Should().BeEmpty();
-        }
-
-        private static bool VerifyCandidatesQueryExpression(QueryExpression query, IEnumerable<Guid> ids)
-        {
-            var objectIds = ids.Select(id => (object)id).ToArray();
-            var hasEntityName = query.EntityName == "contact";
-            var conditions = query.Criteria.Filters.First().Conditions;
-            var hasIdsCondition = conditions.Where(c => c.AttributeName == "contactid" &&
-                c.Operator == ConditionOperator.In && c.Values.ToArray().SequenceEqual(objectIds)).Any();
-
-            return hasEntityName && hasIdsCondition;
         }
 
         [Theory]


### PR DESCRIPTION
We are going to generate these in a background job that looks for all candidates with a `MagicLinkTokenStatusId` of `Pending` instead of having the CRM request candidates explicitly.

Also removes unused `GetCandidates` method on `ICrmService`.