### PR TITLE
Clean up TeacherTrainingAdviserSignUpValidator/Tests

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -273,6 +273,11 @@ namespace GetIntoTeachingApi.Models
             return TypeId == (int)Type.ReturningToTeacherTraining;
         }
 
+        public bool IsInterestedInTeaching()
+        {
+            return TypeId == (int)Type.InterestedInTeacherTraining;
+        }
+
         public bool HasGcseMathsAndEnglish()
         {
             return new[] { HasGcseEnglishId, HasGcseMathsId }.All(g => g == (int)GcseStatus.HasOrIsPlanningOnRetaking);

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -9,128 +9,122 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public TeacherTrainingAdviserSignUpValidator(IStore store)
         {
-            RuleFor(request => request.FirstName).NotNull();
-            RuleFor(request => request.LastName).NotNull();
-            RuleFor(request => request.Email).NotNull();
+            RuleFor(request => request.FirstName).NotEmpty();
+            RuleFor(request => request.LastName).NotEmpty();
+            RuleFor(request => request.Email).NotEmpty();
             RuleFor(request => request.DateOfBirth).NotNull();
             RuleFor(request => request.AcceptedPolicyId).NotNull();
             RuleFor(request => request.CountryId).NotNull();
             RuleFor(request => request.TypeId).NotNull();
 
-            RuleFor(request => request.PreferredEducationPhaseId)
-                .NotNull()
-                .Unless(request => request.SubjectTaughtId != null);
+            When(request => request.Candidate.IsReturningToTeaching(), () =>
+            {
+                RuleFor(request => request.SubjectTaughtId).NotNull()
+                    .WithMessage("Must be set for candidates returning to teacher training.");
+                RuleFor(request => request.PreferredTeachingSubjectId).NotNull()
+                    .WithMessage("Must be set for candidates returning to teacher training.");
+            });
 
-            RuleFor(request => request.AddressLine1).NotEmpty().Unless(request => request.CountryId != LookupItem.UnitedKingdomCountryId)
-                .WithMessage("Must be set candidate in the UK.");
-            RuleFor(request => request.AddressCity).NotEmpty().Unless(request => request.CountryId != LookupItem.UnitedKingdomCountryId)
-                .WithMessage("Must be set candidate in the UK.");
-            RuleFor(request => request.AddressPostcode).NotEmpty().Unless(request => request.CountryId != LookupItem.UnitedKingdomCountryId)
-                .WithMessage("Must be set candidate in the UK.");
+            When(request => request.Candidate.IsInterestedInTeaching(), () =>
+            {
+                RuleFor(request => request.PreferredEducationPhaseId).NotNull()
+                    .WithMessage("Must be set for candidates interested in teacher training.");
+                RuleFor(request => request.InitialTeacherTrainingYearId).NotNull()
+                    .WithMessage("Must be set for candidates interested in teacher training.");
+                RuleFor(request => request.DegreeStatusId).NotNull()
+                    .WithMessage("Must be set for candidates interested in teacher training.");
+                RuleFor(request => request.DegreeTypeId).NotNull()
+                    .WithMessage("Must be set for candidates interested in teacher training.");
+
+                RuleFor(request => request.PreferredTeachingSubjectId).NotNull()
+                    .When(request => request.Candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
+                    .WithMessage("Must be set when preferred education phase is secondary.");
+
+                RuleFor(request => request.DegreeStatusId)
+                    .Must(status => status != (int)CandidateQualification.DegreeStatus.NoDegree)
+                    .WithMessage("Can not be no degree (ineligible for service).");
+
+                RuleFor(request => request.DegreeTypeId)
+                    .Must(type =>
+                        new List<int?>
+                        {
+                            (int)CandidateQualification.DegreeType.Degree,
+                            (int)CandidateQualification.DegreeType.DegreeEquivalent,
+                        }.Contains(type))
+                    .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree)
+                    .WithMessage("Must be set to degree or degree equivalent when the degree status is has a degree.");
+
+                RuleFor(request => request.DegreeTypeId)
+                    .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
+                    .When(request => StudyingForADegreeStatus().Contains(request.DegreeStatusId))
+                    .WithMessage("Must be set to degree when status is studying for a degree.");
+
+                Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent, () =>
+                {
+                    RuleFor(request => request)
+                        .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request))
+                        .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
+                        .WithMessage("Must have or be retaking Maths and English GCSEs when preferred education phase is secondary.");
+
+                    RuleFor(request => request)
+                        .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request) && HasOrIsPlanningOnRetakingScience(request))
+                        .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
+                        .WithMessage("Must have or be retaking all GCSEs when preferred education phase is primary.");
+
+                    RuleFor(request => request.DegreeSubject).NotEmpty()
+                        .When(request => HaveOrStudyingForADegreeStatus().Contains(request.DegreeStatusId))
+                        .WithMessage("Must be set when candidate has a degree or is studying for a degree.");
+
+                    RuleFor(request => request.UkDegreeGradeId).NotNull()
+                        .When(request => HaveOrStudyingForADegreeStatus().Contains(request.DegreeStatusId))
+                        .WithMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
+                });
+
+                When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent, () =>
+                {
+                    RuleFor(request => request.Telephone).NotEmpty()
+                        .WithMessage("Must be set for candidates with an equivalent degree.");
+                    RuleFor(request => request.PhoneCallScheduledAt).NotNull()
+                        .When(request => request.CountryId == LookupItem.UnitedKingdomCountryId)
+                        .WithMessage("Must be set for candidate with UK equivalent degree.");
+                });
+            });
+
+            When(request => request.CountryId == LookupItem.UnitedKingdomCountryId, () =>
+            {
+                RuleFor(request => request.AddressLine1).NotEmpty().WithMessage("Must be set candidate in the UK.");
+                RuleFor(request => request.AddressCity).NotEmpty().WithMessage("Must be set candidate in the UK.");
+                RuleFor(request => request.AddressPostcode).NotEmpty().WithMessage("Must be set candidate in the UK.");
+            });
 
             RuleFor(request => request.Telephone).NotEmpty()
                 .When(request => request.PhoneCallScheduledAt != null)
                 .WithMessage("Must be set to schedule a callback.");
 
