### PR TITLE
Teaching event buildings

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
@@ -9,7 +9,6 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/teaching_event_buildings")]
     [ApiController]
-    [LogRequests]
     [Authorize(Roles = "Admin,GetIntoTeaching")]
     public class TeachingEventBuildingsController : ControllerBase
     {

--- a/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
@@ -1,0 +1,39 @@
+﻿using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers
+{
+    [Route("api/teaching_event_buildings")]
+    [ApiController]
+    [LogRequests]
+    [Authorize(Roles = "Admin,GetIntoTeaching")]
+    public class TeachingEventBuildingsController : ControllerBase
+    {
+        private readonly IStore _store;
+
+        public TeachingEventBuildingsController(IStore store)
+        {
+            _store = store;
+        }
+
+        [HttpGet]
+        [CrmETag]
+        [PrivateShortTermResponseCache]
+        [Route("teaching_event_buildings")]
+        [SwaggerOperation(
+            Summary = "Retrieves all event buildings.",
+            OperationId = "GetTeachingEventBuildings",
+            Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(TeachingEventBuilding), 200)]
+        public IActionResult GetTeachingEventBuildings()
+        {
+            var buildings = _store.GetTeachingEventBuildings();
+
+            return Ok(buildings);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
@@ -10,6 +10,7 @@ namespace GetIntoTeachingApi.Controllers
     [Route("api/teaching_event_buildings")]
     [ApiController]
     [Authorize(Roles = "Admin,GetIntoTeaching")]
+    [PrivateShortTermResponseCache]
     public class TeachingEventBuildingsController : ControllerBase
     {
         private readonly IStore _store;
@@ -21,7 +22,6 @@ namespace GetIntoTeachingApi.Controllers
 
         [HttpGet]
         [CrmETag]
-        [PrivateShortTermResponseCache]
         [Route("")]
         [SwaggerOperation(
             Summary = "Retrieves all event buildings.",

--- a/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventBuildingsController.cs
@@ -22,11 +22,11 @@ namespace GetIntoTeachingApi.Controllers
         [HttpGet]
         [CrmETag]
         [PrivateShortTermResponseCache]
-        [Route("teaching_event_buildings")]
+        [Route("")]
         [SwaggerOperation(
             Summary = "Retrieves all event buildings.",
             OperationId = "GetTeachingEventBuildings",
-            Tags = new[] { "Teaching Events" })]
+            Tags = new[] { "Teaching Event Buildings" })]
         [ProducesResponseType(typeof(TeachingEventBuilding), 200)]
         public IActionResult GetTeachingEventBuildings()
         {

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -97,22 +97,6 @@ namespace GetIntoTeachingApi.Controllers
             return Ok(teachingEvent);
         }
 
-        [HttpGet]
-        [CrmETag]
-        [PrivateShortTermResponseCache]
-        [Route("teaching_event_buildings")]
-        [SwaggerOperation(
-         Summary = "Retrieves all event buildings.",
-         OperationId = "GetTeachingEvent",
-         Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(TeachingEventBuilding), 200)]
-        public IActionResult GetTeachingEventBuildings()
-        {
-            var teachingEvents = _store.GetTeachingEventBuildings();
-
-            return Ok(teachingEvents);
-        }
-
         [HttpPost]
         [Route("attendees")]
         [SwaggerOperation(

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -97,6 +97,22 @@ namespace GetIntoTeachingApi.Controllers
             return Ok(teachingEvent);
         }
 
+        [HttpGet]
+        [CrmETag]
+        [PrivateShortTermResponseCache]
+        [Route("teaching_event_buildings")]
+        [SwaggerOperation(
+         Summary = "Retrieves all event buildings.",
+         OperationId = "GetTeachingEvent",
+         Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(TeachingEventBuilding), 200)]
+        public IActionResult GetTeachingEventBuildings()
+        {
+            var teachingEvents = _store.GetTeachingEventBuildings();
+
+            return Ok(teachingEvents);
+        }
+
         [HttpPost]
         [Route("attendees")]
         [SwaggerOperation(

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -67,6 +67,7 @@ namespace GetIntoTeachingApi.Models
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]
+        [EntityField("msevtmgt_building", typeof(EntityReference), "msevtmgt_buildingid")]
         public Guid? BuildingId { get; set; }
         public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -222,7 +222,6 @@ namespace GetIntoTeachingApi.Services
             query.Criteria.AddFilter(filter);
 
             var link = query.AddLink("msevtmgt_building", "msevtmgt_building", "msevtmgt_buildingid", JoinOperator.LeftOuter);
-            link.Columns.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEventBuilding)));
             link.EntityAlias = "msevtmgt_event_building";
 
             var entities = _service.RetrieveMultiple(query);

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -221,9 +221,6 @@ namespace GetIntoTeachingApi.Services
             filter.Conditions.AddRange(new[] { statusCondition, futureDatedCondition, typeCondition, readableIdCondition });
             query.Criteria.AddFilter(filter);
 
-            var link = query.AddLink("msevtmgt_building", "msevtmgt_building", "msevtmgt_buildingid", JoinOperator.LeftOuter);
-            link.EntityAlias = "msevtmgt_event_building";
-
             var entities = _service.RetrieveMultiple(query);
 
             return entities.Select((entity) => new TeachingEvent(entity, this, _validatorFactory)).ToList();

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
@@ -228,6 +228,12 @@ namespace GetIntoTeachingApi.Services
             var entities = _service.RetrieveMultiple(query);
 
             return entities.Select((entity) => new TeachingEvent(entity, this, _validatorFactory)).ToList();
+        }
+
+        public IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings()
+        {
+            return _service.CreateQuery("msevtmgt_building", Context())
+                .Select((entity) => new TeachingEventBuilding(entity, this, _validatorFactory)).ToList();
         }
 
         private void LoadCandidateRelationships(Entity entity, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -26,5 +26,6 @@ namespace GetIntoTeachingApi.Services
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
+        IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -18,5 +18,6 @@ namespace GetIntoTeachingApi.Services
         Task<IEnumerable<TeachingEvent>> SearchTeachingEventsAsync(TeachingEventSearchRequest request);
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
+        IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -165,7 +165,6 @@ namespace GetIntoTeachingApi.Services
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
             var teachingEventBuildings = _crm.GetTeachingEventBuildings();
 
-
             foreach (var te in teachingEvents.Where(te => te.BuildingId != null))
             {
                 te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -43,6 +43,7 @@ namespace GetIntoTeachingApi.Services
 
         public async Task SyncAsync()
         {
+            await SyncTeachingEventBuildings();
             await SyncTeachingEvents();
             await SyncPrivacyPolicies();
             await SyncLookupItems();
@@ -150,21 +151,22 @@ namespace GetIntoTeachingApi.Services
             return result.Where(te => te.IsOnline && !te.IsVirtual);
         }
 
+        private async Task SyncTeachingEventBuildings()
+        {
+            var buildings = _crm.GetTeachingEventBuildings();
+            await PopulateTeachingEventCoordinates(buildings);
+
+            await SyncModels(buildings, _dbContext.TeachingEventBuildings);
+        }
+
         private async Task SyncTeachingEvents()
         {
             var afterDate = DateTime.UtcNow.Subtract(TeachingEventArchiveSize);
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
-            await PopulateTeachingEventCoordinates(teachingEvents);
 
-            var buildings = teachingEvents.Where(te => te.Building != null)
-                .Select(te => te.Building).DistinctBy(b => b.Id);
-
-            await SyncModels(buildings, _dbContext.TeachingEventBuildings);
-
-            // Link events with buildings attached to the context prior to sync.
             foreach (var te in teachingEvents.Where(te => te.Building != null))
             {
-                te.Building = await _dbContext.TeachingEventBuildings.FindAsync(te.Building.Id);
+                te.Building = await _dbContext.TeachingEventBuildings.FindAsync(te.BuildingId);
             }
 
             await SyncModels(teachingEvents, _dbContext.TeachingEvents);
@@ -248,12 +250,11 @@ namespace GetIntoTeachingApi.Services
             await _dbContext.SaveChangesAsync();
         }
 
-        private async Task PopulateTeachingEventCoordinates(IEnumerable<TeachingEvent> teachingEvents)
+        private async Task PopulateTeachingEventCoordinates(IEnumerable<TeachingEventBuilding> buildings)
         {
-            foreach (var teachingEvent in teachingEvents.Where(te => te.Building?.AddressPostcode != null))
+            foreach (var building in buildings.Where(building => building.AddressPostcode != null))
             {
-                var coordinate = await CoordinateForPostcode(teachingEvent.Building.AddressPostcode);
-                teachingEvent.Building.Coordinate = coordinate;
+                building.Coordinate = await CoordinateForPostcode(building.AddressPostcode);
             }
         }
 

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -163,7 +163,7 @@ namespace GetIntoTeachingApi.Services
         {
             var afterDate = DateTime.UtcNow.Subtract(TeachingEventArchiveSize);
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
-            var teachingEventBuildings = _crm.GetTeachingEventBuildings();
+            var teachingEventBuildings = _dbContext.TeachingEventBuildings.ToList();
 
             foreach (var te in teachingEvents.Where(te => te.BuildingId != null))
             {

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -113,6 +113,11 @@ namespace GetIntoTeachingApi.Services
             return await _dbContext.TeachingEvents.Include(e => e.Building).FirstOrDefaultAsync(e => e.ReadableId == readableId);
         }
 
+        public IQueryable<TeachingEventBuilding> GetTeachingEventBuildings()
+        {
+            return _dbContext.TeachingEventBuildings;
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -163,10 +163,12 @@ namespace GetIntoTeachingApi.Services
         {
             var afterDate = DateTime.UtcNow.Subtract(TeachingEventArchiveSize);
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
+            var teachingEventBuildings = _crm.GetTeachingEventBuildings();
 
-            foreach (var te in teachingEvents.Where(te => te.Building != null))
+
+            foreach (var te in teachingEvents.Where(te => te.BuildingId != null))
             {
-                te.Building = await _dbContext.TeachingEventBuildings.FindAsync(te.BuildingId);
+                te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);
             }
 
             await SyncModels(teachingEvents, _dbContext.TeachingEvents);

--- a/GetIntoTeachingApiTests/Controllers/LookupItemsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/LookupItemsControllerTests.cs
@@ -44,7 +44,11 @@ namespace GetIntoTeachingApiTests.Controllers
         public void CrmETag_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
-            var methods = typeof(LookupItemsController).GetMethods(BindingFlags.DeclaredOnly);
+
+            var methods = typeof(LookupItemsController).GetMethods(
+                BindingFlags.Public |
+                BindingFlags.Instance |
+                BindingFlags.DeclaredOnly);
 
             methods.ForEach(m => m.Should().BeDecoratedWith<CrmETagAttribute>());
         }

--- a/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApiTests.Helpers;
 using FluentAssertions;
 using GetIntoTeachingApi.Models;
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using MoreLinq;
 using Xunit;
 using GetIntoTeachingApi.Attributes;
+using Hangfire;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -39,7 +40,12 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void CrmETag_IsPresent()
         {
-            var methods = typeof(PickListItemsController).GetMethods(BindingFlags.DeclaredOnly);
+            JobStorage.Current = new Mock<JobStorage>().Object;
+
+            var methods = typeof(PickListItemsController).GetMethods(
+                BindingFlags.Public |
+                BindingFlags.Instance |
+                BindingFlags.DeclaredOnly);
 
             methods.ForEach(m => m.Should().BeDecoratedWith<CrmETagAttribute>());
         }

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventBuildingsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventBuildingsControllerTests.cs
@@ -1,11 +1,16 @@
 ﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Controllers;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
+using Hangfire;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using MoreLinq;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Controllers
@@ -19,6 +24,33 @@ namespace GetIntoTeachingApiTests.Controllers
         {
             _mockStore = new Mock<IStore>();
             _controller = new TeachingEventBuildingsController(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Authorize_IsPresent()
+        {
+            typeof(TeachingEventBuildingsController).Should()
+                .BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching");
+        }
+
+        [Fact]
+        public void PrivateShortTermResponseCache_IsPresent()
+        {
+            typeof(TeachingEventBuildingsController).Should()
+                .BeDecoratedWith<PrivateShortTermResponseCacheAttribute>();
+        }
+
+        [Fact]
+        public void CrmETag_IsPresent()
+        {
+            JobStorage.Current = new Mock<JobStorage>().Object;
+
+            var methods = typeof(TeachingEventBuildingsController).GetMethods(
+                BindingFlags.Public |
+                BindingFlags.Instance |
+                BindingFlags.DeclaredOnly);
+
+            methods.ForEach(m => m.Should().BeDecoratedWith<CrmETagAttribute>());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventBuildingsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventBuildingsControllerTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Controllers;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Controllers
+{
+    public class TeachingEventBuildingsControllerTests
+    {
+        private readonly Mock<IStore> _mockStore;
+
+        private readonly TeachingEventBuildingsController _controller;
+        public TeachingEventBuildingsControllerTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _controller = new TeachingEventBuildingsController(_mockStore.Object);
+        }
+
+        [Fact]
+        public void GetTeachingEventBuildings_ReturnsAllTeachingEventBuildings()
+        {
+            var mockBuildings = new List<TeachingEventBuilding>()
+            {
+                new TeachingEventBuilding() { AddressCity = "test" }
+            }
+            .AsQueryable();
+
+            _mockStore.Setup(mock => mock.GetTeachingEventBuildings()).Returns(mockBuildings);
+
+            var response = _controller.GetTeachingEventBuildings();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockBuildings);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -191,23 +191,6 @@ namespace GetIntoTeachingApiTests.Controllers
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
-        [Fact]
-        public void GetTeachingEventBuildings_ReturnsAllTeachingEventBuildings()
-        {
-            var mockBuildings = new List<TeachingEventBuilding>()
-            {
-                new TeachingEventBuilding() { AddressCity = "test" }
-            }
-            .AsQueryable();
-
-            _mockStore.Setup(mock => mock.GetTeachingEventBuildings()).Returns(mockBuildings);
-
-            var response = _controller.GetTeachingEventBuildings();
-
-            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
-            ok.Value.Should().Be(mockBuildings);
-        }
-
         private static IEnumerable<TeachingEvent> MockEvents()
         {
             var event1 = new TeachingEvent() { Name = "Event 1", TypeId = 123 };

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
@@ -189,6 +189,23 @@ namespace GetIntoTeachingApiTests.Controllers
             var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
 
             response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void GetTeachingEventBuildings_ReturnsAllTeachingEventBuildings()
+        {
+            var mockBuildings = new List<TeachingEventBuilding>()
+            {
+                new TeachingEventBuilding() { AddressCity = "test" }
+            }
+            .AsQueryable();
+
+            _mockStore.Setup(mock => mock.GetTeachingEventBuildings()).Returns(mockBuildings);
+
+            var response = _controller.GetTeachingEventBuildings();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().Be(mockBuildings);
         }
 
         private static IEnumerable<TeachingEvent> MockEvents()

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -17,7 +17,6 @@ using GetIntoTeachingApi.Attributes;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using GetIntoTeachingApiTests.Helpers;
-using System.Text.Json;
 using GetIntoTeachingApi.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
@@ -62,7 +61,7 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void CrmETagPrivateShortTermResponseCache_IsPresent()
+        public void PrivateShortTermResponseCache_IsPresent()
         {
             JobStorage.Current = new Mock<JobStorage>().Object;
             var methods = new[] { "Get", "SearchGroupedByType" };

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -38,6 +38,8 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));
+            type.GetProperty("BuildingId").Should().BeDecoratedWith<EntityFieldAttribute>(
+               a => a.Name == "msevtmgt_building" && a.Type == typeof(EntityReference));
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -468,6 +468,29 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().Be(existingEntity);
         }
 
+        [Fact]
+        public void GetTeachingEventBuildings_ReturnsAll()
+        {
+            _mockService.Setup(mock => mock.CreateQuery("msevtmgt_building", _context))
+                .Returns(MockTeachingEventBuildings());
+
+            var result = _crm.GetTeachingEventBuildings();
+
+            result.Select(e => e.Venue).Should().BeEquivalentTo(new string[] { "Venue 1", "Venue 2" },
+                options => options.WithStrictOrdering());
+        }
+
+        private static IQueryable<Entity> MockTeachingEventBuildings()
+        {
+            var building1 = new Entity("msevtmgt_building");
+            building1["msevtmgt_name"] = "Venue 1";
+
+            var building2 = new Entity("msevtmgt_building");
+            building2["msevtmgt_name"] = "Venue 2";
+
+            return new[] { building1, building2 }.AsQueryable();
+        }
+
         private static IQueryable<Entity> MockTeachingEvents()
         {
             var event1 = new Entity("msevtmgt_event");

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -479,6 +479,17 @@ namespace GetIntoTeachingApiTests.Services
             result.Building.Should().NotBeNull();
         }
 
+        [Fact]
+        public async Task GetTeachingEventBuildings_ReturnsAll()
+        {
+            var events = await SeedMockTeachingEventsAsync();
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.IsAny<DateTime>())).Returns(events);
+
+            var result = _store.GetTeachingEventBuildings().ToList();
+
+            result.Should().HaveCount(5);
+        }
+
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -25,12 +25,6 @@ namespace GetIntoTeachingApiTests.Services
         private readonly Mock<IGeocodeClientAdapter> _mockGeocodeClient;
         private readonly Mock<ICrmService> _mockCrm;
 
-        private static readonly Guid eventBuildingGuid1 = new Guid("67ffca5c-5adc-4a63-abb7-632c9ecbf283");
-        private static readonly Guid eventBuildingGuid2 = new Guid("194c0926-5f15-434d-88ba-f76c376ac865");
-        private static readonly Guid eventBuildingGuid3 = new Guid("6dc656a8-50cc-4802-a62a-47576ddbc493");
-        private static readonly Guid eventBuildingGuid4 = new Guid("adc3e6ce-65a8-4752-abcd-781365982a33");
-        private static readonly Guid eventBuildingGuid5 = new Guid("deb12260-84fc-43b5-8682-13aa1015f100");
-
         public StoreTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
             _mockGeocodeClient = new Mock<IGeocodeClientAdapter>();
@@ -84,8 +78,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SyncAsync_UpdatesExistingTeachingEvents()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            var updatedTeachingEvents = (await SeedMockTeachingEventsAsync()).ToList();
+            var updatedTeachingEvents = (await SeedMockTeachingEventsAndBuildingsAsync()).ToList();
             updatedTeachingEvents.ForEach(te =>
             {
                 te.Name += "Updated";
@@ -106,8 +99,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SyncAsync_DeletesOrphanedTeachingEvents()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var teachingEvents = MockTeachingEvents().ToList();
             _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(teachingEvents.GetRange(0, 1));
 
@@ -321,8 +313,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_WithoutFilters_ReturnsAll()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -336,8 +327,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_WithFilters_ReturnsMatching()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest()
             {
                 Postcode = "KY6 2NJ",
@@ -358,8 +348,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_WithFilters_ReturnsEventNarrowlyInRange()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest()
             {
                 Postcode = "KY6 2NJ",
@@ -380,8 +369,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_WithFilters_ExcludesEventNarrowlyOutOfRange()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest()
             {
                 Postcode = "KY6 2NJ",
@@ -400,8 +388,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByRadius_ReturnsMatchingAndOnlineEvents()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { Postcode = "KY6 2NJ", Radius = 15 };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -414,8 +401,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByRadiusWithOutwardOnlyPostcode_ReturnsMatchingAndOnlineEvents()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { Postcode = "KY6", Radius = 15 };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -428,8 +414,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByRadiusWithFailedPostcodeGeocoding_ReturnsEmpty()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { Postcode = "TE7 1NG", Radius = 15 };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -441,8 +426,7 @@ namespace GetIntoTeachingApiTests.Services
         public async void SearchTeachingEvents_FilteredByType_ReturnsMatching()
         {
             SeedMockLocations();
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -454,8 +438,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_FilteredByStartAfter_ReturnsMatching()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { StartAfter = DateTime.UtcNow.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -467,8 +450,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void SearchTeachingEvents_FilteredByStartBefore_ReturnsMatching()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            await SeedMockTeachingEventsAsync();
+            await SeedMockTeachingEventsAndBuildingsAsync();
             var request = new TeachingEventSearchRequest() { StartBefore = DateTime.UtcNow.AddDays(6) };
 
             var result = await _store.SearchTeachingEventsAsync(request);
@@ -480,8 +462,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void GetTeachingEventAsync_WithId_ReturnsMatchingEvent()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            var events = await SeedMockTeachingEventsAsync();
+            var events = await SeedMockTeachingEventsAndBuildingsAsync();
             var result = await _store.GetTeachingEventAsync((Guid)events.First().Id);
 
             result.Id.Should().Be(events.First().Id);
@@ -491,8 +472,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async void GetTeachingEventAsync_WithReadableId_ReturnsMatchingEvent()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            var events = await SeedMockTeachingEventsAsync();
+            var events = await SeedMockTeachingEventsAndBuildingsAsync();
             var result = await _store.GetTeachingEventAsync(events.First().ReadableId);
 
             result.ReadableId.Should().Be(events.First().ReadableId);
@@ -519,10 +499,10 @@ namespace GetIntoTeachingApiTests.Services
             return true;
         }
 
-        private static IEnumerable<TeachingEvent> MockTeachingEvents()
+        private static List<TeachingEvent> MockTeachingEvents()
         {
-            var sharedBuildingId = eventBuildingGuid1;
-
+            var buildings = MockTeachingEventBuildings();
+            var sharedBuildingId = buildings[0].Id;
 
             var event1 = new TeachingEvent()
             {
@@ -542,7 +522,7 @@ namespace GetIntoTeachingApiTests.Services
                 Name = "Event 2",
                 StartAt = DateTime.UtcNow.AddDays(1),
                 TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
-                BuildingId = eventBuildingGuid2
+                BuildingId = buildings[1].Id
             };
 
             var event3 = new TeachingEvent()
@@ -552,7 +532,7 @@ namespace GetIntoTeachingApiTests.Services
                 Name = "Event 3",
                 StartAt = DateTime.UtcNow.AddDays(10),
                 TypeId = (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
-                BuildingId = eventBuildingGuid3
+                BuildingId = buildings[2].Id
             };
 
             var event4 = new TeachingEvent()
@@ -562,7 +542,7 @@ namespace GetIntoTeachingApiTests.Services
                 Name = "Event 4",
                 StartAt = DateTime.UtcNow.AddDays(3),
                 TypeId = (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
-                BuildingId = eventBuildingGuid4
+                BuildingId = buildings[3].Id
             };
 
             var event5 = new TeachingEvent()
@@ -592,14 +572,20 @@ namespace GetIntoTeachingApiTests.Services
                 Name = "Event 7",
                 StartAt = DateTime.UtcNow.AddYears(-1),
                 TypeId = (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
-                BuildingId = eventBuildingGuid5
+                BuildingId = buildings[4].Id
             };
 
-            return new TeachingEvent[] { event1, event2, event3, event4, event5, event6, event7 };
+            return new List<TeachingEvent>() { event1, event2, event3, event4, event5, event6, event7 };
         }
 
-        private static IEnumerable<TeachingEventBuilding> MockTeachingEventBuildings()
+        private static List<TeachingEventBuilding> MockTeachingEventBuildings()
         {
+            Guid eventBuildingGuid1 = new Guid("67ffca5c-5adc-4a63-abb7-632c9ecbf283");
+            Guid eventBuildingGuid2 = new Guid("194c0926-5f15-434d-88ba-f76c376ac865");
+            Guid eventBuildingGuid3 = new Guid("6dc656a8-50cc-4802-a62a-47576ddbc493");
+            Guid eventBuildingGuid4 = new Guid("adc3e6ce-65a8-4752-abcd-781365982a33");
+            Guid eventBuildingGuid5 = new Guid("deb12260-84fc-43b5-8682-13aa1015f100");
+
             var building1 = new TeachingEventBuilding()
             {
                 Id = eventBuildingGuid1
@@ -632,7 +618,7 @@ namespace GetIntoTeachingApiTests.Services
                 AddressPostcode = "TE7 9IN"
             };
 
-            return new TeachingEventBuilding[] { building1, building2, building3, building4, building5 };
+            return new List<TeachingEventBuilding> { building1, building2, building3, building4, building5 };
         }
 
         private async Task<IEnumerable<TeachingEventBuilding>> SeedMockTeachingEventBuildingsAsync()
@@ -645,8 +631,10 @@ namespace GetIntoTeachingApiTests.Services
             return buildings;
         }
 
-        private async Task<IEnumerable<TeachingEvent>> SeedMockTeachingEventsAsync()
+        private async Task<IEnumerable<TeachingEvent>> SeedMockTeachingEventsAndBuildingsAsync()
         {
+            await SeedMockTeachingEventBuildingsAsync();
+
             var teachingEvents = MockTeachingEvents().ToList();
             _mockCrm.Setup(m => m.GetTeachingEvents(It.IsAny<DateTime>())).Returns(teachingEvents);
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -141,6 +141,19 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SyncAsync_DeletesOrphanedTeachingEventBuildings()
+        {
+            var buildings = await SeedMockTeachingEventBuildingsAsync();
+            var building = buildings.ToList().GetRange(0, 1);
+
+            _mockCrm.Setup(m => m.GetTeachingEventBuildings()).Returns(building);
+
+            await _store.SyncAsync();
+
+            DbContext.TeachingEventBuildings.Should().BeEquivalentTo(building);
+        }
+
+        [Fact]
         public async void SyncAsync_PopulatesTeachingEventBuildingCoordinates()
         {
             await SeedMockTeachingEventBuildingsAsync();

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -99,12 +99,15 @@ namespace GetIntoTeachingApiTests.Services
         public async void SyncAsync_DeletesOrphanedTeachingEvents()
         {
             await SeedMockTeachingEventsAndBuildingsAsync();
-            var teachingEvents = MockTeachingEvents().ToList();
-            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(teachingEvents.GetRange(0, 1));
+            var teachingEvent = MockTeachingEvents().ToList().GetRange(0, 1);
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d))))
+                .Returns(teachingEvent);
 
             await _store.SyncAsync();
 
-            DbContext.TeachingEvents.Should().BeEquivalentTo(teachingEvents.GetRange(0, 1));
+            DbContext.TeachingEvents.Should().BeEquivalentTo(teachingEvent);
+
+            DbContext.TeachingEventBuildings.Should().Contain(teachingEvent.Single().Building);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -502,9 +502,8 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async Task GetTeachingEventBuildings_ReturnsAll()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            var events = await SeedMockTeachingEventsAsync();
-            _mockCrm.Setup(m => m.GetTeachingEvents(It.IsAny<DateTime>())).Returns(events);
+            var buildings = await SeedMockTeachingEventBuildingsAsync();
+            _mockCrm.Setup(m => m.GetTeachingEventBuildings()).Returns(buildings);
 
             var result = _store.GetTeachingEventBuildings().ToList();
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -72,7 +72,6 @@ namespace GetIntoTeachingApiTests.Services
             var ids = DbContext.TeachingEvents.Select(te => te.Id);
             ids.Should().BeEquivalentTo(mockTeachingEvents.Select(te => te.Id));
             DbContext.TeachingEvents.Count().Should().Be(7);
-            DbContext.TeachingEventBuildings.Count().Should().Be(5);
         }
 
         [Fact]
@@ -106,6 +105,36 @@ namespace GetIntoTeachingApiTests.Services
             await _store.SyncAsync();
 
             DbContext.TeachingEvents.Should().BeEquivalentTo(teachingEvents.GetRange(0, 1));
+        }
+
+        [Fact]
+        public async void SyncAsync_InsertsNewTeachingEventBuildings()
+        {
+            var mockTeachingEventBuildings = MockTeachingEventBuildings();
+            _mockCrm.Setup(m => m.GetTeachingEventBuildings()).Returns(mockTeachingEventBuildings);
+
+            await _store.SyncAsync();
+
+            var ids = DbContext.TeachingEventBuildings.Select(te => te.Id);
+            ids.Should().BeEquivalentTo(mockTeachingEventBuildings.Select(te => te.Id));
+            DbContext.TeachingEventBuildings.Count().Should().Be(5);
+        }
+
+        [Fact]
+        public async void SyncAsync_UpdatesExistingTeachingEventBuildings()
+        {
+            var updatedTeachingEventBuildings = (await SeedMockTeachingEventBuildingsAsync()).ToList();
+            updatedTeachingEventBuildings.ForEach(building =>
+            {
+                building.AddressLine1 += "Updated";
+            });
+            _mockCrm.Setup(m => m.GetTeachingEventBuildings()).Returns(updatedTeachingEventBuildings);
+
+            await _store.SyncAsync();
+
+            var teachingEventBuildings = DbContext.TeachingEventBuildings;
+            teachingEventBuildings.Select(building => building.AddressLine1).ToList().ForEach(name => name.Should().Contain("Updated"));
+            DbContext.TeachingEventBuildings.Count().Should().Be(5);
         }
 
         [Fact]
@@ -580,41 +609,35 @@ namespace GetIntoTeachingApiTests.Services
 
         private static List<TeachingEventBuilding> MockTeachingEventBuildings()
         {
-            Guid eventBuildingGuid1 = new Guid("67ffca5c-5adc-4a63-abb7-632c9ecbf283");
-            Guid eventBuildingGuid2 = new Guid("194c0926-5f15-434d-88ba-f76c376ac865");
-            Guid eventBuildingGuid3 = new Guid("6dc656a8-50cc-4802-a62a-47576ddbc493");
-            Guid eventBuildingGuid4 = new Guid("adc3e6ce-65a8-4752-abcd-781365982a33");
-            Guid eventBuildingGuid5 = new Guid("deb12260-84fc-43b5-8682-13aa1015f100");
-
             var building1 = new TeachingEventBuilding()
             {
-                Id = eventBuildingGuid1
+                Id = new Guid("67ffca5c-5adc-4a63-abb7-632c9ecbf283")
             };
 
             var building2 = new TeachingEventBuilding()
             {
-                Id = eventBuildingGuid2,
+                Id = new Guid("194c0926-5f15-434d-88ba-f76c376ac865"),
                 AddressLine1 = "Line 1",
                 AddressPostcode = "KY11 9YU"
             };
 
             var building3 = new TeachingEventBuilding()
             {
-                Id = eventBuildingGuid3,
+                Id = new Guid("6dc656a8-50cc-4802-a62a-47576ddbc493"),
                 AddressLine1 = "Line 1",
                 AddressPostcode = "KY6 2NJ",
             };
 
             var building4 = new TeachingEventBuilding()
             {
-                Id = eventBuildingGuid4,
+                Id = new Guid("adc3e6ce-65a8-4752-abcd-781365982a33"),
                 AddressLine1 = "Line 1",
                 AddressPostcode = "CA4 8LE"
             };
 
             var building5 = new TeachingEventBuilding()
             {
-                Id = eventBuildingGuid5,
+                Id = new Guid("deb12260-84fc-43b5-8682-13aa1015f100"),
                 AddressPostcode = "TE7 9IN"
             };
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -511,8 +511,7 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public async Task GetTeachingEventBuildings_ReturnsAll()
         {
-            var buildings = await SeedMockTeachingEventBuildingsAsync();
-            _mockCrm.Setup(m => m.GetTeachingEventBuildings()).Returns(buildings);
+            await SeedMockTeachingEventBuildingsAsync();
 
             var result = _store.GetTeachingEventBuildings().ToList();
 


### PR DESCRIPTION
A new form will be added to the app to allow Abramis to add teaching events, part of this form needs to produce a list of teaching event buildings. Currently, the API only retrieves buildings that are associated with an event.

This PR:
- Adds a new endpoint to get all buildings from the CMS.
- Updates the CMS/postgres sync to:
  - get events without their associated buildings from the CMS.
  - get all buildings before associating them with events via BuildingId.