### PR TITLE
Ignore change tracking on relationships

### DIFF
--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -233,9 +233,8 @@ namespace GetIntoTeachingApi.Models
             {
                 var attribute = EntityRelationshipAttribute(property);
                 var value = property.GetValue(this);
-                var valueChanged = ChangedPropertyNames.Contains(property.Name);
 
-                if (attribute == null || !valueChanged || value == null)
+                if (attribute == null || value == null)
                 {
                     continue;
                 }


### PR DESCRIPTION
We added change tracking to only write changed attributes back to the CRM. The issue with related objects is that the attribute is instantiated as a collection and the collection is mutated rather than the attribute itself changing. This was causing related models not being written back to the CRM.

Removing the check for if a value has changed will cause it to revert to the old behaviour of always writing the attributes back to the CRM. This should be fine for collections just now; if we get a use case in the future where we need to support only writing changed collection items back to the CRM we can tackle it then.