### PR TITLE
Add panel showing event search results by search radius

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1613037108572,
+  "id": 3,
+  "iteration": 1614867417305,
   "links": [],
   "panels": [
     {
@@ -754,13 +754,317 @@
       "type": "stat"
     },
     {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 68,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Event Search Results (no radius)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 69,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Event Search Results (30 miles)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 70,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Event Search Results (50 miles)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 71,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Event Search Results (100 miles)",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 34
       },
       "id": 46,
       "panels": [],
@@ -787,7 +1091,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 52,
@@ -891,7 +1195,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 44,
@@ -1079,7 +1383,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 45
       },
       "id": 38,
       "panels": [],
@@ -1105,7 +1409,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 23,
@@ -1201,7 +1505,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1297,7 +1601,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 58
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1398,7 +1702,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 70
       },
       "id": 40,
       "panels": [],
@@ -1439,7 +1743,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 57
+        "y": 71
       },
       "id": 50,
       "interval": null,
@@ -1506,7 +1810,7 @@
         "h": 10,
         "w": 5,
         "x": 4,
-        "y": 57
+        "y": 71
       },
       "id": 48,
       "interval": null,
@@ -1580,7 +1884,7 @@
         "h": 10,
         "w": 5,
         "x": 9,
-        "y": 57
+        "y": 71
       },
       "id": 6,
       "interval": null,
@@ -1656,7 +1960,7 @@
         "h": 10,
         "w": 5,
         "x": 14,
-        "y": 57
+        "y": 71
       },
       "id": 66,
       "interval": null,
@@ -1732,7 +2036,7 @@
         "h": 10,
         "w": 5,
         "x": 19,
-        "y": 57
+        "y": 71
       },
       "id": 21,
       "interval": null,
@@ -1786,7 +2090,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 81
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1896,7 +2200,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 67
+        "y": 81
       },
       "id": 25,
       "interval": null,
@@ -1956,7 +2260,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 67
+        "y": 81
       },
       "id": 14,
       "interval": null,
@@ -2040,7 +2344,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 93
       },
       "id": 16,
       "pageSize": null,
@@ -2102,7 +2406,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 18,
@@ -2203,7 +2507,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 104
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2268,7 +2572,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 116
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2386,7 +2690,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 116
       },
       "hiddenSeries": false,
       "id": 60,
@@ -2599,7 +2903,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 126
       },
       "id": 34,
       "panels": [],
@@ -2625,7 +2929,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 113
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 61,
@@ -2759,7 +3063,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 113
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 2,
@@ -2846,7 +3150,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 139
       },
       "id": 42,
       "panels": [],
@@ -2894,7 +3198,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 126
+        "y": 140
       },
       "id": 27,
       "interval": null,
@@ -2969,7 +3273,7 @@
         "h": 10,
         "w": 4,
         "x": 4,
-        "y": 126
+        "y": 140
       },
       "id": 55,
       "interval": null,
@@ -3040,7 +3344,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 126
+        "y": 140
       },
       "id": 57,
       "pageSize": null,
@@ -3103,7 +3407,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 126
+        "y": 140
       },
       "hiddenSeries": false,
       "id": 58,


### PR DESCRIPTION
Add single stat panels that group searches by the number of results returned and search radius used.

I’m only including results where the user didn’t search by a type (as I figured that could skew the number of results they get quite heavily). I think I need to tweak the histogram buckets as well to expand on >10 as the majority of searches fall into that bucket and I don't think we'll ever see 0 results (or even <6 very often) as we always include online events.

<img width="1625" alt="Screenshot 2021-03-05 at 09 25 01" src="https://user-images.githubusercontent.com/29867726/110095686-115f7600-7d95-11eb-9479-6609a77e7a79.png">
