### PR TITLE
Record metrics on event search results

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -23,6 +23,7 @@ namespace GetIntoTeachingApi.Controllers
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly ICrmService _crm;
         private readonly IStore _store;
+        private readonly IMetricService _metrics;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<TeachingEventsController> _logger;
 
@@ -31,11 +32,13 @@ namespace GetIntoTeachingApi.Controllers
             IBackgroundJobClient jobClient,
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
-            ILogger<TeachingEventsController> logger)
+            ILogger<TeachingEventsController> logger,
+            IMetricService metrics)
         {
             _store = store;
             _jobClient = jobClient;
             _crm = crm;
+            _metrics = metrics;
             _tokenService = tokenService;
             _logger = logger;
         }
@@ -66,6 +69,9 @@ namespace GetIntoTeachingApi.Controllers
             }
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);
+
+            _metrics.TeachingEventSearchResults.WithLabels(request.TypeId.ToString(), request.Radius.ToString()).Observe(teachingEvents.Count());
+
             return Ok(GroupTeachingEventsByType(teachingEvents, quantityPerType));
         }
 

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -8,6 +8,7 @@ namespace GetIntoTeachingApi.Services
         Histogram LocationSyncDuration { get; }
         Histogram MagicLinkTokenGenerationDuration { get; }
         Histogram HangfireJobQueueDuration { get; }
+        Histogram TeachingEventSearchResults { get; }
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }
         Counter CacheLookups { get; }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -15,6 +15,11 @@ namespace GetIntoTeachingApi.Services
             {
                 LabelNames = new[] { "job" },
             });
+        private static readonly Histogram _teachingEventSearchResults = Metrics
+            .CreateHistogram("api_teaching_event_search_results_count", "Histogram of teaching event search results.", new HistogramConfiguration
+            {
+                LabelNames = new[] { "type_id", "radius" },
+            });
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
@@ -42,6 +47,7 @@ namespace GetIntoTeachingApi.Services
         public Histogram LocationSyncDuration => _locationSyncDuration;
         public Histogram MagicLinkTokenGenerationDuration => _magicLinkTokenGenerationDuration;
         public Histogram HangfireJobQueueDuration => _hangfireJobQueueDuration;
+        public Histogram TeachingEventSearchResults => _teachingEventSearchResults;
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;
         public Counter CacheLookups => _cacheLookups;

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -27,6 +27,7 @@ namespace GetIntoTeachingApiTests.Controllers
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<IStore> _mockStore;
         private readonly Mock<ILogger<TeachingEventsController>> _mockLogger;
+        private readonly IMetricService _metrics;
         private readonly TeachingEventsController _controller;
         private readonly ExistingCandidateRequest _request;
 
@@ -38,8 +39,9 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockStore = new Mock<IStore>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockLogger = new Mock<ILogger<TeachingEventsController>>();
+            _metrics = new MetricService();
             _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object,
-                _mockTokenService.Object, _mockCrm.Object, _mockLogger.Object);
+                _mockTokenService.Object, _mockCrm.Object, _mockLogger.Object, _metrics);
         }
 
         [Fact]
@@ -131,6 +133,8 @@ namespace GetIntoTeachingApiTests.Controllers
             result.Last().TeachingEvents.Count().Should().Be(1);
 
             _mockLogger.VerifyInformationWasCalled("SearchGroupedByType: KY12 8FG");
+
+            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -72,5 +72,12 @@ namespace GetIntoTeachingApiTests.Services
             _metrics.VerifiedTotps.Name.Should().Be("api_verified_totps");
             _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "candidate_id", "totp", "valid" });
         }
+
+        [Fact]
+        public void TeachingEventSearchResults_ReturnsMetric()
+        {
+            _metrics.TeachingEventSearchResults.Name.Should().Be("api_teaching_event_search_results_count");
+            _metrics.TeachingEventSearchResults.LabelNames.Should().BeEquivalentTo(new[] { "type_id", "radius" });
+        }
     }
 }


### PR DESCRIPTION
[Trello-1352](https://trello.com/c/wAptzepa/1352-spike-review-the-radius-of-the-events-finder-to-10-miles-30-miles-50-miles)

We are thinking about tweaking the event search radius select options in the GiT app from the current options of 30/50/100 miles to see if users engage better with different search radii. Before we change it, we want to understand how users are interacting with the search in terms of which radius they select and how many results they receive in their search.

To enable this, we are adding a new histogram metric that observes event search results with labels for type and radius; this should give insight into how the different types of searches are performing.