### PR TITLE
Run DB migration earlier in startup

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -248,6 +248,14 @@ The GIT API aims to provide:
 
             app.UseAuthorization();
 
+            // Configure the database.
+            var dbConfiguration = serviceScope.ServiceProvider.GetRequiredService<DbConfiguration>();
+
+            if (env.IsMasterInstance)
+            {
+                dbConfiguration.Migrate();
+            }
+
             // Configure recurring jobs.
             const string everyFifthMinute = "*/5 * * * *";
             const string everyMinute = "* * * * *";
@@ -282,14 +290,6 @@ The GIT API aims to provide:
             // Configure rate limiting.
             var clientPolicyStore = serviceScope.ServiceProvider.GetRequiredService<IClientPolicyStore>();
             clientPolicyStore.SeedAsync().GetAwaiter().GetResult();
-
-            // Configure the database.
-            var dbConfiguration = serviceScope.ServiceProvider.GetRequiredService<DbConfiguration>();
-
-            if (env.IsMasterInstance)
-            {
-                dbConfiguration.Migrate();
-            }
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
In some environments we check the database state before queueing jobs; previously we were migrating the database _after_ this check, which throws an exception if the database is empty (in need of the first migration being ran).

Moving the call to migrate the database earlier ensures it is ready in time.