-            RuleFor(request => request.Telephone).NotEmpty()
-                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent && !request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set for candidates with an equivalent degree.");
-
-            RuleFor(request => request.PhoneCallScheduledAt).NotNull()
-                .When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent &&
-                !request.Candidate.IsReturningToTeaching() && request.CountryId == LookupItem.UnitedKingdomCountryId)
-                .WithMessage("Must be set for candidate with UK equivalent degree.");
             RuleFor(request => request.PhoneCallScheduledAt).Null()
-                .When(request => request.CountryId != LookupItem.UnitedKingdomCountryId)
-                .WithMessage("Cannot be set for overseas candidates.");
-
-            RuleFor(request => request.InitialTeacherTrainingYearId).NotNull()
-                .Unless(request => request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set unless candidate has past teaching positions.");
-
-            RuleFor(request => request.DegreeStatusId).NotEmpty()
-                .Unless(request => request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set unless candidate has past teaching positions.");
-
-            RuleFor(request => request.DegreeStatusId)
-                .Must(status => status != (int)CandidateQualification.DegreeStatus.NoDegree)
-                .Unless(request => request.Candidate.IsReturningToTeaching())
-                .WithMessage("Not eligible for service if degree status is no degree.");
-
-            RuleFor(request => request.DegreeTypeId).NotEmpty()
-                .Unless(request => request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set unless candidate has past teaching positions.");
-
-            RuleFor(request => request.DegreeTypeId)
-                .Must(type =>
-                    new List<int?>
-                    {
-                        (int)CandidateQualification.DegreeType.Degree,
-                        (int)CandidateQualification.DegreeType.DegreeEquivalent,
-                    }.Contains(type))
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.HasDegree && !request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
-
-            RuleFor(request => request.DegreeTypeId)
-                .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
-                .When(request =>
-                    new List<int?>
-                    {
-                        (int)CandidateQualification.DegreeStatus.FinalYear,
-                        (int)CandidateQualification.DegreeStatus.SecondYear,
-                        (int)CandidateQualification.DegreeStatus.FirstYear,
-                        (int)CandidateQualification.DegreeStatus.Other,
-                    }.Contains(request.DegreeStatusId))
-                .WithMessage("Must be set to degree when status is studying for a degree.");
-
-            RuleFor(request => request.DegreeTypeId)
-                .Must(type => type == (int)CandidateQualification.DegreeType.Degree)
-                .When(request => request.DegreeStatusId == (int)CandidateQualification.DegreeStatus.NoDegree && !request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set to degree when the degree status is no degree.");
-
-            RuleFor(request => request.DegreeSubject).NotEmpty()
-                .When(request =>
-                    new List<int?>
-                    {
-                        (int)CandidateQualification.DegreeStatus.HasDegree,
-                        (int)CandidateQualification.DegreeStatus.FinalYear,
-                        (int)CandidateQualification.DegreeStatus.SecondYear,
-                        (int)CandidateQualification.DegreeStatus.FirstYear,
-                        (int)CandidateQualification.DegreeStatus.Other,
-                    }.Contains(request.DegreeStatusId))
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set when candidate has a degree or is studying for a degree.");
-
-            RuleFor(request => request.UkDegreeGradeId).NotEmpty()
-                .When(request =>
-                    new List<int?>
-                    {
-                        (int)CandidateQualification.DegreeStatus.HasDegree,
-                        (int)CandidateQualification.DegreeStatus.FinalYear,
-                        (int)CandidateQualification.DegreeStatus.SecondYear,
-                        (int)CandidateQualification.DegreeStatus.FirstYear,
-                        (int)CandidateQualification.DegreeStatus.Other,
-                    }.Contains(request.DegreeStatusId))
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
-
-            RuleFor(request => request.PreferredTeachingSubjectId).NotEmpty()
-                .When(request => request.Candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
-                .WithMessage("Must be set when preferred education phase is secondary.");
-
-            RuleFor(request => request)
-                .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request) && HasOrIsPlanningOnRetakingScience(request))
-                .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
-                .Unless(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent || request.Candidate.IsReturningToTeaching())
-                .WithMessage("Must have or be retaking all GCSEs when preferred education phase is primary.");
-
-            RuleFor(request => request)
-                .Must(request => HasOrIsPlanningOnRetakingEnglishAndMaths(request))
-                .When(request => request.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
-                .Unless(request => request.Candidate.IsReturningToTeaching() || request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent)
-                .WithMessage("Must have or be retaking Maths and English GCSEs when preferred education phase is secondary.");
+                .When(request => request.CountryId != LookupItem.UnitedKingdomCountryId ||
+                    request.DegreeTypeId != (int)CandidateQualification.DegreeType.DegreeEquivalent)
+                .WithMessage("Can only be set for UK candidates with an equivalent degree.");
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
+        }
+
+        private static List<int?> StudyingForADegreeStatus()
+        {
+            return new List<int?>
+            {
+                (int)CandidateQualification.DegreeStatus.FinalYear,
+                (int)CandidateQualification.DegreeStatus.SecondYear,
+                (int)CandidateQualification.DegreeStatus.FirstYear,
+                (int)CandidateQualification.DegreeStatus.Other,
+            };
+        }
+
+        private static List<int?> HaveOrStudyingForADegreeStatus()
+        {
+            var status = StudyingForADegreeStatus();
+            status.Add((int)CandidateQualification.DegreeStatus.HasDegree);
+            return status;
         }
 
         private static bool HasOrIsPlanningOnRetakingEnglishAndMaths(TeacherTrainingAdviserSignUp request)

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -28,9 +28,9 @@ namespace GetIntoTeachingApi.Models.Validators
 
             When(request => request.CountryId == LookupItem.UnitedKingdomCountryId, () =>
             {
-                RuleFor(request => request.AddressLine1).NotNull().WithMessage("Must be set candidate in the UK.");
-                RuleFor(request => request.AddressCity).NotNull().WithMessage("Must be set candidate in the UK.");
-                RuleFor(request => request.AddressPostcode).NotNull().WithMessage("Must be set candidate in the UK.");
+                RuleFor(request => request.AddressLine1).NotNull().WithMessage("Must be set when the candidate is in the UK.");
+                RuleFor(request => request.AddressCity).NotNull().WithMessage("Must be set when the candidate is in the UK.");
+                RuleFor(request => request.AddressPostcode).NotNull().WithMessage("Must be set when the candidate is in the UK.");
             });
 
             When(request => request.Candidate.IsReturningToTeaching(), () =>

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -416,6 +416,22 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void IsInterestedInTeaching_WhenTypeIsInterestedInTeaching_ReturnsTrue()
+        {
+            var candidate = new Candidate() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
+
+            candidate.IsInterestedInTeaching().Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsInterestedInTeaching_WhenTypeIdIsIReturningToTeacherTraining_ReturnsFalse()
+        {
+            var candidate = new Candidate() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
+
+            candidate.IsInterestedInTeaching().Should().BeFalse();
+        }
+
+        [Fact]
         public void MagicLinkTokenExpired_WhenNull_ReturnsTrue()
         {
             var candidate = new Candidate

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -103,9 +103,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             var result = _validator.TestValidate(_request);
 
-            result.ShouldHaveValidationErrorFor(request => request.AddressLine1).WithErrorMessage("Must be set candidate in the UK.");
-            result.ShouldHaveValidationErrorFor(request => request.AddressCity).WithErrorMessage("Must be set candidate in the UK.");
-            result.ShouldHaveValidationErrorFor(request => request.AddressPostcode).WithErrorMessage("Must be set candidate in the UK.");
+            result.ShouldHaveValidationErrorFor(request => request.AddressLine1).WithErrorMessage("Must be set when the candidate is in the UK.");
+            result.ShouldHaveValidationErrorFor(request => request.AddressCity).WithErrorMessage("Must be set when the candidate is in the UK.");
+            result.ShouldHaveValidationErrorFor(request => request.AddressPostcode).WithErrorMessage("Must be set when the candidate is in the UK.");
 
             _request.CountryId = Guid.NewGuid();
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -53,7 +53,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 AddressLine2 = "Line 2",
                 AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
-                PhoneCallScheduledAt = DateTime.UtcNow,
             };
 
             var result = _validator.TestValidate(request);
@@ -100,8 +99,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = null,
-                SubjectTaughtId = null,
             };
 
             var result = _validator.TestValidate(request);
@@ -220,6 +219,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 Telephone = null,
             };
@@ -263,6 +263,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 PhoneCallScheduledAt = null,
@@ -300,7 +301,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Cannot be set for overseas candidates.");
+            result.ShouldHaveValidationErrorFor("PhoneCallScheduledAt").WithErrorMessage("Can only be set for UK candidates with an equivalent degree.");
         }
 
         [Fact]
@@ -308,6 +309,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 PhoneCallScheduledAt = DateTime.UtcNow,
@@ -323,12 +325,13 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeStatusId").WithErrorMessage("Not eligible for service if degree status is no degree.");
+            result.ShouldHaveValidationErrorFor("DegreeStatusId").WithErrorMessage("Can not be no degree (ineligible for service).");
         }
 
         [Fact]
@@ -350,13 +353,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set degree or degree equivalent when the degree status is has a degree.");
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
@@ -379,6 +383,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
             };
