### PR TITLE
Remove action to simulate an error

### DIFF
--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -78,19 +78,5 @@ namespace GetIntoTeachingApi.Controllers
 
             return Ok(response);
         }
-
-        [HttpGet]
-        [Route("simulate_error")]
-        [SwaggerOperation(
-            Summary = "Simulates a 500 error to test the Sentry integration.",
-            OperationId = "SimulateError",
-            Tags = new[] { "Operations" })]
-        [ProducesResponseType(typeof(HealthCheckResponse), 200)]
-        public void SimulateError()
-        {
-            System.Text.StringBuilder builder = null;
-
-            builder.Append("throw error");
-        }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -54,12 +54,6 @@ namespace GetIntoTeachingApiTests.Controllers
             ).Should().BeTrue();
         }
 
-        [Fact]
-        public void SimulateError_ThrowsNullReferenceException()
-        {
-            _controller.Invoking(c => c.SimulateError()).Should().Throw<NullReferenceException>();
-        }
-
         [Theory]
         [InlineData(true, true, true, true, true, "healthy")]
         [InlineData(true, true, true, false, true, "degraded")]


### PR DESCRIPTION
This was added when we were integrating Sentry initially to sanity check that it was working in all environments. Removing it as it could leave us open to someone abusing the endpoint and eating up our quota (the operations endpoints aren't behind authentication).