### PR TITLE
Validate CRM responses when mapping to BaseModel subclasses

### DIFF
--- a/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
+++ b/GetIntoTeachingApi/Models/CallbackBookingQuota.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -29,8 +30,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public CallbackBookingQuota(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public CallbackBookingQuota(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -256,11 +256,6 @@ namespace GetIntoTeachingApi.Models
         public Candidate(Entity entity, ICrmService crm)
             : base(entity, crm)
         {
-            // Treat invalid postcodes coming back from the CRM as null.
-            if (AddressPostcode != null && !Location.PostcodeRegex.IsMatch(AddressPostcode))
-            {
-                AddressPostcode = null;
-            }
         }
 
         public bool HasTeacherTrainingAdviser()

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -253,8 +254,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public Candidate(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public Candidate(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
 

--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -25,8 +26,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public CandidatePastTeachingPosition(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public CandidatePastTeachingPosition(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -26,8 +27,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public CandidatePrivacyPolicy(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public CandidatePrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -40,8 +41,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public CandidateQualification(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public CandidateQualification(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -43,8 +44,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public PhoneCall(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public PhoneCall(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/PrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/PrivacyPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -23,8 +24,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public PrivacyPolicy(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public PrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -75,8 +76,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public TeachingEvent(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public TeachingEvent(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -35,8 +36,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public TeachingEventBuilding(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public TeachingEventBuilding(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -29,8 +30,8 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public TeachingEventRegistration(Entity entity, ICrmService crm)
-            : base(entity, crm)
+        public TeachingEventRegistration(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
         {
         }
 

--- a/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidatePastTeachingPositionValidator.cs
@@ -9,9 +9,11 @@ namespace GetIntoTeachingApi.Models.Validators
         public CandidatePastTeachingPositionValidator(IStore store)
         {
             RuleFor(position => position.EducationPhaseId)
-                .SetValidator(new PickListItemIdValidator("dfe_candidatepastteachingposition", "dfe_educationphase", store));
+                .SetValidator(new PickListItemIdValidator("dfe_candidatepastteachingposition", "dfe_educationphase", store))
+                .Unless(position => position.EducationPhaseId == null);
             RuleFor(position => position.SubjectTaughtId)
-                .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store));
+                .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store))
+                .Unless(position => position.SubjectTaughtId == null);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -31,13 +31,10 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be true or false (as string values).");
 
             RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator(store)).Unless(candidate => candidate.PhoneCall == null);
-            RuleFor(candidate => candidate.PrivacyPolicy).NotNull().SetValidator(new CandidatePrivacyPolicyValidator(store));
+            RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(store));
             RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(store));
             RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(store));
             RuleForEach(candidate => candidate.TeachingEventRegistrations).SetValidator(new TeachingEventRegistrationValidator(store));
-            RuleFor(candidate => candidate.TeachingEventRegistrations)
-                .Must(registrations => registrations.Select(s => s.EventId).Distinct().Count() == registrations.Count)
-                .WithMessage("Must not contain multiple registrations for the same event.");
 
             RuleFor(candidate => candidate.PreferredTeachingSubjectId)
                 .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store))
@@ -54,10 +51,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.ChannelId)
                 .SetValidator(new PickListItemIdValidator("contact", "dfe_channelcreation", store))
                 .Unless(candidate => candidate.Id != null);
-            RuleFor(candidate => candidate.ChannelId)
-                .Must(id => id == null)
-                .Unless(candidate => candidate.Id == null)
-                .WithMessage("You cannot change the channel of an existing candidate.");
             RuleFor(candidate => candidate.HasGcseEnglishId)
                 .SetValidator(new PickListItemIdValidator("contact", "dfe_websitehasgcseenglish", store))
                 .Unless(candidate => candidate.HasGcseEnglishId == null);

--- a/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/PhoneCallValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentValidation;
+﻿using FluentValidation;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Validators;
 
@@ -9,9 +8,9 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public PhoneCallValidator(IStore store)
         {
-            RuleFor(phoneCall => phoneCall.ScheduledAt).GreaterThan(candidate => DateTime.UtcNow);
             RuleFor(phoneCall => phoneCall.ChannelId)
-                .SetValidator(new PickListItemIdValidator("phonecall", "dfe_channelcreation", store));
+                .SetValidator(new PickListItemIdValidator("phonecall", "dfe_channelcreation", store))
+                .Unless(phoneCall => phoneCall.ChannelId == null);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using GetIntoTeachingApi.Services;
@@ -20,6 +21,9 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.Telephone).NotNull()
                 .When(request => request.PhoneCallScheduledAt != null)
                 .WithMessage("Must be set to schedule a callback.");
+            RuleFor(request => request.PhoneCallScheduledAt).GreaterThan(candidate => DateTime.UtcNow)
+                .When(request => request.PhoneCallScheduledAt != null)
+                .WithMessage("Can only be scheduled for future dates.");
 
             RuleFor(request => request.PhoneCallScheduledAt).Null()
                 .When(request => request.CountryId != LookupItem.UnitedKingdomCountryId ||

--- a/GetIntoTeachingApiTests/Mocks/Models.cs
+++ b/GetIntoTeachingApiTests/Mocks/Models.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -25,7 +26,8 @@ namespace GetIntoTeachingApiTests.Mocks
 
         public MockModel() : base() { }
 
-        public MockModel(Entity entity, ICrmService crm) : base(entity, crm) { }
+        public MockModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory) :
+            base(entity, crm, validatorFactory) { }
     }
 
     [Entity("relatedMock")]
@@ -33,6 +35,7 @@ namespace GetIntoTeachingApiTests.Mocks
     {
         public MockRelatedModel() : base() { }
 
-        public MockRelatedModel(Entity entity, ICrmService crm) : base(entity, crm) { }
+        public MockRelatedModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory) :
+            base(entity, crm, validatorFactory) { }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -477,20 +477,5 @@ namespace GetIntoTeachingApiTests.Models
 
             candidate.MagicLinkTokenAlreadyExchanged().Should().Be(expected);
         }
-
-        [Theory]
-        [InlineData("invalid", null)]
-        [InlineData("KY11 9YU", "KY11 9YU")]
-        public void Constructor_WithEntity_OnlyPopulatesValidAddressPostcodes(string postcode, string expected)
-        {
-            var mockCrm = new Mock<ICrmService>();
-            var entity = new Entity("contact");
-
-            entity.Attributes.Add("address1_postalcode", postcode);
-
-            var candidate = new Candidate(entity, mockCrm.Object);
-
-            candidate.AddressPostcode.Should().Be(expected);
-        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidatePastTeachingPositionValidatorTests.cs
@@ -52,9 +52,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_SubjectTaughtIdIsNull_HasError()
+        public void Validate_SubjectTaughtIdIsNull_HasNoError()
         {
-            _validator.ShouldHaveValidationErrorFor(position => position.SubjectTaughtId, null as Guid?);
+            _validator.ShouldNotHaveValidationErrorFor(position => position.SubjectTaughtId, null as Guid?);
         }
 
         [Fact]
@@ -64,9 +64,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_EducationPhaseIsNull_HasError()
+        public void Validate_EducationPhaseIsNull_HasNoError()
         {
-            _validator.ShouldHaveValidationErrorFor(position => position.EducationPhaseId, null as int?);
+            _validator.ShouldNotHaveValidationErrorFor(position => position.EducationPhaseId, null as int?);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -112,24 +112,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_TeachingEventRegistrationsWithDuplicateEvents_HasError()
-        {
-            var mockEvent = new TeachingEvent { Id = Guid.NewGuid() };
-
-            var candidate = new Candidate
-            {
-                TeachingEventRegistrations = new List<TeachingEventRegistration>
-                {
-                    new TeachingEventRegistration {EventId = (Guid)mockEvent.Id},
-                    new TeachingEventRegistration {EventId = (Guid)mockEvent.Id},
-                }
-            };
-            var result = _validator.TestValidate(candidate);
-
-            result.ShouldHaveValidationErrorFor("TeachingEventRegistrations");
-        }
-
-        [Fact]
         public void Validate_TechingEventRegistrationIsInvalid_HasError()
         {
             var candidate = new Candidate
@@ -180,11 +162,11 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var candidate = new Candidate
             {
-                PhoneCall = new PhoneCall() { ScheduledAt = DateTime.UtcNow.AddDays(-10) }
+                PhoneCall = new PhoneCall() { ChannelId = -1 }
             };
             var result = _validator.TestValidate(candidate);
 
-            result.ShouldHaveValidationErrorFor(c => c.PhoneCall.ScheduledAt);
+            result.ShouldHaveValidationErrorFor(c => c.PhoneCall.ChannelId);
         }
 
         [Fact]
@@ -197,12 +179,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.PrivacyPolicy.AcceptedPolicyId);
-        }
-
-        [Fact]
-        public void Validate_PrivacyPolicyIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PrivacyPolicy, null as CandidatePrivacyPolicy);
         }
 
         [Fact]
@@ -483,19 +459,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_ChannelIdIsNullWhenNewCandidate_HasError()
         {
             var candidate = new Candidate() { Id = null, ChannelId = null};
-            var result = _validator.TestValidate(candidate);
-
-            result.ShouldHaveValidationErrorFor("ChannelId");
-        }
-
-        [Fact]
-        public void Validate_ChannelIdIsNotNullWhenExistingCandidate_HasError()
-        {
-            var mockChannel = new PickListItem() { Id = 123 };
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
-                .Returns(new[] { mockChannel }.AsQueryable());
-            var candidate = new Candidate() { Id = Guid.NewGuid(), ChannelId = mockChannel.Id };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor("ChannelId");

--- a/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/PhoneCallValidatorTests.cs
@@ -42,27 +42,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_ScheduledAtInPast_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ScheduledAt, DateTime.UtcNow.AddMinutes(-1));
-        }
-
-        [Fact]
-        public void Validate_ScheduledAtInFuture_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(phoneCall => phoneCall.ScheduledAt, DateTime.UtcNow.AddMinutes(1));
-        }
-
-        [Fact]
         public void Validate_ChannelIdIsInvalid_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ChannelId, 123);
         }
 
         [Fact]
