### PR TITLE
Add job to generate magic link tokens

### DIFF
--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -10,5 +10,6 @@ namespace GetIntoTeachingApi.Jobs
         public static TimeSpan ExpirationTimeout => TimeSpan.FromHours(24);
         public static string CrmSyncJobId => "crm-sync";
         public static string LocationSyncJobId => "location-sync";
+        public static string MagicLinkTokenGenerationJobId => "magic-link-token-generation";
     }
 }

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Prometheus;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class MagicLinkTokenGenerationJob : BaseJob
+    {
+        private const int BatchSize = 1000;
+        private readonly ICrmService _crm;
+        private readonly IBackgroundJobClient _jobClient;
+        private readonly ICandidateMagicLinkTokenService _magicLinkTokenService;
+        private readonly ILogger<MagicLinkTokenGenerationJob> _logger;
+        private readonly IMetricService _metrics;
+
+        public MagicLinkTokenGenerationJob(
+            IEnv env,
+            IBackgroundJobClient jobClient,
+            ICandidateMagicLinkTokenService magicLinkTokenService,
+            ICrmService crm,
+            ILogger<MagicLinkTokenGenerationJob> logger,
+            IMetricService metrics)
+            : base(env)
+        {
+            _jobClient = jobClient;
+            _magicLinkTokenService = magicLinkTokenService;
+            _crm = crm;
+            _logger = logger;
+            _metrics = metrics;
+        }
+
+        [DisableConcurrentExecution(timeoutInSeconds: 10 * 30)]
+        public void Run()
+        {
+            using (_metrics.MagicLinkTokenGenerationDuration.NewTimer())
+            {
+                _logger.LogInformation("MagicLinkTokenGenerationJob - Started");
+                GenerateTokens();
+                _logger.LogInformation("MagicLinkTokenGenerationJob - Succeeded");
+            }
+        }
+
+        private void GenerateTokens()
+        {
+            var candidates = _crm.GetCandidatesPendingMagicLinkTokenGeneration(BatchSize);
+            _logger.LogInformation($"MagicLinkTokenGenerationJob - Processing ({candidates.Count()})");
+
+            foreach (var candidate in candidates)
+            {
+                _magicLinkTokenService.GenerateToken(candidate);
+                _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(candidate, null));
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -121,6 +121,15 @@ namespace GetIntoTeachingApi.Services
             return entity == null ? null : new Candidate(entity, this);
         }
 
+        public IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10)
+        {
+            return _service.CreateQuery("contact", Context())
+                .Where(entity => entity.GetAttributeValue<OptionSetValue>("dfe_websitemltokenstatus") != null &&
+                    entity.GetAttributeValue<OptionSetValue>("dfe_websitemltokenstatus").Value == (int)Candidate.MagicLinkTokenStatus.Pending)
+                .Take(limit)
+                .Select(e => new Candidate(e, this));
+        }
+
         public bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId)
         {
             return GetCandidate(candidateId).EventsSubscriptionTypeId == (int)Candidate.SubscriptionType.LocalEvent;

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi.Services
         Candidate MatchCandidate(ExistingCandidateRequest request);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
+        IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10);
         IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -6,6 +6,7 @@ namespace GetIntoTeachingApi.Services
     {
         Histogram CrmSyncDuration { get; }
         Histogram LocationSyncDuration { get; }
+        Histogram MagicLinkTokenGenerationDuration { get; }
         Histogram HangfireJobQueueDuration { get; }
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -8,6 +8,8 @@ namespace GetIntoTeachingApi.Services
             .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
         private static readonly Histogram _locationSyncDuration = Metrics
             .CreateHistogram("api_location_sync_duration_seconds", "Histogram of location sync durations.");
+        private static readonly Histogram _magicLinkTokenGenerationDuration = Metrics
+            .CreateHistogram("api_magic_link_token_generation_duration_seconds", "Histogram of magic link token generation durations.");
         private static readonly Histogram _hangfireJobQueueDuration = Metrics
             .CreateHistogram("api_hangfire_job_queue_duration_seconds", "Histogram of the time jobs spend in the queue.", new HistogramConfiguration
             {
@@ -38,6 +40,7 @@ namespace GetIntoTeachingApi.Services
 
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
+        public Histogram MagicLinkTokenGenerationDuration => _magicLinkTokenGenerationDuration;
         public Histogram HangfireJobQueueDuration => _hangfireJobQueueDuration;
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -249,11 +249,21 @@ The GIT API aims to provide:
 
             // Configure recurring jobs.
             const string everyFifthMinute = "*/5 * * * *";
+            const string everyMinute = "* * * * *";
             RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
             RecurringJob.AddOrUpdate<LocationSyncJob>(
                 JobConfiguration.LocationSyncJobId,
                 (x) => x.RunAsync(LocationSyncJob.FreeMapToolsUrl),
                 Cron.Weekly());
+
+            // Disabled in Production until magic link fields are available.
+            if (!env.IsProduction)
+            {
+                RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
+                    JobConfiguration.MagicLinkTokenGenerationJobId,
+                    (x) => x.Run(),
+                    everyMinute);
+            }
 
             // Don't seed test environment.
             if (!env.IsTest)

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -1,0 +1,65 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class MagicLinkTokenGenerationJobTests
+    {
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        private readonly Mock<ICandidateMagicLinkTokenService> _mockMagicLinkTokenService;
+        private readonly Mock<ILogger<MagicLinkTokenGenerationJob>> _mockLogger;
+        private readonly IMetricService _metrics;
+        private readonly MagicLinkTokenGenerationJob _job;
+
+        public MagicLinkTokenGenerationJobTests()
+        {
+            _mockLogger = new Mock<ILogger<MagicLinkTokenGenerationJob>>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockMagicLinkTokenService = new Mock<ICandidateMagicLinkTokenService>();
+            _metrics = new MetricService();
+            _job = new MagicLinkTokenGenerationJob(new Env(), _mockJobClient.Object, _mockMagicLinkTokenService.Object, _mockCrm.Object, _mockLogger.Object, _metrics);
+        }
+
+        [Fact]
+        public void DisableConcurrentExecutionAttribute()
+        {
+            var type = typeof(MagicLinkTokenGenerationJob);
+
+            type.GetMethod("Run").Should().BeDecoratedWith<DisableConcurrentExecutionAttribute>();
+        }
+
+        [Fact]
+        public void Run_UpsertsCandidatesWithMagicLinkTokens()
+        {
+            var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
+            _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(1000)).Returns(new Candidate[] { candidate });
+
+            _job.Run();
+
+            _mockMagicLinkTokenService.Verify(m => m.GenerateToken(candidate));
+
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                candidate == (Candidate)job.Args[0]),
+                It.IsAny<EnqueuedState>()));
+
+            _mockLogger.VerifyInformationWasCalled("MagicLinkTokenGenerationJob - Started");
+            _mockLogger.VerifyInformationWasCalled("MagicLinkTokenGenerationJob - Processing (1)");
+            _mockLogger.VerifyInformationWasCalled("MagicLinkTokenGenerationJob - Succeeded");
+
+            _metrics.MagicLinkTokenGenerationDuration.Count.Should().Be(1);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -270,6 +270,28 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().BeNull();
         }
 
