### PR TITLE
Manually serialize Hangfire payloads

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -60,7 +60,7 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            string json = JsonSerializer.Serialize(request.Candidate);
+            string json = request.Candidate.SerializeChangedTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();
@@ -113,7 +113,7 @@ namespace GetIntoTeachingApi.Controllers
                 return Unauthorized(result);
             }
 
-            string json = JsonSerializer.Serialize(result.Candidate);
+            string json = result.Candidate.SerializeChangedTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return Ok(new MailingListAddMember(result.Candidate));

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -59,7 +60,8 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(request.Candidate, null));
+            string json = JsonSerializer.Serialize(request.Candidate);
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();
         }
@@ -111,7 +113,8 @@ namespace GetIntoTeachingApi.Controllers
                 return Unauthorized(result);
             }
 
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(result.Candidate, null));
+            string json = JsonSerializer.Serialize(result.Candidate);
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return Ok(new MailingListAddMember(result.Candidate));
         }

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -52,7 +53,8 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 return BadRequest(this.ModelState);
             }
 
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(request.Candidate, null));
+            string json = JsonSerializer.Serialize(request.Candidate);
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -53,7 +53,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 return BadRequest(this.ModelState);
             }
 
-            string json = JsonSerializer.Serialize(request.Candidate);
+            string json = request.Candidate.SerializeChangedTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -118,7 +118,7 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            string json = JsonSerializer.Serialize(request.Candidate);
+            string json = request.Candidate.SerializeChangedTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
@@ -117,7 +118,8 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(request.Candidate, null));
+            string json = JsonSerializer.Serialize(request.Candidate);
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -48,6 +48,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
+		<PackageReference Include="Dahomey.Json" Version="1.10.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text.Json;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
@@ -51,7 +52,8 @@ namespace GetIntoTeachingApi.Jobs
             foreach (var candidate in candidates)
             {
                 _magicLinkTokenService.GenerateToken(candidate);
-                _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(candidate, null));
+                string json = JsonSerializer.Serialize(candidate);
+                _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(json, null));
             }
         }
     }

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Text.Json;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
@@ -52,7 +51,7 @@ namespace GetIntoTeachingApi.Jobs
             foreach (var candidate in candidates)
             {
                 _magicLinkTokenService.GenerateToken(candidate);
-                string json = JsonSerializer.Serialize(candidate);
+                string json = candidate.SerializeChangedTracked();
                 _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(json, null));
             }
         }

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -33,8 +34,10 @@ namespace GetIntoTeachingApi.Jobs
             _logger = logger;
         }
 
