### PR TITLE
Optimise metrics by removing high-cardinality labels

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApi.Adapters
 
             if (response.Status != GeocodeStatus.Ok)
             {
-                _metrics.GoogleApiCalls.WithLabels(postcode, "error").Inc();
+                _metrics.GoogleApiCalls.WithLabels("error").Inc();
                 return null;
             }
 
@@ -39,11 +39,11 @@ namespace GetIntoTeachingApi.Adapters
 
             if (result == null)
             {
-                _metrics.GoogleApiCalls.WithLabels(postcode, "fail").Inc();
+                _metrics.GoogleApiCalls.WithLabels("fail").Inc();
                 return null;
             }
 
-            _metrics.GoogleApiCalls.WithLabels(postcode, "success").Inc();
+            _metrics.GoogleApiCalls.WithLabels("success").Inc();
 
             var location = result.Geometry.Location;
             var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: DbConfiguration.Wgs84Srid);

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApi.Services
         {
             var totp = CreateTotp(request).ComputeTotp();
 
-            _metrics.GeneratedTotps.WithLabels(candidateId.ToString(), totp).Inc();
+            _metrics.GeneratedTotps.Inc();
 
             return totp;
         }
@@ -51,7 +51,7 @@ namespace GetIntoTeachingApi.Services
                 out _,
                 new VerificationWindow(previous: VerificationWindow, future: 0));
 
-            _metrics.VerifiedTotps.WithLabels(candidateId.ToString(), token, valid.ToString()).Inc();
+            _metrics.VerifiedTotps.WithLabels(valid.ToString()).Inc();
 
             return valid;
         }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApi.Services
         private static readonly Counter _googleApiCalls = Metrics
             .CreateCounter("api_google_api_calls", "Number of Google API calls.", new CounterConfiguration
             {
-                LabelNames = new[] { "postcode", "result" },
+                LabelNames = new[] { "result" },
             });
         private static readonly Counter _cacheLookups = Metrics
             .CreateCounter("api_cache_lookups", "Number of cache lookups.", new CounterConfiguration
@@ -33,14 +33,11 @@ namespace GetIntoTeachingApi.Services
                 LabelNames = new[] { "outcome" },
             });
         private static readonly Counter _generatedTotps = Metrics
-            .CreateCounter("api_generated_totps", "Number of generated timed one time passwords.", new CounterConfiguration
-            {
-                LabelNames = new[] { "candidate_id", "totp" },
-            });
+            .CreateCounter("api_generated_totps", "Number of generated timed one time passwords.");
         private static readonly Counter _verifiedTotps = Metrics
             .CreateCounter("api_verified_totps", "Number of verified timed one time passwords.", new CounterConfiguration
             {
-                LabelNames = new[] { "candidate_id", "totp", "valid" },
+                LabelNames = new[] { "valid" },
             });
 
         public Histogram CrmSyncDuration => _crmSyncDuration;

--- a/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
@@ -5,8 +5,6 @@ using System;
 using GetIntoTeachingApi.Utils;
 using Moq;
 using Xunit;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -31,12 +29,14 @@ namespace GetIntoTeachingApiTests.Services
         [InlineData("e@a.com", "B", "C")]
         public void GenerateToken_ReturnsAValidToken(string email, string firstName, string lastName)
         {
+            var generatedTotpsCount = _metrics.GeneratedTotps.Value;
+            var verifiedTotpsCount = _metrics.VerifiedTotps.WithLabels(new[] { true.ToString() }).Value;
             var request = new ExistingCandidateRequest { Email = email, FirstName = firstName, LastName = lastName };
             var token = _service.GenerateToken(request, _candidateId);
 
             _service.IsValid(token, request, _candidateId).Should().BeTrue();
-            _metrics.GeneratedTotps.WithLabels(new[] { _candidateId.ToString(), token }).Value.Should().Be(1);
-            _metrics.VerifiedTotps.WithLabels(new[] { _candidateId.ToString(), token, true.ToString() }).Value.Should().Be(1);
+            _metrics.GeneratedTotps.Value.Should().Be(generatedTotpsCount + 1);
+            _metrics.VerifiedTotps.WithLabels(new[] { true.ToString() }).Value.Should().Be(verifiedTotpsCount + 1);
         }
 
         [Fact]
@@ -75,12 +75,14 @@ namespace GetIntoTeachingApiTests.Services
         [InlineData("abcdef")]
         public void IsValid_WithInvalidToken_ReturnsFalse(string invalidToken)
         {
+            var verifiedTotpsCount = _metrics.VerifiedTotps.WithLabels(new[] { false.ToString() }).Value;
+
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             _service.IsValid(invalidToken, request, _candidateId).Should().BeFalse();
 
             if (!string.IsNullOrWhiteSpace(invalidToken))
             {
-                _metrics.VerifiedTotps.WithLabels(new[] { _candidateId.ToString(), invalidToken, false.ToString() }).Value.Should().Be(1);
+                _metrics.VerifiedTotps.WithLabels(new[] { false.ToString() }).Value.Should().Be(verifiedTotpsCount + 1);
             }
         }
 