-        public void Validate_ChannelIdIsNull_HasError()
+        public void Validate_ChannelIdIsNull_HasNoError()
         {
-            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ChannelId, null as int?);
+            _validator.ShouldNotHaveValidationErrorFor(phoneCall => phoneCall.ChannelId, null as int?);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_WhenTelephoneIsNull_AndPhoneCallScheduledAtIsNotNull_HasError()
         {
             _request.Telephone = null;
-            _request.PhoneCallScheduledAt = DateTime.UtcNow;
+            _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(1);
 
             var result = _validator.TestValidate(_request);
 
@@ -61,7 +61,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenPhoneCallScheduledAtIsNotNull_AndCountryIsNotUk_OrDegreeTypeIsNotDegreeEquivalent_HasError()
         {
-            _request.PhoneCallScheduledAt = DateTime.UtcNow;
+            _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(1);
             _request.CountryId = Guid.NewGuid();
             _request.DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent;
 
@@ -454,7 +454,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
             }
 
             [Fact]
-            public void Validate_WhenPhoneCallScheduledAtIsNull_AndDegreeTypeIsDegreeEquivalent_AndCountryIdIsUk_HasError()
+            public void Validate_WhenPhoneCallScheduledAtIsNullOrInPast_AndDegreeTypeIsDegreeEquivalent_AndCountryIdIsUk_HasError()
             {
                 _request.PhoneCallScheduledAt = null;
                 _request.CountryId = LookupItem.UnitedKingdomCountryId;
@@ -465,7 +465,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 result.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt)
                     .WithErrorMessage("Must be set for candidate with UK equivalent degree.");
 
-                _request.PhoneCallScheduledAt = DateTime.UtcNow;
+                _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(-1);
+
+                result = _validator.TestValidate(_request);
+
+                result.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt)
+                    .WithErrorMessage("Can only be scheduled for future dates.");
+
+                _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(1);
 
                 result = _validator.TestValidate(_request);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -11,6 +11,8 @@ using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Xunit;
 using System.Linq.Dynamic.Core;
