### PR TITLE
Increase magic link token generation batch size

### DIFF
--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -9,7 +9,7 @@ namespace GetIntoTeachingApi.Jobs
 {
     public class MagicLinkTokenGenerationJob : BaseJob
     {
-        private const int BatchSize = 1000;
+        private const int BatchSize = 5000;
         private readonly ICrmService _crm;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ICandidateMagicLinkTokenService _magicLinkTokenService;

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_UpsertsCandidatesWithMagicLinkTokens()
         {
             var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
-            _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(1000)).Returns(new Candidate[] { candidate });
+            _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(5000)).Returns(new Candidate[] { candidate });
 
             _job.Run();
 


### PR DESCRIPTION
On testing this in a hosted staging environment the job (and 1,000 spawned `UpsertCandidateJob` jobs) were completed in around 5 seconds. As we run this job periodically every minute we should be able to comfortably do 5,000 records/minute (we want to avoid the job overlapping itself by keeping the runtime < 1m - there is also a distributed lock on this job so if it does overlap the next run will wait/timeout).