### PR TITLE
Stop inferring returning teacher status from other attributes

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -270,7 +270,7 @@ namespace GetIntoTeachingApi.Models
 
         public bool IsReturningToTeaching()
         {
-            return PastTeachingPositions.Count > 0;
+            return TypeId == (int)Type.ReturningToTeacherTraining;
         }
 
         public bool HasGcseMathsAndEnglish()

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -161,7 +161,6 @@ namespace GetIntoTeachingApi.Models
             AddQualification(candidate);
             AddPastTeachingPosition(candidate);
             SetAdviserEligibility(candidate);
-            SetType(candidate);
             DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
@@ -274,23 +273,6 @@ namespace GetIntoTeachingApi.Models
                 candidate.AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned;
                 candidate.AdviserEligibilityId = (int)Candidate.AdviserEligibility.Yes;
                 candidate.AdviserRequirementId = (int)Candidate.AdviserRequirement.Yes;
-            }
-        }
-
-        private void SetType(Candidate candidate)
-        {
-            if (candidate.TypeId != null)
-            {
-                return;
-            }
-
-            if (candidate.IsReturningToTeaching())
-            {
-                candidate.TypeId = (int)Candidate.Type.ReturningToTeacherTraining;
-            }
-            else
-            {
-                candidate.TypeId = (int)Candidate.Type.InterestedInTeacherTraining;
             }
         }
 

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.DateOfBirth).NotNull();
             RuleFor(request => request.AcceptedPolicyId).NotNull();
             RuleFor(request => request.CountryId).NotNull();
+            RuleFor(request => request.TypeId).NotNull();
 
             RuleFor(request => request.PreferredEducationPhaseId)
                 .NotNull()

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -400,21 +400,17 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void IsReturningToTeaching_WhenHasPastTeachingPositions_ReturnsTrue()
+        public void IsReturningToTeaching_WhenTypeIsReturningToTeaching_ReturnsTrue()
         {
-            var candidate = new Candidate();
-            candidate.PastTeachingPositions.Add(new CandidatePastTeachingPosition());
+            var candidate = new Candidate() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
             candidate.IsReturningToTeaching().Should().BeTrue();
         }
 
         [Fact]
-        public void IsReturningToTeaching_WhenHasPastTeachingPositions_ReturnsFalse()
+        public void IsReturningToTeaching_WhenTypeIdIsInterestedInTeacherTraining_ReturnsFalse()
         {
-            var candidate = new Candidate
-            {
-                PastTeachingPositions = new List<CandidatePastTeachingPosition>()
-            };
+            var candidate = new Candidate() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
 
             candidate.IsReturningToTeaching().Should().BeFalse();
         }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -137,7 +137,7 @@ namespace GetIntoTeachingApiTests.Models
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 CountryId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
-                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 UkDegreeGradeId = 0,
                 DegreeStatusId = 1,
                 DegreeTypeId = 2,