-        public void Run(Candidate candidate, PerformContext context)
+        public void Run(string json, PerformContext context)
         {
+            var candidate = JsonSerializer.Deserialize<Candidate>(json);
+
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
 
             if (IsLastAttempt(context, _contextAdapter))
@@ -81,6 +84,11 @@ namespace GetIntoTeachingApi.Jobs
 
         private PhoneCall ClearPhoneCall(Candidate candidate)
         {
+            if (candidate.PhoneCall == null)
+            {
+                return null;
+            }
+
             // Due to reasons unknown the phone call relationship can't be deep-inserted
             // in the same way we do for other relationships - we need to explicitly save them against
             // the candidate instead.

--- a/GetIntoTeachingApi/Mocks/MockModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockModel.cs
@@ -27,6 +27,7 @@ namespace GetIntoTeachingApi.Mocks
         [EntityRelationship("dfe_mock_dfe_relatedmock_mocks", typeof(MockRelatedModel))]
         public IEnumerable<MockRelatedModel> RelatedMocks { get; set; }
         public string CompoundField => $"Field 4: {Field4}";
+        public string FieldDefinedWithValue { get; set; } = "initial value";
 
         public MockModel()
             : base()

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -25,9 +25,11 @@ namespace GetIntoTeachingApi.Models
 
         public BaseModel()
         {
+            InitChangedPropertyNames();
         }
 
         public BaseModel(Entity entity, ICrmService crm, IValidatorFactory vaidatorFactory)
+            : this()
         {
             Id = entity.Id;
 
@@ -120,6 +122,19 @@ namespace GetIntoTeachingApi.Models
         {
             input = input?.Trim();
             return string.IsNullOrWhiteSpace(input) ? null : input;
+        }
+
+        private void InitChangedPropertyNames()
+        {
+            // Adds any properties that are defined with a value in the model.
+            var nonNullPropertyNames = GetType().GetProperties()
+                .Where(p => p.CanWrite && p.GetValue(this) != null)
+                .Select(p => p.Name);
+
+            foreach (var name in nonNullPropertyNames)
+            {
+                NotifyPropertyChanged(name);
+            }
         }
 
         private void NullifyInvalidFieldAttributes(IValidatorFactory validatorFactory)

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
@@ -18,13 +16,10 @@ namespace GetIntoTeachingApi.Models
 {
     public class BaseModel : INotifyPropertyChanged
     {
-        private readonly string[] _propertyNamesExcludedFromChangeTracking = new string[] { "ChangeTrackingEnabled", "ChangedPropertyNames" };
+        private readonly string[] _propertyNamesExcludedFromChangeTracking = new string[] { "ChangedPropertyNames" };
 
         [NotMapped]
         public HashSet<string> ChangedPropertyNames { get; set; } = new HashSet<string>();
-        [JsonIgnore]
-        [NotMapped]
-        public bool ChangeTrackingEnabled { get; set; } = true;
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public Guid? Id { get; set; }
 
@@ -99,7 +94,7 @@ namespace GetIntoTeachingApi.Models
 
         protected void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            if (ChangeTrackingEnabled && !_propertyNamesExcludedFromChangeTracking.Any(p => p == propertyName))
+            if (!_propertyNamesExcludedFromChangeTracking.Any(p => p == propertyName))
             {
                 ChangedPropertyNames.Add(propertyName);
             }
@@ -152,18 +147,6 @@ namespace GetIntoTeachingApi.Models
                     property.SetValue(this, null);
                 }
             }
-        }
-
-        [OnDeserializing]
-        private void StopChangeTracking(StreamingContext context)
-        {
-            ChangeTrackingEnabled = false;
-        }
-
-        [OnDeserialized]
-        private void StartChangeTracking(StreamingContext context)
-        {
-            ChangeTrackingEnabled = true;
         }
 
         private void MapFieldAttributesFromEntity(Entity entity)

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
+using Dahomey.Json;
 using dotenv.net;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Adapters;
@@ -95,6 +96,10 @@ namespace GetIntoTeachingApi
             })
             .AddJsonOptions(o =>
             {
+                // Ensures ChangedPropertyNames is deserialized correctly.
+                o.JsonSerializerOptions.IgnoreNullValues = true;
+                o.JsonSerializerOptions.SetupExtensions();
+
                 o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                 o.JsonSerializerOptions.Converters.Add(new TrimStringJsonConverter());
                 o.JsonSerializerOptions.Converters.Add(new EmptyStringToNullJsonConverter());

--- a/GetIntoTeachingApi/Utils/JsonExtensions.cs
+++ b/GetIntoTeachingApi/Utils/JsonExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json;
+using Dahomey.Json;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class JsonExtensions
+    {
+        private static JsonSerializerOptions _options = new JsonSerializerOptions()
+        {
+            IgnoreNullValues = true,
+        }.SetupExtensions();
+
+        public static T DeserializeChangedTracked<T>(this string json)
+        {
+            return JsonSerializer.Deserialize<T>(json, _options);
+        }
+
+        public static string SerializeChangedTracked<T>(this T value)
+        {
+            return JsonSerializer.Serialize(value, _options);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -12,6 +12,8 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
 using GetIntoTeachingApi.Attributes;
+using System.Text.Json;
+using Dahomey.Json;
 
 namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 {
@@ -103,12 +105,16 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
             response.Should().BeOfType<NoContentResult>();
             _mockJobClient.Verify(x => x.Create(
                 It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-                IsMatch(request.Candidate, (Candidate)job.Args[0])),
+                IsMatch(request.Candidate, (string)job.Args[0])),
                 It.IsAny<EnqueuedState>()));
         }
 
-        private static bool IsMatch(Candidate candidateA, Candidate candidateB)
+        private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
+            var options = new JsonSerializerOptions() { IgnoreNullValues = true };
+            options.SetupExtensions();
+            var candidateB = JsonSerializer.Deserialize<Candidate>(candidateBJson, options);
+
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options
                 .Excluding(c => c.TeacherTrainingAdviserSubscriptionStartAt)

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using FluentAssertions;
+﻿using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -45,7 +44,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_UpsertsCandidatesWithMagicLinkTokens()
         {
             var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
-            string json = JsonSerializer.Serialize(candidate);
+            string json = candidate.SerializeChangedTracked();
             _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(5000)).Returns(new Candidate[] { candidate });
 
             _job.Run();

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Text.Json;
+using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -44,6 +45,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_UpsertsCandidatesWithMagicLinkTokens()
         {
             var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
+            string json = JsonSerializer.Serialize(candidate);
             _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(5000)).Returns(new Candidate[] { candidate });
 
             _job.Run();
@@ -52,7 +54,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockJobClient.Verify(x => x.Create(
                 It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-                candidate == (Candidate)job.Args[0]),
+                json == (string)job.Args[0]),
                 It.IsAny<EnqueuedState>()));
 
             _mockLogger.VerifyInformationWasCalled("MagicLinkTokenGenerationJob - Started");

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using Dahomey.Json;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
@@ -19,6 +21,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly Candidate _candidate;
+        private readonly JsonSerializerOptions _options;
         private readonly IMetricService _metrics;
         private readonly UpsertCandidateJob _job;
         private readonly Mock<ILogger<UpsertCandidateJob>> _mockLogger;
