### PR TITLE
Swap Newtonsoft.Json to System.Text.Json

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
 using Npgsql;
 
 namespace GetIntoTeachingApi.Database
@@ -36,7 +37,8 @@ namespace GetIntoTeachingApi.Database
 
         private static string GenerateConnectionString(IEnv env, string instanceName)
         {
-            var vcap = JsonConvert.DeserializeObject<VcapServices>(env.VcapServices);
+            var options = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+            var vcap = JsonSerializer.Deserialize<VcapServices>(env.VcapServices, options);
             var postgres = vcap.Postgres.First(p => p.InstanceName == instanceName);
 
             var builder = new NpgsqlConnectionStringBuilder
@@ -60,7 +62,7 @@ namespace GetIntoTeachingApi.Database
 
         internal class VcapPostgres
         {
-            [JsonProperty("instance_name")]
+            [JsonPropertyName("instance_name")]
             public string InstanceName { get; set; }
             public VcapCredentials Credentials { get; set; }
         }

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -26,7 +26,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DATABASE_INSTANCE_NAME": "gis",
         "HANGFIRE_INSTANCE_NAME": "gis",
-        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}]}",
+        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",

--- a/GetIntoTeachingApi/Redis/RedisConfiguration.cs
+++ b/GetIntoTeachingApi/Redis/RedisConfiguration.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Utils;
-using Newtonsoft.Json;
 using StackExchange.Redis;
 
 namespace GetIntoTeachingApi.Redis
@@ -10,7 +11,8 @@ namespace GetIntoTeachingApi.Redis
     {
         public static ConfigurationOptions ConfigurationOptions(IEnv env)
         {
-            var vcap = JsonConvert.DeserializeObject<VcapServices>(env.VcapServices);
+            var options = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+            var vcap = JsonSerializer.Deserialize<VcapServices>(env.VcapServices, options);
             var redis = vcap.Redis.First();
             var credentials = redis.Credentials;
 
@@ -38,7 +40,7 @@ namespace GetIntoTeachingApi.Redis
             public string Host { get; set; }
             public string Password { get; set; }
             public int Port { get; set; }
-            [JsonProperty("tls_enabled")]
+            [JsonPropertyName("tls_enabled")]
             public bool TlsEnabled { get; set; }
         }
     }

--- a/GetIntoTeachingApi/Redis/RedisRateLimitCounterStore.cs
+++ b/GetIntoTeachingApi/Redis/RedisRateLimitCounterStore.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AspNetCoreRateLimit;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using StackExchange.Redis;
 
 namespace GetIntoTeachingApi.Redis
@@ -55,7 +55,7 @@ namespace GetIntoTeachingApi.Redis
 
                     if (!string.IsNullOrEmpty(value))
                     {
-                        return JsonConvert.DeserializeObject<RateLimitCounter?>(value);
+                        return JsonSerializer.Deserialize<RateLimitCounter>(value) as RateLimitCounter?;
                     }
 
                     return null;
@@ -92,7 +92,7 @@ namespace GetIntoTeachingApi.Redis
             _ = await TryRedisCommandAsync(
                 async () =>
                 {
-                    await RedisDatabase.StringSetAsync(id, JsonConvert.SerializeObject(entry.Value), expirationTime);
+                    await RedisDatabase.StringSetAsync(id, JsonSerializer.Serialize(entry.Value), expirationTime);
 
                     return true;
                 },

--- a/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
@@ -19,8 +19,8 @@ namespace GetIntoTeachingApiTests.Helpers
             Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", TemplateDatabaseName);
             Environment.SetEnvironmentVariable("VCAP_SERVICES",
                 $"{{\"postgres\": [{{\"instance_name\": \"{TemplateDatabaseName}\",\"credentials\": {{\"host\": \"localhost\"," +
-                $"\"name\": \"{TemplateDatabaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": \"5432\"}}}}]," +
-                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": \"6379\",\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
+                $"\"name\": \"{TemplateDatabaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}}}]," +
+                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
 
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
             DbConfiguration.ConfigPostgres(ConnectionString, builder);


### PR DESCRIPTION
We still use Newtonsoft.Json in a couple of places; ideally we want to use System.Text.Json everywhere so we only have the one Json serializer; this updates the remaining places.

Updates integers in JSON fixtures to be without quotes as System.Text.Json is stricter than Newtonsoft.Json (the VCAP_SERVICES has them without quotes in cloud foundry so this change shouldn't effect the environments).