@@ -393,6 +398,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
             };
@@ -407,13 +413,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.FinalYear,
                 DegreeTypeId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set to degree when status is studying for a degree.");
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
@@ -421,6 +428,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.FinalYear,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
             };
@@ -435,13 +443,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
                 DegreeTypeId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set to degree when the degree status is no degree.");
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
@@ -464,6 +473,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.NoDegree,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
             };
@@ -474,25 +484,25 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndInitialTeacherTrainingYearIsNull_HasError()
+        public void Validate_TypeIdIsInterestedInTeachingAndInitialTeacherTrainingYearIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 InitialTeacherTrainingYearId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("InitialTeacherTrainingYearId").WithErrorMessage("Must be set unless candidate has past teaching positions.");
+            result.ShouldHaveValidationErrorFor("InitialTeacherTrainingYearId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndInitialTeacherTrainingYearIsNotNull_HasNoError()
+        public void Validate_TypeIdIsInterestedInTeachingAndInitialTeacherTrainingYearIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 InitialTeacherTrainingYearId = 1,
             };
 
@@ -502,25 +512,25 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndDegreeStatusIsNull_HasError()
+        public void Validate_TypeIdIsInterestedInTeachingAndDegreeStatusIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeStatusId").WithErrorMessage("Must be set unless candidate has past teaching positions.");
+            result.ShouldHaveValidationErrorFor("DegreeStatusId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndDegreeStatusIsNotNull_HasNoError()
+        public void Validate_TypeIdIsInterestedInTeachingAndDegreeStatusIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = 1,
             };
 