@@ -29,6 +32,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm = new Mock<ICrmService>();
             _mockNotifyService = new Mock<INotifyService>();
             _mockLogger = new Mock<ILogger<UpsertCandidateJob>>();
+            _options = new JsonSerializerOptions() { IgnoreNullValues = true };
+            _options.SetupExtensions();
             _metrics = new MetricService();
             _candidate = new Candidate() { Id = Guid.NewGuid(), Email = "test@test.com" };
             _job = new UpsertCandidateJob(new Env(), _mockCrm.Object, _mockNotifyService.Object,
@@ -43,9 +48,9 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
 
-            _job.Run(_candidate, null);
+            _job.Run(JsonSerializer.Serialize(_candidate, _options), null);
 
-            _mockCrm.Verify(mock => mock.Save(_candidate), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<Candidate>(c => IsMatch(_candidate, c))), Times.Once);
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (1/24)");
             _mockLogger.VerifyInformationWasCalled($"UpsertCandidateJob - Succeeded - {_candidate.Id}");
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
@@ -58,46 +63,32 @@ namespace GetIntoTeachingApiTests.Jobs
             var registration = new TeachingEventRegistration() { EventId = Guid.NewGuid() };
             _candidate.TeachingEventRegistrations.Add(registration);
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
-            _mockCrm.Setup(mock => mock.Save(_candidate)).Callback(() => _candidate.Id = candidateId);
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
 
-            _job.Run(_candidate, null);
+            _job.Run(JsonSerializer.Serialize(_candidate, _options), null);
 
-            _mockCrm.Verify(mock => mock.Save(registration), Times.Once);
-            registration.CandidateId.Should().Be(candidateId);
+            registration.CandidateId = candidateId;
+            _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(r => IsMatch(registration, r))), Times.Once);
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
         }
 
         [Fact]
