### PR TITLE
Minor bug fixes for magic link mechanism

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -111,6 +111,8 @@ namespace GetIntoTeachingApi.Controllers
                 return Unauthorized(result);
             }
 
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(result.Candidate, null));
+
             return Ok(new MailingListAddMember(result.Candidate));
         }
     }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -101,7 +101,7 @@ namespace GetIntoTeachingApi.Services
             }
 
             var context = Context();
-            var entities = _service.CreateQuery("contact", Context())
+            var entities = _service.CreateQuery("contact", context)
                 .Where(c => c.GetAttributeValue<string>("dfe_websitemltoken") == magicLinkToken);
 
             foreach (var entity in entities)


### PR DESCRIPTION
I missed these originally as there was no test data in the CRM available, but we have it now so its highlighted theses issues.

- Share context when loading related entities

The candidate was being loaded in a different context to the related entities, which was causing an error (you can't relate entities across contexts).

- Persist candidate after exchanging magic link token

When the magic link token gets exchanged the candidate status is updated. We weren't persisting this back to the CRM, which meant tokens could be re-used until they expired (instead of being single use).
