### PR TITLE
Update action return types to use AspNetCore.Http.StatusCodes

### DIFF
--- a/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
+++ b/GetIntoTeachingApi/Controllers/CallbackBookingQuotasController.cs
@@ -2,6 +2,7 @@
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -25,7 +26,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves all callback booking quotas.",
             OperationId = "GetCallbackBookingQuotas",
             Tags = new[] { "Callback Booking Quotas" })]
-        [ProducesResponseType(typeof(IEnumerable<CallbackBookingQuota>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<CallbackBookingQuota>), StatusCodes.Status200OK)]
         public IActionResult GetAll()
         {
             var quotas = _callbackBookingService.GetCallbackBookingQuotas();

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -37,9 +38,9 @@ namespace GetIntoTeachingApi.Controllers
                 that can then be used for verification.",
             OperationId = "CreateCandidateAccessToken",
             Tags = new[] { "Candidates" })]
-        [ProducesResponseType(204)]
-        [ProducesResponseType(404)]
-        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
             if (!ModelState.IsValid)

--- a/GetIntoTeachingApi/Controllers/LookupItemsController.cs
+++ b/GetIntoTeachingApi/Controllers/LookupItemsController.cs
@@ -5,6 +5,7 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
@@ -31,7 +32,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of countries.",
             OperationId = "GetCountries",
             Tags = new[] { "Lookup Items" })]