@@ -88,12 +90,15 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void IsValid_WithExpiredToken_ReturnsFalse()
         {
+            var verifiedTotpsCount = _metrics.VerifiedTotps.WithLabels(new[] { false.ToString() }).Value;
             var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             var secondsToOutsideOfWindow = (CandidateAccessTokenService.StepInSeconds * CandidateAccessTokenService.VerificationWindow) + 1;
             var dateTimeOutsideOfWindow = DateTime.UtcNow.AddSeconds(-secondsToOutsideOfWindow);
+
             var token = _service.GenerateToken(request, _candidateId);
+
             _service.IsValid(token, request, _candidateId, dateTimeOutsideOfWindow).Should().BeFalse();
-            _metrics.VerifiedTotps.WithLabels(new[] { _candidateId.ToString(), token, false.ToString() }).Value.Should().Be(1);
+            _metrics.VerifiedTotps.WithLabels(new[] { false.ToString() }).Value.Should().Be(verifiedTotpsCount + 1);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using GetIntoTeachingApi.Services;
-using Prometheus;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Services
@@ -49,7 +48,7 @@ namespace GetIntoTeachingApiTests.Services
         public void GoogleApiCalls_ReturnsMetric()
         {
             _metrics.GoogleApiCalls.Name.Should().Be("api_google_api_calls");
-            _metrics.GoogleApiCalls.LabelNames.Should().BeEquivalentTo(new[] { "postcode", "result" });
+            _metrics.GoogleApiCalls.LabelNames.Should().BeEquivalentTo(new[] { "result" });
         }
 
         [Fact]
@@ -63,14 +62,13 @@ namespace GetIntoTeachingApiTests.Services
         public void GeneratedTotps_ReturnsMetric()
         {
             _metrics.GeneratedTotps.Name.Should().Be("api_generated_totps");
-            _metrics.GeneratedTotps.LabelNames.Should().BeEquivalentTo(new[] { "candidate_id", "totp" });
         }
 
         [Fact]
         public void VerifiedTotps_ReturnsMetric()
         {
             _metrics.VerifiedTotps.Name.Should().Be("api_verified_totps");
-            _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "candidate_id", "totp", "valid" });
+            _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "valid" });
         }
 
         [Fact]

--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1614867417305,
+  "id": 4,
+  "iteration": 1614940792105,
   "links": [],
   "panels": [
     {
@@ -3163,6 +3163,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "decimals": 0,
           "mappings": [
             {
               "id": 0,
@@ -3221,7 +3222,7 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_google_api_calls[$__range]))",
+          "expr": "sum(increase(api_google_api_calls[$__interval]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -3326,68 +3327,6 @@
       "type": "stat"
     },
     {
-      "columns": [
-        {
-          "text": "Total",
-          "value": "total"
-        }
-      ],
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 10,
-        "w": 8,
-        "x": 8,
-        "y": 140
-      },
-      "id": 57,
-      "pageSize": null,
-      "showHeader": true,
-      "sort": {
-        "col": 1,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "",
-          "align": "auto",
-          "colorMode": null,
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "decimals": 0,
-          "pattern": "/.*/",
-          "thresholds": [
-            "0.1",
-            "0.30"
-          ],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(increase(api_google_api_calls[$__range])) by (postcode)",
-          "interval": "",
-          "legendFormat": "{{postcode}}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Geocode Requests by Postcode",
-      "transform": "timeseries_aggregations",
-      "type": "table-old"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -3405,8 +3344,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 8,
-        "x": 16,
+        "w": 16,
+        "x": 8,
         "y": 140
       },
       "hiddenSeries": false,
@@ -3470,7 +3409,7 @@
           "datasource": "Prometheus",
           "expr": "sum(rate(api_google_api_calls{result != \"success\"}[3m])) by (result)",
           "interval": "",
-          "legendFormat": "Google Geocoder - {result}",
+          "legendFormat": "Google Geocoder - {{result}}",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
- Remove high cardinality metric labels

It turns out that using high cardinality labels against metrics is bad as each combination is recorded as its own time-series, which is expensive (lots of different label values == lots of different time series).

We do this in a couple of metrics and for the most part the labels aren't actually used when it comes to graphing or alerting on the metrics, so this commit removes them.

- Remove panel using high-cardinality label

The Google requests by postcode panel is operating on a metric with a high cardinality label (postcode, which has a lot of values). Removing it as this impacts performance; the data is still sent to the logs.