-        public void Run_WithPhoneCallOnSuccess_SavesPhoneCall()
-        {
-            var candidateId = Guid.NewGuid();
-            var phoneCall = new PhoneCall();
-            _candidate.PhoneCall = phoneCall;
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
-            _mockCrm.Setup(mock => mock.Save(_candidate)).Callback(() => _candidate.Id = candidateId);
-
-            _job.Run(_candidate, null);
-
-            _mockCrm.Verify(mock => mock.Save(phoneCall), Times.Once);
-            phoneCall.CandidateId.Should().Be(candidateId.ToString());
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
-        }
-
-        [Fact]
-        public void Run_WithPhoneCallOnSuccess_IncrementsCallbackBookingQuotaNumberOfBookings()
+        public void Run_WithPhoneCallOnSuccess_SavesPhoneCallAndIncrementsCallbackBookingQuotaNumberOfBookings()
         {
             var candidateId = Guid.NewGuid();
             var scheduledAt = DateTime.UtcNow.AddDays(3);
             var phoneCall = new PhoneCall() { ScheduledAt = scheduledAt };
-            var quota = new CallbackBookingQuota() { StartAt = scheduledAt, NumberOfBookings = 5, Quota = 10 };
             _candidate.PhoneCall = phoneCall;
+            var quota = new CallbackBookingQuota() { StartAt = scheduledAt, NumberOfBookings = 5, Quota = 10 };
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
-            _mockCrm.Setup(mock => mock.Save(_candidate)).Callback(() => _candidate.Id = candidateId);
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
             _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
 
-            _job.Run(_candidate, null);
+            _job.Run(JsonSerializer.Serialize(_candidate, _options), null);
 
-            _mockCrm.Verify(mock => mock.Save(quota), Times.Once);
+            phoneCall.CandidateId = candidateId.ToString();
+            _mockCrm.Verify(mock => mock.Save(It.Is<PhoneCall>(p => IsMatch(phoneCall, p))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<CallbackBookingQuota>(q => IsMatch(quota, q))), Times.Once);
             quota.NumberOfBookings.Should().Be(6);
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
         }
@@ -111,12 +102,12 @@ namespace GetIntoTeachingApiTests.Jobs
             var quota = new CallbackBookingQuota() { StartAt = scheduledAt, NumberOfBookings = 5, Quota = 5 };
             _candidate.PhoneCall = phoneCall;
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
-            _mockCrm.Setup(mock => mock.Save(_candidate)).Callback(() => _candidate.Id = candidateId);
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
             _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
 
-            _job.Run(_candidate, null);
+            _job.Run(JsonSerializer.Serialize(_candidate, _options), null);
 
-            _mockCrm.Verify(mock => mock.Save(quota), Times.Never);
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<CallbackBookingQuota>()), Times.Never);
             quota.NumberOfBookings.Should().Be(5);
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
         }
@@ -126,14 +117,20 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
 
-            _job.Run(_candidate, null);
+            _job.Run(JsonSerializer.Serialize(_candidate, _options), null);
 