+        [Fact]
+        public void GetCandidatesPendingMagicLinkTokenGeneration_ReturnsCorrectly()
+        {
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates());
+
+            var result = _crm.GetCandidatesPendingMagicLinkTokenGeneration();
+
+            result.Select(c => c.MagicLinkTokenStatusId).Should().AllBeEquivalentTo((int)Candidate.MagicLinkTokenStatus.Pending);
+        }
+
+        [Fact]
+        public void GetCandidatesPendingMagicLinkTokenGeneration_WithLimit_ReturnsCorrectly()
+        {
+            _mockService.Setup(m => m.CreateQuery("contact", _context))
+                .Returns(MockCandidates());
+
+            var result = _crm.GetCandidatesPendingMagicLinkTokenGeneration(1);
+
+            result.Count().Should().Be(1);
+        }
+
         [Theory]
         [InlineData("john@doe.com", "New John", "Doe", "New John")]
         [InlineData("JOHN@doe.com", "New John", "Doe", "New John")]
@@ -468,6 +490,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate1["lastname"] = "Doe";
             candidate1["modifiedon"] = DateTime.UtcNow;
             candidate1["dfe_websitemltoken"] = JaneDoeMagicLinkToken;
+            candidate1["dfe_websitemltokenstatus"] = new OptionSetValue((int)Candidate.MagicLinkTokenStatus.Pending);
             candidate1["dfe_duplicatescorecalculated"] = 10.0;
             candidate1["dfe_gitiseventsservicesubscriptiontype"] = new OptionSetValue((int)Candidate.SubscriptionType.LocalEvent);
 
@@ -482,6 +505,7 @@ namespace GetIntoTeachingApiTests.Services
             candidate2["lastname"] = "Doe";
             candidate2["modifiedon"] = DateTime.UtcNow;
             candidate2["dfe_websitemltoken"] = "duplicated-token";
+            candidate2["dfe_websitemltokenstatus"] = new OptionSetValue((int)Candidate.MagicLinkTokenStatus.Pending);
             candidate2["dfe_duplicatescorecalculated"] = 9.5;
             candidate2["dfe_gitiseventsservicesubscriptiontype"] = new OptionSetValue((int)Candidate.SubscriptionType.SingleEvent);
 

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -27,6 +27,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void MagicLinkTokenGenerationDuration_ReturnsMetric()
+        {
+            _metrics.MagicLinkTokenGenerationDuration.Name.Should().Be("api_magic_link_token_generation_duration_seconds");
+        }
+
+        [Fact]
         public void HangfireJobQueueDuration_ReturnsMetric()
         {
             _metrics.HangfireJobQueueDuration.Name.Should().Be("api_hangfire_job_queue_duration_seconds");


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the fifth step of migrating existing candidates onto the new privacy policy via a mailing list sign up in the GiT app:

- [x] Refactor existing endpoints to exchange access tokens for candidate data
- [x] Add new magic link token endpoints (creating tokens and exchanging for mailing list candidate data)
- [x] Expire magic link tokens after 48 hours and ensure they are only single-use tokens. Write to field indicating when token is generated/used.
- [x] Add CRM client and restrict access to magic link generation endpoint. 
- [x] Add job to process pending magic link generations.
- [ ] Update the GiT app to handle mailing list sign up via magic links
- [ ] Handle scenario where a user clicks on an expired magic link
- [ ] Enable magic link token generation job in production

---

- Add metric to track MagicLinkTokenGenerationJob

The metric will enable us to track how long the metric link token generation is taken.

- Add method to retrieve candidates that require magic link tokens

When the CRM requires a magic link token to be generated for a candidate they will change the status to 'pending'. The API will then pick these up in a background job and assign tokens.

- Add job to generate magic link tokens

The job runs every minute and processes 1,000 candidates (we should be able to do a lot more than this if needed, but it's a good starting point). Once a token has been generated the candidate magic link token status is updated to 'generated' and the updated record is sent back to the CRM.

The job is disabled in production for now as the fields are not yet available in the prod CRM instance.