### PR TITLE
Enable magic links in production

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -135,7 +135,7 @@ namespace GetIntoTeachingApi.Models
         public int? PreferredContactMethodId { get; set; } = (int)ContactMethod.Any;
         [EntityField("msgdpr_gdprconsent", typeof(OptionSetValue))]
         public int? GdprConsentId { get; set; } = (int)GdprConsent.Consent;
-        [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue), null, new string[] { "Production" })]
+        [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue))]
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
@@ -177,9 +177,9 @@ namespace GetIntoTeachingApi.Models
         public bool? OptOutOfGdpr { get; set; } = false;
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
-        [EntityField("dfe_websitemltoken", null, null, new string[] { "Production" })]
+        [EntityField("dfe_websitemltoken")]
         public string MagicLinkToken { get; set; }
-        [EntityField("dfe_websitemltokenexpirydate", null, null, new string[] { "Production" })]
+        [EntityField("dfe_websitemltokenexpirydate")]
         public DateTime? MagicLinkTokenExpiresAt { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -255,15 +255,10 @@ The GIT API aims to provide:
                 JobConfiguration.LocationSyncJobId,
                 (x) => x.RunAsync(LocationSyncJob.FreeMapToolsUrl),
                 Cron.Weekly());
-
-            // Disabled in Production until magic link fields are available.
-            if (!env.IsProduction)
-            {
-                RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
-                    JobConfiguration.MagicLinkTokenGenerationJobId,
-                    (x) => x.Run(),
-                    everyMinute);
-            }
+            RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
+                JobConfiguration.MagicLinkTokenGenerationJobId,
+                (x) => x.Run(),
+                everyMinute);
 
             // Don't seed test environment.
             if (!env.IsTest)

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -62,7 +62,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("GdprConsentId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
             type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue) && a.IgnoreInEnvironments.Contains("Production"));
+                a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
             
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
@@ -92,8 +92,8 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("TeacherId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_dfesnumber");
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
-            type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken" && a.IgnoreInEnvironments.Contains("Production"));
-            type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate" && a.IgnoreInEnvironments.Contains("Production"));
+            type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken");
+            type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate");
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));


### PR DESCRIPTION
Updates the `Candidate` attribute mapping to map the magic link attributes in all environments, as they are now available in production.

Enables the magic link generation job in production.