### PR TITLE
Convert empty strings to null on serialize/deserialize operations

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -97,6 +97,7 @@ namespace GetIntoTeachingApi
             .AddJsonOptions(o =>
             {
                 o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                o.JsonSerializerOptions.Converters.Add(new EmptyStringToNullJsonConverter());
             });
 
             services.Configure<KestrelServerOptions>(options =>

--- a/GetIntoTeachingApi/Utils/EmptyStringToNullJsonConverter.cs
+++ b/GetIntoTeachingApi/Utils/EmptyStringToNullJsonConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class EmptyStringToNullJsonConverter : JsonConverter<string>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(string);
+        }
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string value = reader.GetString();
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                value = null;
+            }
+
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/EmptyStringToNullJsonConverterTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EmptyStringToNullJsonConverterTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Text.Json;
+using FluentAssertions;
+using GetIntoTeachingApi.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class EmptyStringToNullJsonConverterTests
+    {
+        private readonly EmptyStringToNullJsonConverter _converter;
+
+        public EmptyStringToNullJsonConverterTests()
+        {
+            _converter = new EmptyStringToNullJsonConverter();
+        }
+
+        [Theory]
+        [InlineData(typeof(string), true)]
+        [InlineData(typeof(object), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(bool), false)]
+        public void CanConvert_ReturnsCorrectly(Type type, bool expected)
+        {
+            _converter.CanConvert(type).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("{\"Name\":\"\"}", null)]
+        [InlineData("{\"Name\":\" \"}", null)]
+        [InlineData("{\"Name\":null}", null)]
+        [InlineData("{\"Name\":\" a\"}", " a")]
+        [InlineData("{\"Name\":\"a test string\"}", "a test string")]
+        public void Read_DeserializesString_ToNullIfEmpty(string json, string expected)
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            var result = JsonSerializer.Deserialize<StubPerson>(json, options);
+
+            result.Name.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", "{\"Name\":null}")]
+        [InlineData(" ", "{\"Name\":null}")]
+        [InlineData(null, "{\"Name\":null}")]
+        [InlineData(" a", "{\"Name\":\" a\"}")]
+        [InlineData("a test string", "{\"Name\":\"a test string\"}")]
+        public void Write_SerializesString_ToNullIfEmpty(string input, string expected)
+        {
+            var stub = new StubPerson() { Name = input };
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+           
+            var result = JsonSerializer.Serialize(stub, options);
+
+            result.Should().Be(expected);
+        }
+
+        private class StubPerson
+        {
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
The CRM appears to have a number of existing candidates whereby the postcode is an empty string `""` instead of `null`. This means when we retrieve an existing record and pre-fill the store in the app we can hit a scenario where the user didn't specify a postcode but an invalid postcode (empty string) is sent back to the API.

By serialising/deserialising an empty string to `null` the behaviour will be correct and the postcode validation will not be applied.