-            _mockCrm.Verify(mock => mock.Save(_candidate), Times.Never);
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<Candidate>()), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_candidate.Email,
                 NotifyService.CandidateRegistrationFailedEmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Deleted");
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
+        }
+
+        private bool IsMatch(object objectA, object objectB)
+        {
+            objectA.Should().BeEquivalentTo(objectB);
+            return true;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -138,29 +138,16 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void ChangedPropertyNames_DuringDeserialization_IsNotAltered()
         {
-            // If you deserialize an object with change tracking enabled
-            // all of the attributes are considered 'changed' and the serialized
-            // ChangedPropertyNames are lost, which is not what we want.
+            // Ensures the JSON serializer correctly deserializes
+            // ChangedPropertyNames (and doesn't inadvertently change it
+            // during the deserialization process when writing to attributes).
             var model = new MockModel() { Id = Guid.NewGuid(), Field3 = "test" };
-
-            model.ChangeTrackingEnabled = false;
-            model.Field4 = "test";
-            model.ChangeTrackingEnabled = true;
 
             model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3" });
 
-            // Test using Newtonsoft.Json as Hangfire uses this (we manually disable tracking during deserialization).
-            string json = Newtonsoft.Json.JsonConvert.SerializeObject(model);
-            var deserializedModel = Newtonsoft.Json.JsonConvert.DeserializeObject<MockModel>(json);
-
-            deserializedModel.Id.Should().Be(model.Id);
-            deserializedModel.Field3.Should().Be(model.Field3);
-            deserializedModel.Field4.Should().Be(model.Field4);
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3" });
-
             // Test using System.Text.Json as this is the app default (works correctly out of the box with tracking enabled).
-            json = System.Text.Json.JsonSerializer.Serialize(model);
-            deserializedModel = System.Text.Json.JsonSerializer.Deserialize<MockModel>(json);
+            var json = System.Text.Json.JsonSerializer.Serialize(model);
+            var deserializedModel = System.Text.Json.JsonSerializer.Deserialize<MockModel>(json);
 
             deserializedModel.Id.Should().Be(model.Id);
             deserializedModel.Field3.Should().Be(model.Field3);

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using Dahomey.Json;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
@@ -145,14 +147,47 @@ namespace GetIntoTeachingApiTests.Models
 
             model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
 
-            // Test using System.Text.Json as this is the app default (works correctly out of the box with tracking enabled).
-            var json = System.Text.Json.JsonSerializer.Serialize(model);
-            var deserializedModel = System.Text.Json.JsonSerializer.Deserialize<MockModel>(json);
+            // Test serializing/deseriaizing model.
+            var json = JsonSerializer.Serialize(model);
+            var options = new JsonSerializerOptions() { IgnoreNullValues = true };
+            options.SetupExtensions();
+            var deserializedModel = JsonSerializer.Deserialize<MockModel>(json, options);
 
             deserializedModel.Id.Should().Be(model.Id);
             deserializedModel.Field3.Should().Be(model.Field3);
             deserializedModel.Field4.Should().Be(model.Field4);
             deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
+
+            // Test deserializing model with ChangedPropertyNames in different order/combinations.
+            json = "{\"ChangedPropertyNames\":[\"Id\",\"Field1\"],\"Field3\":null,\"Field2\":123}";
+            deserializedModel = JsonSerializer.Deserialize<MockModel>(json, options);
+
+            deserializedModel.Field2.Should().Be(123);
+            deserializedModel.Field3.Should().BeNull();
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1" });
+
+            json = "{\"Field3\":null,\"Field2\":123,\"ChangedPropertyNames\":[\"Id\",\"Field1\"]}";
+            deserializedModel = JsonSerializer.Deserialize<MockModel>(json, options);
+
+            deserializedModel.Field2.Should().Be(123);
+            deserializedModel.Field3.Should().BeNull();
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1" });
+        }
+
+        [Fact]
+        public void DisableEnableChangeTracking_WorksCorrectly()
+        {
+            var model = new MockModel() { Id = Guid.NewGuid() };
+
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "FieldDefinedWithValue" });
+
+            model.DisableChangeTracking();
+            model.Field4 = "test";
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "FieldDefinedWithValue" });
+
+            model.EnableChangeTracking();
+            model.Field2 = 123;
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "FieldDefinedWithValue", "Field2" });
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -107,32 +107,32 @@ namespace GetIntoTeachingApiTests.Models
         {
             var model = new MockModel();
 
-            // Empty on init.
-            model.ChangedPropertyNames.Should().BeEmpty();
+            // Contains fields defined with a value on init.
+            model.ChangedPropertyNames.Should().ContainSingle("FieldDefinedWithValue");
 
             // Null to value.
             model.Field3 = "test";
-            model.ChangedPropertyNames.Should().ContainSingle("Field3");
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3" });
 
             // Value to null.
             model.Field3 = null;
-            model.ChangedPropertyNames.Should().ContainSingle("Field3");
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3" });
 
             // Second property change.
             model.Field2 = 0;
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Field3", "Field2" });
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3", "Field2" });
 
             // Computed attributes.
             model.Field4 = "test";
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Field3", "Field2", "Field4", "CompoundField" });
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3", "Field2", "Field4", "CompoundField" });
 
             // Not changed to null.
             model.Field1 = null;
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Field3", "Field2", "Field4", "CompoundField", "Field1" });
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3", "Field2", "Field4", "CompoundField", "Field1" });
 
             // Init with changes.
             model = new MockModel() { Field3 = "test", Field2 = 0 };
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Field3", "Field2" });
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3", "Field2" });
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace GetIntoTeachingApiTests.Models
             // during the deserialization process when writing to attributes).
             var model = new MockModel() { Id = Guid.NewGuid(), Field3 = "test" };
 
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3" });
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
 
             // Test using System.Text.Json as this is the app default (works correctly out of the box with tracking enabled).
             var json = System.Text.Json.JsonSerializer.Serialize(model);
@@ -152,7 +152,7 @@ namespace GetIntoTeachingApiTests.Models
             deserializedModel.Id.Should().Be(model.Id);
             deserializedModel.Field3.Should().Be(model.Field3);
             deserializedModel.Field4.Should().Be(model.Field4);
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3" });
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
         }
 
         [Fact]