@@ -530,25 +540,25 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndDegreeTypeIsNull_HasError()
+        public void Validate_TypeIdIsInterestedInTeachingAndDegreeTypeIsNull_HasError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeTypeId = null,
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set unless candidate has past teaching positions.");
+            result.ShouldHaveValidationErrorFor("DegreeTypeId").WithErrorMessage("Must be set for candidates interested in teacher training.");
         }
 
         [Fact]
-        public void Validate_NoPastTeachingPositionsAndDegreeTypeIsNotNull_HasNoError()
+        public void Validate_TypeIdIsInterestedInTeachingAndDegreeTypeIsNotNull_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = null,
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeTypeId = 1,
             };
 
@@ -562,6 +572,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
                 DegreeSubject = null,
             };
@@ -591,6 +602,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 DegreeSubject = null,
@@ -606,6 +618,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.FirstYear,
                 DegreeSubject = "Maths",
             };
@@ -620,6 +633,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeSubject = null,
             };
@@ -634,6 +648,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeSubject = "English",
             };
@@ -648,6 +663,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 UkDegreeGradeId = null,
             };
@@ -677,6 +693,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
                 UkDegreeGradeId = null,
@@ -692,6 +709,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 UkDegreeGradeId = 1,
             };
@@ -706,6 +724,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 UkDegreeGradeId = null,
             };
