### PR TITLE
Support explicitly setting the type on the sign up request model

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApi.Models
         public Guid? CountryId { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
+        public int? TypeId { get; set; }
         public int? UkDegreeGradeId { get; set; }
         public int? DegreeStatusId { get; set; }
         public int? DegreeTypeId { get; set; }
@@ -97,6 +98,7 @@ namespace GetIntoTeachingApi.Models
             AddressLine2 = candidate.AddressLine2;
             AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
+            TypeId = candidate.TypeId;
 
             AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
 
@@ -137,6 +139,7 @@ namespace GetIntoTeachingApi.Models
                 AddressPostcode = AddressPostcode,
                 Telephone = Telephone,
                 TeacherId = TeacherId,
+                TypeId = TypeId,
                 InitialTeacherTrainingYearId = InitialTeacherTrainingYearId,
                 PreferredEducationPhaseId = PreferredEducationPhaseId,
                 HasGcseEnglishId = HasGcseMathsAndEnglishId,
@@ -276,6 +279,11 @@ namespace GetIntoTeachingApi.Models
 
         private void SetType(Candidate candidate)
         {
+            if (candidate.TypeId != null)
+            {
+                return;
+            }
+
             if (candidate.IsReturningToTeaching())
             {
                 candidate.TypeId = (int)Candidate.Type.ReturningToTeacherTraining;

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -69,6 +69,7 @@ namespace GetIntoTeachingApiTests.Models
                 CountryId = Guid.NewGuid(),
                 InitialTeacherTrainingYearId = 1,
                 PreferredEducationPhaseId = 2,
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 HasGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -101,6 +102,7 @@ namespace GetIntoTeachingApiTests.Models
             response.HasGcseScienceId.Should().Be(candidate.HasGcseScienceId);
             response.PlanningToRetakeGcseScienceId.Should().Be(candidate.PlanningToRetakeGcseScienceId);
             response.PlanningToRetakeGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
+            response.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
@@ -135,6 +137,7 @@ namespace GetIntoTeachingApiTests.Models
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 CountryId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 UkDegreeGradeId = 0,
                 DegreeStatusId = 1,
                 DegreeTypeId = 2,
@@ -174,6 +177,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
+            candidate.TypeId.Should().Be((int)Candidate.Type.InterestedInTeacherTraining);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
@@ -339,7 +343,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_TypeIdIsPresent_QualificationIsCreated()
+        public void Candidate_DegreeTypeIdIsPresent_QualificationIsCreated()
         {
             var request = new TeacherTrainingAdviserSignUp() { UkDegreeGradeId = null, DegreeStatusId = null, DegreeSubject = null, DegreeTypeId = 1 };
 
@@ -450,7 +454,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_ReturningToTeaching_TypeIsCorrect()
+        public void Candidate_SubjectTaughtIdIsPresent_ReturningToTeachingAndTypeIdAreCorrect()
         {
             var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
 
@@ -459,7 +463,7 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_NotReturningToTeaching_TypeIsCorrect()
+        public void Candidate_SubjectTaughtIdIsNull_ReturningToTeachingAndTypeIdAreCorrect()
         {
             var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
 


### PR DESCRIPTION
Currently the `TypeId` of a `Candidate` is inferred based on if any past teaching positions are present. Instead, we can explicitly pass this from the client in response to the "Are you returning to teaching?" question. This will have two benefits:

- We can then pre-fill this question on matchback
- We can use `TypeId` going forward to determine if a candidate is  returning to   teaching

Initially this is being added as an optional field; once the TTA service has been updated we can add validation to ensure it is always present and remove the code to infer the type.