### PR DESCRIPTION
Hangfire uses Newtonsoft.Json by default and it turns out this wasn't deserializing payloads with change tracking information correctly - this PR swaps it out for System.Text.Json and makes some updates to ensure this is deserializing consistently.

Also marks properties defined with a value as changed on initialisation, as we do this for default values in models and they were being missed/skipped over.

- Remove custom Newtonsoft.Json deserialization logic

We're going to manually serialize/deserialize the Hangfire payloads using the default System.Text.Json serializer used in the rest of the app, instead of relying on Newtonsoft.Json that Hangfire uses by default (it appears to be buggy around deserializing the `ChangedPropertyNames` attribute of nested models).

- Mark properties defined with a value as changed

In a number of places we define attributes with a value, for example:

```
public string FieldWithValue { get; set; } = "initial value";
```

As these are set as part of initialising the object we don't receive property changed notifications. Instead, we have to manually fire the notifications on initialisation for these fields.

- Fix bug in deserializing ChangedPropertyNames

Initially I thought System.Text.Json was correctly deserializing `ChangedPropertyNames` by default, but it turns out when you get more complex objects with nesting and inheritance it can break due to the way the serializer works. It was also dependent on the order of the attributes when serialized.

In order to consistently serialize/deserialize models with change tracking this commit:

\- Turns on `IgnoreNullValues` - if the serializer encounters a `null` we don't want it to deserialize the attribute and modify `ChangedPropertyNames`. If a `null` _was_ changed it will already be present in the list when deserialized anyway. This will also keep the Hangifre payload length down and make it easier to interpret.

\- Turn change tracking off during deserialization. We serialize  `ChangedPropertyNames` so we don't want the deserializer to inadvertently effect the values.

\- Improves test coverage around deserialization to ensure various   orders/combinations work correctly.

- Manually serialize/deserialize UpsertCandidateJob payload

If we pass an object to a Hangfire job the library serializes/deserilizes it for us using Newtonsoft.Json. This library is buggy when it comes to deserializing the change tracking information and we also use System.Text.Json everywhere else in the application, so it makes sense to do it manually/using the same library. It also means we can have test coverage for the
serialization/deserialization process.

- Add convenience extensions for serializing/deserializing change tracked models

Add an extension that loads in the necessary `JsonSerializerOptions` to correctly serialize/deserialize models that have change tracking enabled.