### PR TITLE
Format postcodes before sending to the API

### DIFF
--- a/GetIntoTeachingApi/Models/Location.cs
+++ b/GetIntoTeachingApi/Models/Location.cs
@@ -17,6 +17,7 @@ namespace GetIntoTeachingApi.Models
             CSV,
         }
 
+        public static readonly int InwardPostcodeLength = 3;
         public static readonly Regex OutwardOrFullPostcodeRegex = new Regex(
             $@"\A({OutwardPostcodePattern})\Z|\A({FullPostcodePattern})\z", RegexOptions.IgnoreCase);
         public static readonly Regex PostcodeRegex = new Regex(

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -79,7 +80,7 @@ namespace GetIntoTeachingApi.Models
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
-                AddressPostcode = AddressPostcode,
+                AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 Telephone = Telephone,
                 EligibilityRulesPassed = "false",
             };

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -125,7 +126,7 @@ namespace GetIntoTeachingApi.Models
                 AddressLine1 = AddressLine1,
                 AddressLine2 = AddressLine2,
                 AddressCity = AddressCity,
-                AddressPostcode = AddressPostcode,
+                AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 Telephone = Telephone,
                 TeacherId = TeacherId,
                 TypeId = TypeId,

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -82,7 +83,7 @@ namespace GetIntoTeachingApi.Models
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
-                AddressPostcode = AddressPostcode,
+                AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 Telephone = Telephone,
             };
 

--- a/GetIntoTeachingApi/Utils/ApplicationExtensions.cs
+++ b/GetIntoTeachingApi/Utils/ApplicationExtensions.cs
@@ -5,7 +5,7 @@ using Prometheus;
 
 namespace GetIntoTeachingApi.Utils
 {
-    public static class Extensions
+    public static class ApplicationExtensions
     {
         public static IApplicationBuilder UsePrometheusHangfireExporter(this IApplicationBuilder app)
         {

--- a/GetIntoTeachingApi/Utils/StringExtensions.cs
+++ b/GetIntoTeachingApi/Utils/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class StringExtensions
+    {
+        public static string AsFormattedPostcode(this string str)
+        {
+            str = str?.Replace(" ", string.Empty);
+
+            if (str == null || !Location.PostcodeRegex.IsMatch(str))
+            {
+                return null;
+            }
+
+            return str.ToUpper().Insert(str.Length - Location.InwardPostcodeLength, " ");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -145,5 +145,13 @@ namespace GetIntoTeachingApiTests.Models
             request.Candidate.MailingListSubscriptionChannelId.Should().Be(123);
             request.Candidate.EventsSubscriptionChannelId.Should().Be(123);
         }
+
+        [Fact]
+        public void Candidate_AddressPostcode_IsFormatted()
+        {
+            var request = new MailingListAddMember() { AddressPostcode = "ky119yu" };
+
+            request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -420,5 +420,13 @@ namespace GetIntoTeachingApiTests.Models
             request.Candidate.AdviserEligibilityId.Should().BeNull();
             request.Candidate.AdviserRequirementId.Should().BeNull();
         }
+
+        [Fact]
+        public void Candidate_AddressPostcode_IsFormatted()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { AddressPostcode = "ky119yu" };
+
+            request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -162,5 +162,13 @@ namespace GetIntoTeachingApiTests.Models
 
             request.Candidate.HasEventsSubscription.Should().BeTrue();
         }
+
+        [Fact]
+        public void Candidate_AddressPostcode_IsFormatted()
+        {
+            var request = new TeachingEventAddAttendee() { AddressPostcode = "ky119yu" };
+
+            request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -10,6 +10,7 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("KY11 9YU", "KY11 9YU")]
         [InlineData("KY119YU", "KY11 9YU")]
         [InlineData("ca48le", "CA4 8LE")]
+        [InlineData("M12WD", "M1 2WD")]
         [InlineData("ca4 8LE", "CA4 8LE")]
         [InlineData("  ca4   8L E", "CA4 8LE")]
         [InlineData("invalid", null)]

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class StringExtensionsTests
+    {
+        [Theory]
+        [InlineData("KY11 9YU", "KY11 9YU")]
+        [InlineData("KY119YU", "KY11 9YU")]
+        [InlineData("ca48le", "CA4 8LE")]
+        [InlineData("ca4 8LE", "CA4 8LE")]
+        [InlineData("  ca4   8L E", "CA4 8LE")]
+        [InlineData("invalid", null)]
+        [InlineData(null, null)]
+        public void AsFormattedPostcode_ReturnsCorrectly(string input, string expected)
+        {
+            input.AsFormattedPostcode().Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
- Rename extension for clarity

- Add StringExtensions for formatting postcodes

The extension will take a valid postcode and ensure it is formatted correctly (upper case and with a space before the inward part of the postcode).

- Format postcodes from request models

When a postcode comes into the API we want to format it before it gets to the CRM; this adds formatting when mapping from the request models to a `Candidate`.