@@ -720,6 +739,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 DegreeStatusId = (int)CandidateQualification.DegreeStatus.HasDegree,
                 UkDegreeGradeId = 1,
             };
@@ -734,6 +754,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 PreferredTeachingSubjectId = null,
             };
@@ -748,6 +769,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 PreferredTeachingSubjectId = Guid.NewGuid(),
             };
@@ -758,11 +780,11 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_HasPastTeachingPositionsAndPreferredEducationPhaseIsSecondary_HasNoError()
+        public void Validate_TypeIdIsReturningToTeachingAndPreferredEducationPhaseIsSecondary_HasNoError()
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                SubjectTaughtId = Guid.NewGuid(),
+                TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
             };
 
@@ -776,6 +798,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = -1,
@@ -807,6 +830,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -822,6 +846,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary,
                 HasGcseMathsAndEnglishId = -1,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
@@ -837,8 +862,8 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
-                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
+                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = -1,
             };
 
@@ -852,6 +877,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = -1,
                 DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent,
@@ -867,6 +893,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = -1,
             };
@@ -881,6 +908,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new TeacherTrainingAdviserSignUp
             {
+                TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
                 PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,


### PR DESCRIPTION
- Re-structure the TTA sign up validation

By nesting the rules it makes the validator easier to read.

Add `IsInterestedInTeaching` helper to `Candidate` for convenience.

Tests left largely unchanged.

- Clean up TeacherTrainingAdviserSignUpValidatorTests

Refactors the tests to be more readable and groups them into two main classes for returning to teacher training and interested in teacher training.