### PR TITLE
Fix build error in pipeline

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,16 +39,16 @@ jobs:
       run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
 
     - name: Install dependencies
-      run: sudo dotnet restore
+      run: dotnet restore
 
     - name: Build
-      run: sudo dotnet build --configuration Release --no-restore /warnaserror
+      run: dotnet build --configuration Release --no-restore /warnaserror
 
     - name: Spin Up Stack
       run: docker-compose up -d
 
     - name: Test
-      run: sudo dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal
 
     - name: Lint Dockerfile
       uses: brpaz/hadolint-action@master

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
         run:  dotnet tool install --global dotnet-sonarscanner --version 4.8.0
 
       - name: Install dependencies
-        run:  sudo dotnet restore
+        run:  dotnet restore
 
       - name: Spin Up Stack
         run: docker-compose up -d

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,9 +67,9 @@ jobs:
             " \
             /d:sonar.verbose=true \
             /d:sonar.log.level="DEBUG"
-          sudo dotnet build
-            sudo dotnet test --no-build --logger:trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-          dotnet sonarscanner end /d:sonar.login="${{ steps.azSecret.outputs.SONAR-TOKEN }}"
+             dotnet build
+             dotnet test --no-build --logger:trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+             dotnet sonarscanner end /d:sonar.login="${{ steps.azSecret.outputs.SONAR-TOKEN }}"
 
       - name: Slack Notification
         if: failure()


### PR DESCRIPTION
### Problem
Two workflows that call .NET are no longer running, they fail to find the Notify NuGet provided by the UK Government, and they attempt to install some other old Notify NuGet

### Investigation
Replicated the fault in the workflows, but not on CLI or inside docker.

### Cause
Some of the .NET steps in the workflow were using **sudo** and others were not. This until recently was not a problem, but something must have changed in the GitHub CI virtual environment and it became a problem. 

### Solution
Remove the **sudo** command on all .NET functions