### PR TITLE
Return NoResult instead of Failure when Authorization header missing

### DIFF
--- a/GetIntoTeachingApi/Auth/ApiClientHandler.cs
+++ b/GetIntoTeachingApi/Auth/ApiClientHandler.cs
@@ -13,7 +13,6 @@ namespace GetIntoTeachingApi.Auth
     public class ApiClientHandler : AuthenticationHandler<ApiClientSchemaOptions>
     {
         private readonly IClientManager _clientManager;
-        private readonly ILogger<ApiClientHandler> _logger;
 
         public ApiClientHandler(
             IClientManager clientManager,
@@ -24,7 +23,6 @@ namespace GetIntoTeachingApi.Auth
             : base(options, loggerFactory, encoder, clock)
         {
             _clientManager = clientManager;
-            _logger = loggerFactory.CreateLogger<ApiClientHandler>();
         }
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -32,9 +30,13 @@ namespace GetIntoTeachingApi.Auth
             var apiKey = GetApiKey();
             var claims = AuthenticateApiClient(apiKey);
 
+            if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
             if (string.IsNullOrWhiteSpace(apiKey) || !claims.Any())
             {
-                _logger.LogWarning("ApiClientHandler - API key is not valid");
                 return Task.FromResult(AuthenticateResult.Fail("API key is not valid"));
             }
 

--- a/GetIntoTeachingApiTests/Auth/ApiClientHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/ApiClientHandlerTests.cs
@@ -91,6 +91,7 @@ namespace GetIntoTeachingApiTests.Auth
             var result = await _handler.AuthenticateAsync();
 
             result.Succeeded.Should().BeFalse();
+            result.Failure.Message.Should().Be("API key is not valid");
         }
 
         [Fact]
@@ -103,19 +104,6 @@ namespace GetIntoTeachingApiTests.Auth
             var result = await _handler.AuthenticateAsync();
 
             result.Succeeded.Should().BeFalse();
-        }
-
-        [Fact]
-        public async void InitializeAsync_IncorrectAuthorizationHeader_LogsWarning()
-        {
-            var context = new DefaultHttpContext();
-            context.Request.Headers.Add("Authorization", "incorrect_admin_secret");
-            var scheme = new AuthenticationScheme("ApiClientHandler", null, typeof(ApiClientHandler));
-            await _handler.InitializeAsync(scheme, context);
-
-            await _handler.AuthenticateAsync();
-
-            _mockLogger.VerifyWarningWasCalled("ApiClientHandler - API key is not valid");
         }
     }
 }


### PR DESCRIPTION
Some actions in the API don't require authentication (such as the health-check). Currently, if a request doesn't contain an `Authorization` header we return `AuthenticateResult.Failure` which marks the request as unauthorized _and_ logs out an error.

Instead, we should be returning `Authenticate.NoResult` if the request can't be authenticated due to missing `Authorization` header, which still results in a 401 unauthorized but prevents logging an error (we return `AuthenticateResult.Failure` when the header is present but the API key is invalid, which is when the error logging is useful).

Removes manual logging as ASP.NET Core will log out the failure anyway, so we were seeing duplicate log lines.