### PR TITLE
Sanitize invalid CRM postcodes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -256,6 +256,11 @@ namespace GetIntoTeachingApi.Models
         public Candidate(Entity entity, ICrmService crm)
             : base(entity, crm)
         {
+            // Treat invalid postcodes coming back from the CRM as null.
+            if (AddressPostcode != null && !Location.PostcodeRegex.IsMatch(AddressPostcode))
+            {
+                AddressPostcode = null;
+            }
         }
 
         public bool HasTeacherTrainingAdviser()

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -22,7 +22,9 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
-            RuleFor(candidate => candidate.AddressPostcode).MaximumLength(40).Matches(Location.PostcodeRegex);
+            RuleFor(candidate => candidate.AddressPostcode)
+                .SetValidator(new PostcodeValidator())
+                .Unless(candidate => candidate.AddressPostcode == null);
             RuleFor(candidate => candidate.EligibilityRulesPassed)
                 .Must(value => _validEligibilityRulesPassedValues.Contains(value))
                 .Unless(candidate => candidate.EligibilityRulesPassed == null)

--- a/GetIntoTeachingApi/Validators/PostcodeValidator.cs
+++ b/GetIntoTeachingApi/Validators/PostcodeValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation.Validators;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Validators
+{
+    public class PostcodeValidator : PropertyValidator
+    {
+        public PostcodeValidator()
+            : base("{PropertyName} must be a valid postcode.")
+        {
+        }
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            var postcode = (string)context.PropertyValue;
+
+            if (postcode != null && Location.PostcodeRegex.IsMatch(postcode))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Attributes;
@@ -63,7 +62,7 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
             type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
-            
+
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
@@ -153,14 +152,14 @@ namespace GetIntoTeachingApiTests.Models
         public void HasTeacherTrainingAdviser_WithSubscription_ReturnsCorrectly(bool? hasSubscription, string owningBusinessUnitId, bool expectedOutcome)
         {
             Guid? id = null;
-            
+
             if (owningBusinessUnitId != null)
             {
                 id = new Guid(owningBusinessUnitId);
             }
 
-            var candidate = new Candidate() { 
-                HasTeacherTrainingAdviserSubscription = hasSubscription, 
+            var candidate = new Candidate() {
+                HasTeacherTrainingAdviserSubscription = hasSubscription,
                 OwningBusinessUnitId = id,
             };
 
@@ -465,6 +464,21 @@ namespace GetIntoTeachingApiTests.Models
             };
 
             candidate.MagicLinkTokenAlreadyExchanged().Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("invalid", null)]
+        [InlineData("KY11 9YU", "KY11 9YU")]
+        public void Constructor_WithEntity_OnlyPopulatesValidAddressPostcodes(string postcode, string expected)
+        {
+            var mockCrm = new Mock<ICrmService>();
+            var entity = new Entity("contact");
+
+            entity.Attributes.Add("address1_postalcode", postcode);
+
+            var candidate = new Candidate(entity, mockCrm.Object);
+
+            candidate.AddressPostcode.Should().Be(expected);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Validators/PostcodeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/PostcodeValidatorTests.cs
@@ -1,0 +1,49 @@
+﻿using GetIntoTeachingApi.Validators;
+using Xunit;
+using FluentValidation;
+using FluentValidation.Internal;
+using FluentValidation.Validators;
+using System.Linq;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Validators
+{
+    public class PostcodeValidatorTests
+    {
+        private readonly PostcodeValidator _validator;
+
+        public PostcodeValidatorTests()
+        {
+            _validator = new PostcodeValidator();
+        }
+
+        [Theory]
+        [InlineData("KY119YU", true)]
+        [InlineData("KY11 9YU", true)]
+        [InlineData("CA48LE", true)]
+        [InlineData("CA4 8LE", true)]
+        [InlineData("ky119yu", true)]
+        [InlineData("KY999 9YU", false)]
+        [InlineData("AZ1VS1", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsValid_WithPostcode_ReturnsCorectly(string postcode, bool expectedValid)
+        {
+            var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
+            var validationContext = new ValidationContext(postcode, new PropertyChain(), selector);
+            var propertyValidatorContext = new PropertyValidatorContext(validationContext, PropertyRule.Create<string, string>(t => t), "Prop");
+
+            var errors = _validator.Validate(propertyValidatorContext);
+
+            if (expectedValid)
+            {
+                errors.Should().BeEmpty();
+            }
+            else
+            {
+                errors.Should().NotBeEmpty();
+                errors.First().ErrorMessage.Should().Equals("Prop must be a valid postcode.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Extract postcode validation into property validator

Initially I did this so that I could re-use it in the request models, but FluentValidation doesn't let you validate a single value (only an entire model).

It's a worthwhile refactoring anyway, so leaving it in.

- Sanitize invalid postcodes coming back from the CRM

We have a potential scenario where an candidate in the CRM has an invalid postcode against them; if we use their data when pre-filling one of the forms in the front-end apps this postcode will then be re-submitted to the API and it will fail validation (the data is only validated on the client-side if shown to the user and postcodes are often optional/skipped steps).

This commit updates the API to sanitize invalid postcodes coming back from the CRM.