### PR TITLE
Add event search dashboard

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1614940792105,
+  "id": 1,
+  "iteration": 1614952059614,
   "links": [],
   "panels": [
     {
@@ -754,317 +754,13 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-purple",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 20
-      },
-      "id": 68,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "> 10",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "6 - 10",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "1 - 5",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "0",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Event Search Results (no radius)",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-purple",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 20
-      },
-      "id": 69,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "> 10",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "6 - 10",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "1 - 5",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "0",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Event Search Results (30 miles)",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-purple",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "id": 70,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "> 10",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "6 - 10",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "1 - 5",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "0",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Event Search Results (50 miles)",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-purple",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "id": 71,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "> 10",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "6 - 10",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "1 - 5",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
-          "interval": "",
-          "legendFormat": "0",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Event Search Results (100 miles)",
-      "type": "stat"
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 20
       },
       "id": 46,
       "panels": [],
@@ -1091,7 +787,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 52,
@@ -1195,7 +891,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 44,
@@ -1383,7 +1079,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 31
       },
       "id": 38,
       "panels": [],
@@ -1409,7 +1105,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 23,
@@ -1505,7 +1201,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 46
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1601,7 +1297,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1702,7 +1398,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 56
       },
       "id": 40,
       "panels": [],
@@ -1743,7 +1439,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 71
+        "y": 57
       },
       "id": 50,
       "interval": null,
@@ -1810,7 +1506,7 @@
         "h": 10,
         "w": 5,
         "x": 4,
-        "y": 71
+        "y": 57
       },
       "id": 48,
       "interval": null,
@@ -1884,7 +1580,7 @@
         "h": 10,
         "w": 5,
         "x": 9,
-        "y": 71
+        "y": 57
       },
       "id": 6,
       "interval": null,
@@ -1960,7 +1656,7 @@
         "h": 10,
         "w": 5,
         "x": 14,
-        "y": 71
+        "y": 57
       },
       "id": 66,
       "interval": null,
@@ -2036,7 +1732,7 @@
         "h": 10,
         "w": 5,
         "x": 19,
-        "y": 71
+        "y": 57
       },
       "id": 21,
       "interval": null,
@@ -2090,7 +1786,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 81
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 10,
@@ -2200,7 +1896,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 81
+        "y": 67
       },
       "id": 25,
       "interval": null,
@@ -2260,7 +1956,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 81
+        "y": 67
       },
       "id": 14,
       "interval": null,
@@ -2344,7 +2040,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 79
       },
       "id": 16,
       "pageSize": null,
@@ -2406,7 +2102,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 104
+        "y": 90
       },
       "hiddenSeries": false,
       "id": 18,
@@ -2507,7 +2203,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 104
+        "y": 90
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2572,7 +2268,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 116
+        "y": 102
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2690,7 +2386,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 116
+        "y": 102
       },
       "hiddenSeries": false,
       "id": 60,
@@ -2903,7 +2599,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 126
+        "y": 112
       },
       "id": 34,
       "panels": [],
@@ -2929,7 +2625,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 61,
@@ -3063,7 +2759,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 2,
@@ -3150,7 +2846,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 139
+        "y": 125
       },
       "id": 42,
       "panels": [],
@@ -3199,7 +2895,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 140
+        "y": 126
       },
       "id": 27,
       "interval": null,
@@ -3274,7 +2970,7 @@
         "h": 10,
         "w": 4,
         "x": 4,
-        "y": 140
+        "y": 126
       },
       "id": 55,
       "interval": null,
@@ -3346,7 +3042,7 @@
         "h": 10,
         "w": 16,
         "x": 8,
-        "y": 140
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 58,

--- a/monitoring/grafana/dashboards/get_into_teaching_api_event_search.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api_event_search.json
@@ -1,0 +1,849 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_count[$__interval]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 13,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.2.2",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "No Type",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "Train to Teach",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",type_id=\"222750008\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "Online",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",type_id=\"222750009\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "School and University",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total by Type",
+      "type": "grafana-piechart-panel",
+      "valueName": "total"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 13,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 4,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.2.2",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "No Radius",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "100 miles",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "50 miles",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "30 miles",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total by Radius",
+      "type": "grafana-piechart-panel",
+      "valueName": "total"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 73,
+      "panels": [],
+      "title": "Results by Radius (Train to Teach)",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 76,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "No Radius",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 69,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "30 miles",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 78,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "50 miles",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 79,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "100 miles",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 6,
+      "title": "Results by Radius",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 68,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "No Radius",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 77,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "30 miles",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 70,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "50 miles",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 71,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "> 10",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "6 - 10",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "1 - 5",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "0",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "100 miles",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Get into Teaching Api - Event Search",
+  "uid": null,
+  "version": 0
+}


### PR DESCRIPTION
Adds an event search dashboard (and removes the event search panels from the main API dashboard):

![screencapture-grafana-prod-get-into-teaching-london-cloudapps-digital-dashboard-new-2021-03-05-12_01_55](https://user-images.githubusercontent.com/29867726/110121922-e423bf80-7db6-11eb-92ba-1ecf2436ad9c.png)