-        [ProducesResponseType(typeof(IEnumerable<LookupItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<LookupItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCountries()
         {
             var countries = await _store.GetLookupItems("dfe_country").ToListAsync();
@@ -46,7 +47,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of teaching subjects.",
             OperationId = "GetTeachingSubjects",
             Tags = new[] { "Lookup Items" })]
-        [ProducesResponseType(typeof(IEnumerable<LookupItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<LookupItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetTeachingSubjects()
         {
             var subjects = await _store.GetLookupItems("dfe_teachingsubjectlist").ToListAsync();

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -6,6 +6,7 @@ using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -48,8 +49,8 @@ namespace GetIntoTeachingApi.Controllers
                           "`Candidate.Qualifications[0].UkDegreeGradeId` and `UkDegreeGradeId`.",
             OperationId = "AddMailingListMember",
             Tags = new[] { "Mailing List" })]
-        [ProducesResponseType(204)]
-        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult AddMember(
             [FromBody, SwaggerRequestBody("Member to add to the mailing list.", Required = true)] MailingListAddMember request)
         {
@@ -74,8 +75,8 @@ namespace GetIntoTeachingApi.Controllers
                 exchanged for your token matches the request payload here).",
             OperationId = "ExchangeAccessTokenForMailingListAddMember",
             Tags = new[] { "Mailing List" })]
-        [ProducesResponseType(typeof(MailingListAddMember), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(MailingListAddMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult ExchangeAccessTokenForMember(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
@@ -99,8 +100,8 @@ namespace GetIntoTeachingApi.Controllers
                 `POST /candidates/magic_link_tokens` request.",
             OperationId = "ExchangeMagicLinkTokenForMailingListAddMember",
             Tags = new[] { "Mailing List" })]
-        [ProducesResponseType(typeof(MailingListAddMember), 200)]
-        [ProducesResponseType(typeof(CandidateMagicLinkExchangeResult), 401)]
+        [ProducesResponseType(typeof(MailingListAddMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(CandidateMagicLinkExchangeResult), StatusCodes.Status401Unauthorized)]
         public IActionResult ExchangeMagicLinkTokenForMember(
             [FromRoute, SwaggerParameter("Magic link token.", Required = true)] string magicLinkToken)
         {

--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -44,7 +45,7 @@ namespace GetIntoTeachingApi.Controllers
                           "models in the API map to the corresponding entities in Dynamics 365.",
             OperationId = "GenerateMappingInfo",
             Tags = new[] { "Operations" })]
-        [ProducesResponseType(typeof(IEnumerable<MappingInfo>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<MappingInfo>), StatusCodes.Status200OK)]
         public IActionResult GenerateMappingInfo()
         {
             var assembly = typeof(BaseModel).Assembly;
@@ -60,7 +61,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Performs a health check.",
             OperationId = "HealthCheck",
             Tags = new[] { "Operations" })]
-        [ProducesResponseType(typeof(HealthCheckResponse), 200)]
+        [ProducesResponseType(typeof(HealthCheckResponse), StatusCodes.Status200OK)]
         public async Task<IActionResult> HealthCheck()
         {
             var response = new HealthCheckResponse()

--- a/GetIntoTeachingApi/Controllers/PickListItemsController.cs
+++ b/GetIntoTeachingApi/Controllers/PickListItemsController.cs
@@ -4,6 +4,7 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
@@ -30,7 +31,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate initial teacher training years.",
             OperationId = "GetCandidateInitialTeacherTrainingYears",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateInitialTeacherTrainingYears()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_ittyear").ToListAsync());
@@ -43,7 +44,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate preferred education phases.",
             OperationId = "GetCandidatePreferredEducationPhases",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidatePreferredEducationPhases()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_preferrededucationphase01").ToListAsync());
@@ -56,7 +57,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate channels.",
             OperationId = "GetCandidateChannels",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateChannels()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_channelcreation").ToListAsync());
@@ -69,7 +70,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate mailing list subscription channels.",
             OperationId = "GetCandidateMailingListSubscriptionChannels",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateMailingListSubscriptionChannels()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel").ToListAsync());
@@ -82,7 +83,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate event subscription channels.",
             OperationId = "GetCandidateEventSubscriptionChannels",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateEventSubscriptionChannels()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel").ToListAsync());
@@ -95,7 +96,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate GCSE status.",
             OperationId = "GetCandidateGcseStatus",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateGcseStatus()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_websitehasgcseenglish").ToListAsync());
@@ -108,7 +109,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate retake GCSE status.",
             OperationId = "GetCandidateRetakeGcseStatus",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateRetakeGcseStatus()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_websiteplanningretakeenglishgcse").ToListAsync());
@@ -121,7 +122,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate consideration journey stages.",
             OperationId = "GetCandidateJourneyStages",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateConsiderationJourneyStages()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_websitewhereinconsiderationjourney").ToListAsync());
@@ -134,7 +135,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate adviser eligibilities.",
             OperationId = "GetCandidateAdviserEligibilities",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateAdviserEligibilities()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_iscandidateeligibleforadviser").ToListAsync());
@@ -147,7 +148,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate adviser requirements.",
             OperationId = "GetCandidateAdviserRequirements",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateAdviserRequirements()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_isadvisorrequiredos").ToListAsync());
@@ -160,7 +161,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate types.",
             OperationId = "GetCandidateTypes",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateTypes()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_typeofcandidate").ToListAsync());
@@ -173,7 +174,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of candidate assignment status.",
             OperationId = "GetCandidateAssignmentStatus",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCandidateAssignmentStatus()
         {
             return Ok(await _store.GetPickListItems("contact", "dfe_candidatestatus").ToListAsync());
@@ -186,7 +187,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of qualification degree status.",
             OperationId = "GetQualificationDegreeStatus",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetQualificationDegreeStatus()
         {
             return Ok(await _store.GetPickListItems("dfe_candidatequalification", "dfe_degreestatus").ToListAsync());
@@ -199,7 +200,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of qualification types.",
             OperationId = "GetQualificationTypes",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetQualificationTypes()
         {
             return Ok(await _store.GetPickListItems("dfe_candidatequalification", "dfe_type").ToListAsync());
@@ -212,7 +213,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of qualification UK degree grades.",
             OperationId = "GetQualificationUkDegreeGrades",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetQualificationUkDegreeGrades()
         {
             return Ok(await _store.GetPickListItems("dfe_candidatequalification", "dfe_ukdegreegrade").ToListAsync());
@@ -225,7 +226,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of past teaching position education phases.",
             OperationId = "GetPastTeachingPositionEducationPhases",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPastTeachingPositionEducationPhases()
         {
             return Ok(await _store.GetPickListItems("dfe_candidatepastteachingposition", "dfe_educationphase").ToListAsync());
@@ -238,7 +239,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of teaching event types.",
             OperationId = "GetTeachingEventTypes",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetTeachingEventTypes()
         {
             return Ok(await _store.GetPickListItems("msevtmgt_event", "dfe_event_type").ToListAsync());
@@ -251,7 +252,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of teaching event status.",
             OperationId = "GetTeachingEventStatus",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetTeachingEventStatus()
         {
             return Ok(await _store.GetPickListItems("msevtmgt_event", "dfe_eventstatus").ToListAsync());
@@ -264,7 +265,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of teaching event registration channels.",
             OperationId = "GetTeachingEventRegistrationChannels",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetTeachingEventRegistrationChannels()
         {
             return Ok(await _store.GetPickListItems("msevtmgt_eventregistration", "dfe_channelcreation").ToListAsync());
@@ -277,7 +278,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of phone call channels.",
             OperationId = "GetPhoneCallChannels",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPhoneCallChannels()
         {
             return Ok(await _store.GetPickListItems("phonecall", "dfe_channelcreation").ToListAsync());
@@ -290,7 +291,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the list of subscription types.",
             OperationId = "GetSubscriptionTypes",
             Tags = new[] { "Pick List Items" })]
-        [ProducesResponseType(typeof(IEnumerable<PickListItem>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetSubscriptionTypes()
         {
             return Ok(await _store.GetPickListItems("dfe_servicesubscription", "dfe_servicesubscriptiontype").ToListAsync());

--- a/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
+++ b/GetIntoTeachingApi/Controllers/PrivacyPoliciesController.cs
@@ -4,6 +4,7 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -29,7 +30,7 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves the latest privacy policy.",
             OperationId = "GetLatestPrivacyPolicy",
             Tags = new[] { "Privacy Policies" })]
-        [ProducesResponseType(typeof(PrivacyPolicy), 200)]
+        [ProducesResponseType(typeof(PrivacyPolicy), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetLatest()
         {
             var privacyPolicy = await _store.GetLatestPrivacyPolicyAsync();
@@ -43,8 +44,8 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves a privacy policy.",
             OperationId = "GetPrivacyPolicy",
             Tags = new[] { "Privacy Policies" })]
-        [ProducesResponseType(typeof(PrivacyPolicy), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(PrivacyPolicy), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromRoute, SwaggerParameter("The `id` of the `PrivacyPolicy`.", Required = true)] Guid id)
         {
             var policy = await _store.GetPrivacyPolicyAsync(id);

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -6,6 +6,7 @@ using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -41,8 +42,8 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                           "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
             OperationId = "SignUpTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" })]
-        [ProducesResponseType(204)]
-        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult SignUp(
             [FromBody, SwaggerRequestBody("Candidate to sign up for the Teacher Training Adviser service.", Required = true)] TeacherTrainingAdviserSignUp request)
         {
@@ -67,8 +68,8 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 exchanged for your token matches the request payload here).",
             OperationId = "ExchangeAccessTokenForTeacherTrainingAdviserSignUp",
             Tags = new[] { "Teacher Training Adviser" })]
-        [ProducesResponseType(typeof(TeacherTrainingAdviserSignUp), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(TeacherTrainingAdviserSignUp), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult ExchangeAccessToken(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -9,6 +9,7 @@ using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -52,8 +53,8 @@ namespace GetIntoTeachingApi.Controllers
     Description = @"Searches for teaching events. Optionally limit the results by distance (in miles) from a postcode, event type and start date.",
     OperationId = "SearchTeachingEventsGroupedByType",
     Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), 200)]
-        [ProducesResponseType(400)]
+        [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> SearchGroupedByType(
     [FromQuery, SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request,
     [FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
@@ -83,8 +84,8 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Retrieves an event.",
             OperationId = "GetTeachingEvent",
             Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(TeachingEvent), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromRoute, SwaggerParameter("The `readableId` of the `TeachingEvent`.", Required = true)] string readableId)
         {
             var teachingEvent = await _store.GetTeachingEventAsync(readableId);
@@ -112,9 +113,9 @@ namespace GetIntoTeachingApi.Controllers
                           "`Candidate.PrivacyPolicy.AcceptedPolicyId` and `AcceptedPolicyId`.",
             OperationId = "AddTeachingEventAttendee",
             Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(204)]
-        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult AddAttendee(
             [FromBody, SwaggerRequestBody("Attendee to add to the teaching event.", Required = true)] TeachingEventAddAttendee request)
         {
@@ -139,8 +140,8 @@ namespace GetIntoTeachingApi.Controllers
                 exchanged for your token matches the request payload here).",
             OperationId = "ExchangeAccessTokenForTeachingEventAddAttendee",
             Tags = new[] { "Teaching Events" })]
-        [ProducesResponseType(typeof(TeachingEventAddAttendee), 200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(typeof(TeachingEventAddAttendee), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult ExchangeAccessTokenForAttendee(
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)


### PR DESCRIPTION
Use AspNetCore.Http.StatusCodes for action annotations to clean up/provide some context to the return types