### PR TITLE
Trim/nullify empty strings coming into/out of the API

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -49,6 +49,7 @@
 	  <Folder Include="Redis\" />
 	  <Folder Include="Validators\" />
 	  <Folder Include="Fixtures\" />
+	  <Folder Include="JsonConverters\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/JsonConverters/EmptyStringToNullJsonConverter.cs
+++ b/GetIntoTeachingApi/JsonConverters/EmptyStringToNullJsonConverter.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace GetIntoTeachingApi.Utils
+namespace GetIntoTeachingApi.JsonConverters
 {
     public class EmptyStringToNullJsonConverter : JsonConverter<string>
     {

--- a/GetIntoTeachingApi/JsonConverters/TrimStringJsonConverter.cs
+++ b/GetIntoTeachingApi/JsonConverters/TrimStringJsonConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GetIntoTeachingApi.JsonConverters
+{
+    public class TrimStringJsonConverter : JsonConverter<string>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(string);
+        }
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string value = reader.GetString();
+
+            return value?.Trim();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value?.Trim());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -95,6 +95,12 @@ namespace GetIntoTeachingApi.Models
             return model.GetType().GetProperties();
         }
 
+        private static string TrimAndNullifyIfEmpty(string input)
+        {
+            input = input?.Trim();
+            return string.IsNullOrWhiteSpace(input) ? null : input;
+        }
+
         private void MapFieldAttributesFromEntity(Entity entity)
         {
             foreach (var property in GetProperties(this))
@@ -116,7 +122,14 @@ namespace GetIntoTeachingApi.Models
                 }
                 else
                 {
-                    property.SetValue(this, entity.GetAttributeValue<dynamic>(attribute.Name));
+                    var value = entity.GetAttributeValue<dynamic>(attribute.Name);
+
+                    if (value is string @string)
+                    {
+                        value = TrimAndNullifyIfEmpty(@string);
+                    }
+
+                    property.SetValue(this, value);
                 }
             }
         }

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -98,6 +98,7 @@ namespace GetIntoTeachingApi
             .AddJsonOptions(o =>
             {
                 o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                o.JsonSerializerOptions.Converters.Add(new TrimStringJsonConverter());
                 o.JsonSerializerOptions.Converters.Add(new EmptyStringToNullJsonConverter());
             });
 

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -8,6 +8,7 @@ using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Auth;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.JsonConverters;
 using GetIntoTeachingApi.ModelBinders;
 using GetIntoTeachingApi.OperationFilters;
 using GetIntoTeachingApi.RateLimiting;

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Folder Include="Redis\" />
     <Folder Include="Validators\" />
+    <Folder Include="JsonConverters\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/JsonConverters/EmptyStringToNullJsonConverterTests.cs
+++ b/GetIntoTeachingApiTests/JsonConverters/EmptyStringToNullJsonConverterTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Text.Json;
 using FluentAssertions;
-using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApi.JsonConverters;
 using Xunit;
 
-namespace GetIntoTeachingApiTests.Utils
+namespace GetIntoTeachingApiTests.JsonConverters
 {
     public class EmptyStringToNullJsonConverterTests
     {

--- a/GetIntoTeachingApiTests/JsonConverters/TrimStringJsonConverterTests.cs
+++ b/GetIntoTeachingApiTests/JsonConverters/TrimStringJsonConverterTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Text.Json;
+using FluentAssertions;
+using GetIntoTeachingApi.JsonConverters;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.JsonConverters
+{
+    public class TrimStringJsonConverterTests
+    {
+        private readonly TrimStringJsonConverter _converter;
+
+        public TrimStringJsonConverterTests()
+        {
+            _converter = new TrimStringJsonConverter();
+        }
+
+        [Theory]
+        [InlineData(typeof(string), true)]
+        [InlineData(typeof(object), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(bool), false)]
+        public void CanConvert_ReturnsCorrectly(Type type, bool expected)
+        {
+            _converter.CanConvert(type).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("{\"Name\":\"\"}", "")]
+        [InlineData("{\"Name\":\" \"}", "")]
+        [InlineData("{\"Name\":null}", null)]
+        [InlineData("{\"Name\":\" a\"}", "a")]
+        [InlineData("{\"Name\":\" a test string   \"}", "a test string")]
+        [InlineData("{\"Name\":\"test\\n\\r\"}", "test")]
+        [InlineData("{\"Name\":\"\\n\\rtest\\n\\rtest\\n\\r\"}", "test\n\rtest")]
+        public void Read_DeserializesString_ToNullIfEmpty(string json, string expected)
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            var result = JsonSerializer.Deserialize<StubPerson>(json, options);
+
+            result.Name.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", "{\"Name\":\"\"}")]
+        [InlineData(" ", "{\"Name\":\"\"}")]
+        [InlineData(null, "{\"Name\":null}")]
+        [InlineData(" a", "{\"Name\":\"a\"}")]
+        [InlineData(" a test string   ", "{\"Name\":\"a test string\"}")]
+        [InlineData("test\n\r", "{\"Name\":\"test\"}")]
+        [InlineData("\n\rtest\n\rtest\n\r", "{\"Name\":\"test\\n\\rtest\"}")]
+        public void Write_SerializesString_ToNullIfEmpty(string input, string expected)
+        {
+            var stub = new StubPerson() { Name = input };
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            var result = JsonSerializer.Serialize(stub, options);
+
+            result.Should().Be(expected);
+        }
+
+        private class StubPerson
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -125,6 +125,30 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Constructor_WithEntityThatHasUntrimmedAndEmptyStrings_TrimsAndNullifiesStrings()
+        {
+            var entity = new Entity("mock") { Id = Guid.NewGuid() };
+            entity["dfe_field3"] = "   a field3\n\rgoes here\n\r  ";
+            entity["dfe_field4"] = "  ";
+
+            var mock = new MockModel(entity, _crm);
+
+            mock.Field3.Should().Be("a field3\n\rgoes here");
+            mock.Field4.Should().BeNull();
+        }
+
+        [Fact]
+        public void Constructor_WithEntityThatHasNullStrings_MapsCorrectly()
+        {
+            var entity = new Entity("mock") { Id = Guid.NewGuid() };
+            entity["dfe_field3"] = null as string;
+
+            var mock = new MockModel(entity, _crm);
+
+            mock.Field3.Should().BeNull();
+        }
+
+        [Fact]
         public void Constructor_WithEntityThatHasNoLoadedRelationships()
         {
             var entity = new Entity("mock") { Id = Guid.NewGuid() };


### PR DESCRIPTION
- Move existing json converter into subdir

We're going to have a couple of these and they aren't really utility classes anyway, so better off in their own folder.

- Add TrimStringJsonConverter

We have seen a few cases where the CRM has returned a postcode with a stray space at the start or end. If the candidate matches-back and the postcode is optional we will skip that step in the front-end and re-post the invalid postcode back to the API, at which point the submission fails validation.

This converter will ensure all string values are trimmed of white space when they exit/enter the API.

- Trim strings coming back from the CRM

Some string values in the CRM have leading/trailing white space; this can be an issue if they get ran through a strict validator (such as the postcode validator).

By trimming strings returned from the CRM we can avoid potential issues with validation later on.