@@ -177,7 +177,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
-            candidate.TypeId.Should().Be((int)Candidate.Type.InterestedInTeacherTraining);
+            candidate.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
@@ -235,10 +235,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_ReturningToTeaching_CorrectConsent()
         {
-            var request = new TeacherTrainingAdviserSignUp()
-            {
-                SubjectTaughtId = Guid.NewGuid()
-            };
+            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
             var candidate = request.Candidate;
 
@@ -249,10 +246,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_InterestedInTeaching_CorrectConsent()
         {
-            var request = new TeacherTrainingAdviserSignUp()
-            {
-                SubjectTaughtId = null
-            };
+            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
 
             var candidate = request.Candidate;
 
@@ -390,15 +384,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_ReturningToTeaching_PreferredEducationPhaseIdDefaultsToSecondary()
         {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
-
-            request.Candidate.PreferredEducationPhaseId.Should().Be((int)Candidate.PreferredEducationPhase.Secondary);
-        }
-
-        [Fact]
-        public void Candidate_SubjectTaughtIdIsNotNull_PreferredEducationPhaseIdDefaultsToSecondary()
-        {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
             request.Candidate.PreferredEducationPhaseId.Should().Be((int)Candidate.PreferredEducationPhase.Secondary);
         }
@@ -434,7 +420,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_ReturningToTeaching_IsEligibleForAdviser()
         {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
+            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
             request.Candidate.IsReturningToTeaching().Should().BeTrue();
             request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
@@ -443,32 +429,14 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Candidate_HasNoPastTeachingPositions_IsNotEligibleForAdviser()
+        public void Candidate_InterestedInTeaching_IsNotEligibleForAdviser()
         {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
+            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
 
             request.Candidate.IsReturningToTeaching().Should().BeFalse();
             request.Candidate.AssignmentStatusId.Should().BeNull();
             request.Candidate.AdviserEligibilityId.Should().BeNull();
             request.Candidate.AdviserRequirementId.Should().BeNull();
-        }
-
-        [Fact]
-        public void Candidate_SubjectTaughtIdIsPresent_ReturningToTeachingAndTypeIdAreCorrect()
-        {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = Guid.NewGuid() };
-
-            request.Candidate.IsReturningToTeaching().Should().BeTrue();
-            request.Candidate.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
-        }
-
-        [Fact]
-        public void Candidate_SubjectTaughtIdIsNull_ReturningToTeachingAndTypeIdAreCorrect()
-        {
-            var request = new TeacherTrainingAdviserSignUp() { SubjectTaughtId = null };
-
-            request.Candidate.IsReturningToTeaching().Should().BeFalse();
-            request.Candidate.TypeId.Should().Be((int)Candidate.Type.InterestedInTeacherTraining);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 UkDegreeGradeId = 1,
                 DegreeStatusId = 2,
-                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 InitialTeacherTrainingYearId = 3,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -236,7 +236,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 Telephone = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -281,7 +281,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 PhoneCallScheduledAt = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -337,7 +337,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -366,7 +366,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -451,7 +451,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
                 DegreeTypeId = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -578,7 +578,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
                 DegreeSubject = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -664,7 +664,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             {
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 UkDegreeGradeId = null,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -794,7 +794,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = -1,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             var result = _validator.TestValidate(request);
@@ -838,7 +838,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var request = new TeacherTrainingAdviserSignUp
             {
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 HasGcseMathsAndEnglishId = -1,
             };
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -35,6 +35,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 UkDegreeGradeId = 1,
                 DegreeStatusId = 2,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 InitialTeacherTrainingYearId = 3,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -86,6 +87,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_CountryIdIsNull_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.CountryId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_TypeIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.TypeId, null as int?);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -120,7 +120,10 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void SubscribeToTeacherTrainingAdviser_NotReturningToTeaching_CorrectSubscription()
         {
-            var candidate = new Candidate();
+            var candidate = new Candidate()
+            {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
+            };
 
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
 
@@ -137,8 +140,10 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void SubscribeToTeacherTrainingAdviser_ReturningToTeaching_CorrectSubscription()
         {
-            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
-            var candidate = new Candidate() { PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position } };
+            var candidate = new Candidate()
+            {
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
+            };
 
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
 
@@ -170,8 +175,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void SubscribeToTeacherTrainingAdviser_NewReturnerCandidate_CorrectConsent()
         {
-            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
-            var candidate = new Candidate() { PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position } };
+            var candidate = new Candidate() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
 
@@ -184,16 +188,15 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void SubscribeToTeacherTrainingAdviser_ExistingCandidate_DoesNotOptOutIfAlreadyConsented()
+        public void SubscribeToTeacherTrainingAdviser_ExistingReturnerCandidate_DoesNotOptOutIfAlreadyConsented()
         {
-            var position = new CandidatePastTeachingPosition() { Id = Guid.NewGuid() };
             var candidate = new Candidate()
             {
                 DoNotBulkEmail = false,
                 DoNotBulkPostalMail = false,
                 DoNotPostalMail = false,
                 DoNotSendMm = false,
-                PastTeachingPositions = new List<CandidatePastTeachingPosition>() { position },
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);


### PR DESCRIPTION
Until recently determining if a candidate was returning to teaching (vs interested in teaching) involved checking the `Candidate` model for `PastTeachingPosition` or checking the `TeacherTrainingAdviserSignUp` model for a `SubjectTaughtId`. This isn't very intuitive and the CRM actually stores a `TypeId` that tells us if the candidate is a returner. Now that the TTA service explicitly sends the `TypeId` we can consolidate and simplify how we determine if a `Candidate` is a returner.

- Make TypeId required on TeacherTrainingAdviserSignUp

The TTA app has been updated to send a `type_id` with all requests now, so we can mark this as required and remove the inferred logic around candidate type.

- Stop inferring candidate type in TeacherTrainingAdviserSignUp

This is now passed explicitly from the client and marked as required in the TeacherTrainingAdviserSignUp, so we no longer need to infer it.

Also updates `Candidate` to use the `TypeId` instead of inferring returning teachers from if they have any `PastTeachingPositions`.

Various tests updated so that they make more sense (instead of setting `SubjectTaughtId` or `PastTeachingPositions` to indicate a returner the `TypeId` is now explicitly set).