### PR TITLE
Improve Release note

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -87,7 +87,7 @@ jobs:
          env:
            SLACK_COLOR:    ${{env.SLACK_SUCCESS}}
            SLACK_TITLE:    "Release Published to ${{github.event.inputs.environment}}: ${{steps.tag_id.outputs.release_name}}"
-           SLACK_MESSAGE:  ${{steps.tag_id.outputs.release_body}}
+           SLACK_MESSAGE:  ${{ fromJson( steps.tag_id.outputs.release_body) }}
            SLACK_WEBHOOK:  ${{steps.azSecret.outputs.SLACK-RELEASE-NOTE-WEBHOOK}}
            MSG_MINIMAL:    true
 


### PR DESCRIPTION
### Trello card
[Release Notes are only first line](https://trello.com/c/Ueda1EDd/640-release-notes-are-only-first-line)

### Context
When SLACK outputs a Release Note, it only presents the first line of the text, this is not adequate

### Changes proposed in this pull request
Change the github action to use Powershell and return a json string

### Guidance to review
No change to  application