### PR TITLE
Add panels for magic link generation/usage

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1610633064571,
+  "id": 5,
+  "iteration": 1613037108572,
   "links": [],
   "panels": [
     {
@@ -345,7 +345,7 @@
       "format": "short",
       "gridPos": {
         "h": 10,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 10
       },
@@ -470,6 +470,102 @@
     },
     {
       "aliasColors": {
+        "Failed Attempt": "#F2495C",
+        "Mailing List (failure)": "#F2495C",
+        "Miss": "#5794F2"
+      },
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "id": 65,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "alias": "Mailing List",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/mailing_list/members/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 200 AND cf.app:\"$App\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "Failed Attempt",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 401 AND cf.app:\"$App\"",
+          "refId": "B",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Magic Link Requests",
+      "type": "grafana-piechart-panel",
+      "valueName": "total"
+    },
+    {
+      "aliasColors": {
         "Unverified": "#F2495C"
       },
       "breakPoint": "50%",
@@ -490,8 +586,8 @@
       "format": "short",
       "gridPos": {
         "h": 10,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 10
       },
       "id": 63,
@@ -590,8 +686,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 10
       },
       "id": 64,
@@ -1341,7 +1437,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 4,
         "x": 0,
         "y": 57
       },
@@ -1408,8 +1504,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 6,
+        "w": 5,
+        "x": 4,
         "y": 57
       },
       "id": 48,
@@ -1482,8 +1578,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
+        "w": 5,
+        "x": 9,
         "y": 57
       },
       "id": 6,
@@ -1544,11 +1640,11 @@
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
-                "value": 300
+                "value": 10
               },
               {
                 "color": "#d44a3a",
-                "value": 600
+                "value": 20
               }
             ]
           },
@@ -1558,8 +1654,84 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
+        "w": 5,
+        "x": 14,
+        "y": 57
+      },
+      "id": 66,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "avg(rate(api_crm_sync_duration_seconds_sum[$__range]) / rate(api_crm_sync_duration_seconds_count[$__range]))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CRM Sync Duration",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 30
+              },
+              {
+                "color": "#d44a3a",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 19,
         "y": 57
       },
       "id": 21,
@@ -1583,7 +1755,7 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "avg(rate(api_location_sync_duration_seconds_sum[$__range]) / rate(api_location_sync_duration_seconds_count[$__range]) > 0)",
+          "expr": "avg(rate(api_magic_link_token_generation_duration_seconds_sum[$__range]) / rate(api_magic_link_token_generation_duration_seconds_count[$__range]) > 0)",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -1592,7 +1764,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Location Sync Duration",
+      "title": "Magic Link Token Generation Duration",
       "type": "stat"
     },
     {


### PR DESCRIPTION
The panels are empty at the moment as we haven't ran any generation jobs, but they are essentially the same format as the other two panels included in the screenshots.

<img width="598" alt="Screenshot 2021-02-11 at 13 24 45" src="https://user-images.githubusercontent.com/29867726/107642250-834c1000-6c6c-11eb-86dd-592c3ba8a579.png">

<img width="724" alt="Screenshot 2021-02-11 at 13 24 35" src="https://user-images.githubusercontent.com/29867726/107642227-7d562f00-6c6c-11eb-9b53-d1010aa572a9.png">
