### PR TITLE
Relex validation on returning teacher sign ups

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -32,11 +32,12 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be set to schedule a callback.");
 
             RuleFor(request => request.Telephone).NotEmpty()
-                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent && !request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set for candidates with an equivalent degree.");
 
             RuleFor(request => request.PhoneCallScheduledAt).NotNull()
-                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent && request.CountryId == LookupItem.UnitedKingdomCountryId)
+                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent &&
+                !request.Candidate.IsReturningToTeaching() && request.CountryId == LookupItem.UnitedKingdomCountryId)
                 .WithMessage("Must be set for candidate with UK equivalent degree.");
             RuleFor(request => request.PhoneCallScheduledAt).Null()
                 .When(request => request.CountryId != LookupItem.UnitedKingdomCountryId)
@@ -52,6 +53,7 @@ namespace GetIntoTeachingApi.Models.Validators
 
             RuleFor(request => request.DegreeStatusId)
                 .Must(status => status != (int)CandidateQualification.DegreeStatus.NoDegree)
+                .Unless(request => request.Candidate.IsReturningToTeaching())
                 .WithMessage("Not eligible for service if degree status is no degree.");
 
             RuleFor(request => request.DegreeTypeId).NotEmpty()
@@ -65,7 +67,7 @@ namespace GetIntoTeachingApi.Models.Validators
                         (int)CandidateQualification.DegreeType.Degree,
                         (int)CandidateQualification.DegreeType.DegreeEquivalent,
                     }.Contains(type))
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree)
+                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree && !request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
 
             RuleFor(request => request.DegreeTypeId)
@@ -82,7 +84,7 @@ namespace GetIntoTeachingApi.Models.Validators
 
             RuleFor(request => request.DegreeTypeId)
                 .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.NoDegree)
+                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.NoDegree && !request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set to degree when the degree status is no degree.");
 
             RuleFor(request => request.DegreeSubject).NotEmpty()
@@ -95,7 +97,7 @@ namespace GetIntoTeachingApi.Models.Validators
                         (int)CandidateQualification.DegreeStatus.FirstYear,
                         (int)CandidateQualification.DegreeStatus.Other,
                     }.Contains(request.DegreeStatusId))
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set when candidate has a degree or is studying for a degree.");
 
             RuleFor(request => request.UkDegreeGradeId).NotEmpty()
@@ -108,7 +110,7 @@ namespace GetIntoTeachingApi.Models.Validators
                         (int)CandidateQualification.DegreeStatus.FirstYear,
                         (int)CandidateQualification.DegreeStatus.Other,
                     }.Contains(request.DegreeStatusId))
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
 
             RuleFor(request => request.PreferredTeachingSubjectId).NotEmpty()
@@ -118,7 +120,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request)
                 .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request) && HasOrIsPlanningOnRetakingScience(request))
                 .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
                 .WithMessage("Must have or be retaking all GCSEs when preferred education phase is primary.");
 
             RuleFor(request => request)

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -223,6 +223,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_DegreeTypeIdIsEquivalentAndTelephoneIsNullAndIsReturningToTeaching_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                Telephone = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("Telephone");
+        }
+
+        [Fact]
         public void Validate_PhoneCallScheduledAtIsPresentAndTelephoneIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
@@ -249,6 +264,22 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Must be set for candidate with UK equivalent degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeTypeIsEquivalentAndCountryIsUkAndPhoneCallScheduledAtIsNullAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                CountryId = LookupItem.UnitedKingdomCountryId,
+                PhoneCallScheduledAt = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("PhoneCallScheduledAt");
         }
 
         [Fact]
@@ -294,6 +325,20 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_DegreeStatusIsNoDegreeAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeStatusId");
+        }
+
+        [Fact]
         public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
@@ -305,6 +350,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsNullAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                DegreeTypeId = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
         }
 
         [Fact]
@@ -375,6 +435,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set to degree when the degree status is no degree.");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsNoDegreeAndAndDegreeTypeIsNullAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
+                DegreeTypeId = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeTypeId");
         }
 
         [Fact]
@@ -490,6 +565,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_DegreeStatusIsStudyingAndDegreeSubjectIsNullAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
+                DegreeSubject = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("DegreeSubject");
+        }
+
+        [Fact]
         public void Validate_DegreeStatusIsHasDegreeAndDegreeTypeIsEquivalentAndDegreeSubjectIsNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
@@ -558,6 +648,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor("UkDegreeGradeId").WithErrorMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
+        }
+
+        [Fact]
+        public void Validate_DegreeStatusIsHasDegreeAndUkDegreeGradeIsNullAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
+                UkDegreeGradeId = null,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("UkDegreeGradeId");
         }
 
         [Fact]
@@ -672,6 +777,22 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor(request => request).WithErrorMessage("Must have or be retaking all GCSEs when preferred education phase is primary.");
+        }
+
+        [Fact]
+        public void Validate_PreferredEducationPhaseIsPrimaryAndDoesNotHaveNorPlanningToRetakeAllGcsesAndReturningTeacher_HasNoError()
+        {
+            var request = new TeacherTrainingAdviserSignUp
+            {
+                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
+                HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                HasGcseScienceId = -1,
+                SubjectTaughtId = Guid.NewGuid(),
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(request => request);
         }
 
         [Fact]


### PR DESCRIPTION
If a candidate is already in the CRM the apps will now send existing data back with the sign up payload (which will mean we can ultimately write `nil` values to the CRM, as currently we have no way to differentiate between 'not set' and 'unset' fields).

A side-effect of this is that if an existing candidate is in the system with a degree type and then goes through the TTA as a returner a load of validation errors can occur due to the unexpected state (we don't ask new returners about their degree status). To avoid this we relax the validation around certain fields that trigger when the candidate has a degree - excluding  returners.

The validation is getting pretty complex now; it may be worth relaxing some of this in general in the API to avoid future problems, relying on the app-side validation more.