### PR TITLE
Use Newtonsoft.Json for Hangfire payloads

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -48,7 +48,6 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
-		<PackageReference Include="Dahomey.Json" Version="1.10.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -36,7 +36,7 @@ namespace GetIntoTeachingApi.Jobs
 
         public void Run(string json, PerformContext context)
         {
-            var candidate = JsonSerializer.Deserialize<Candidate>(json);
+            var candidate = json.DeserializeChangedTracked<Candidate>();
 
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
 

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
-using Dahomey.Json;
 using dotenv.net;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Adapters;

--- a/GetIntoTeachingApi/Utils/JsonExtensions.cs
+++ b/GetIntoTeachingApi/Utils/JsonExtensions.cs
@@ -1,23 +1,22 @@
-﻿using System.Text.Json;
-using Dahomey.Json;
+﻿using Newtonsoft.Json;
 
 namespace GetIntoTeachingApi.Utils
 {
     public static class JsonExtensions
     {
-        private static JsonSerializerOptions _options = new JsonSerializerOptions()
+        private static readonly JsonSerializerSettings _settings = new JsonSerializerSettings()
         {
-            IgnoreNullValues = true,
-        }.SetupExtensions();
+            NullValueHandling = NullValueHandling.Ignore,
+        };
 
         public static T DeserializeChangedTracked<T>(this string json)
         {
-            return JsonSerializer.Deserialize<T>(json, _options);
+            return JsonConvert.DeserializeObject<T>(json, _settings);
         }
 
         public static string SerializeChangedTracked<T>(this T value)
         {
-            return JsonSerializer.Serialize(value, _options);
+            return JsonConvert.SerializeObject(value, Formatting.Indented, _settings);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Moq;
 using GetIntoTeachingApi.Services;
 using System.Text.Json;
-using Dahomey.Json;
+using GetIntoTeachingApi.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -152,9 +152,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var options = new JsonSerializerOptions() { IgnoreNullValues = true };
-            options.SetupExtensions();
-            var candidateB = JsonSerializer.Deserialize<Candidate>(candidateBJson, options);
+            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -12,7 +12,7 @@ using Hangfire.Common;
 using Hangfire.States;
 using Microsoft.AspNetCore.Authorization;
 using System.Text.Json;
-using Dahomey.Json;
+using GetIntoTeachingApi.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 {
@@ -104,9 +104,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var options = new JsonSerializerOptions() { IgnoreNullValues = true };
-            options.SetupExtensions();
-            var candidateB = JsonSerializer.Deserialize<Candidate>(candidateBJson, options);
+            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -18,7 +18,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using GetIntoTeachingApiTests.Helpers;
 using System.Text.Json;
-using Dahomey.Json;
+using GetIntoTeachingApi.Utils;
 
 namespace GetIntoTeachingApiTests.Controllers
 {
@@ -204,9 +204,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var options = new JsonSerializerOptions() { IgnoreNullValues = true };
-            options.SetupExtensions();
-            var candidateB = JsonSerializer.Deserialize<Candidate>(candidateBJson, options);
+            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Dahomey.Json;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -152,23 +152,22 @@ namespace GetIntoTeachingApiTests.Models
 
             deserializedModel.Id.Should().Be(model.Id);
             deserializedModel.Field3.Should().Be(model.Field3);
-            deserializedModel.Field4.Should().Be(model.Field4);
             deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
 
             // Test deserializing model with ChangedPropertyNames in different order/combinations.
-            json = "{\"ChangedPropertyNames\":[\"Id\",\"Field1\"],\"Field3\":null,\"Field2\":123}";
+            json = "{\"ChangedPropertyNames\":[\"Id\",\"Field1\"],\"Field3\":\"test\",\"Field2\":123}";
             deserializedModel = json.DeserializeChangedTracked<MockModel>();
 
             deserializedModel.Field2.Should().Be(123);
-            deserializedModel.Field3.Should().BeNull();
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1" });
+            deserializedModel.Field3.Should().Be("test");
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
 
-            json = "{\"Field3\":null,\"Field2\":123,\"ChangedPropertyNames\":[\"Id\",\"Field1\"]}";
+            json = "{\"Field3\":\"test\",\"Field2\":123,\"ChangedPropertyNames\":[\"Id\",\"Field1\"]}";
             deserializedModel = json.DeserializeChangedTracked<MockModel>();
 
             deserializedModel.Field2.Should().Be(123);
-            deserializedModel.Field3.Should().BeNull();
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1" });
+            deserializedModel.Field3.Should().Be("test");
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
         }
 
         [Fact]


### PR DESCRIPTION
In an ideal world we would use `System.Text.Json` for all serialization in the API. Whilst we got to this state recently it has a few drawbacks:

1. Dahomey.Json extensions are required to pause change tracking during se/deserialization. This brings various oddities into `System.Text.Json` and it doesn't implement `System.Runtime.Serialization.OnDeserializing/OnDeserialized` according to the spec (it misses the `StreamingContext` argument, which can have knock on effects). It also brings in `AutoMapper` which is slow and in general it's difficult to follow code, making it iffy to rely on.

2. `System.Text.Json` doesn't support conditional serialization, meaning we can't omit the `ChangedPropertyNames` attribute from API responses and include them when serializing to Hangfire -- we have to always include them, which isn't great as it pollutes the API output.

To avoid these drawbacks I've reverted the Hangfire payloads to be se/deserialized using `Newtonsoft.Json`, which is a robust library in itself and still well supported. It implements `OnDeserializing`/`OnDeserialized` correctly and the only difference appears to be that properties with default values get included in the `ChangedPropertyNames` on deserializing, which is fine and probably a better outcome anyway (we always want to consider these properties 'changed').

This commit also utilises the `JsonExtensions` in a few other areas so we're not manually constructing the same serialization options repeatedly.

- Add Json serializer details to README