+using FluentValidation;
+using FluentValidation.Results;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -25,10 +27,13 @@ namespace GetIntoTeachingApiTests.Services
 
         public CrmServiceTests()
         {
+            var mockValidatorFactory = new Mock<IValidatorFactory>();
+            mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
+
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _context = new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
             _mockService.Setup(mock => mock.Context()).Returns(_context);
-            _crm = new CrmService(_mockService.Object);
+            _crm = new CrmService(_mockService.Object, mockValidatorFactory.Object);
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ You can hit the API endpoints directly from the Swagger UI - hit the `Authorize`
 
 The majority of the validation should be performed against the core models linked to Dynamics entities (any model that inherits from `BaseModel`). The validation in these models should make sure that the data is correct, but remain loose around which fields are required; often a model will be reused in different contexts and the required fields will change. `Candidate` is a good example of this; the request models `MailingListAddMember`, `TeacherTrainingAdviserSignUp` and `TeachingEventAddAttendee` all map onto `Candidate`, however the required fields are different for each.
 
+We also call registered validators for subclasses of `BaseModel` when mapping CRM entities into our API models. If the CRM returns an invalid value according to our validation logic it will be nullified. An example of where this can happen is with postcodes; if the CRM returns an invalid postcode we will nullify it (otherwise the client may re-post the invalid postcode back to the API without checking it and receive a 400 bad request response unexpectedly).
+
 Property names in request models should be consistent with any hidden `BaseModel` models they encapsulate and map to; this way the client can resolve the validation error messages back to the original request attributes. For example, the `MailingListAddMember.UkDegreeGradeId` maps to and is consistent with `MailingListAddMember.Candidate.Qualifications[0].UkDegreeGradeId`.
 
 ### Testing


### PR DESCRIPTION
The CRM may contain invalid data as their validation is not as stringent/complete as the API's. If we map an invalid field to a model that is used for matching back a candidate and that model gets re-posted to the API on form submission it will fail the validation (this can happen as optional fields are skipped in the front-end clients so the data will not be sanitized/validated until the API receives it).

We manually check the candidate postcode to validate it, but it would be better to auto-load the validator for the model being mapped to and running validation after the mapping process has completed. If a property fails validation we should nullify it.

- Remove manually clearing of invalid candidate postcodes

We're going to start doing this automatically using the existing model validators, so removing the one case where we do this manually already (nullify invalid candidate postcodes).

- Validate models mapped from CRM entities

When an entity comes back from the CRM we want to validate it so that we can nullify any invalid attributes that the CRM returns.

An example would be if a `contact` entity has an invalid `address1_postalcode`; if we mapped the invalid postcode to a `Candidate.AddressPostcode` and that was then used in a match-back scenario the client application would end up posting
the invalid postcode back to the API and the submission would fail validation.

By sanitising the responses from the CRM we can ensure the API won't inadvertently return invalid data to clients (and later receive it as part of a submission).

We only sanitize the field attributes (not the relationships) - this is because the related models get mapped recursively and their attributes will be validated as part of that mapping process.

- Update base model validators to be less strict

As we are now validating values coming back from the API we need to tweak some of the base model validators to ensure they will pass for old/existing data.

For example, the `PhoneCall.ScheduledAt` validation used to ensure dates were in the future, but if we retrieve an old candidate with past `PhoneCall` models attached to their record these dates could be in the past; in this case we shift that validation logic into the request model.

Other changes ensure that `null` values are valid for virtually all attributes (request model validators will enforce presence).

- Update README to clarify validation during mapping phase