### PR TITLE
Remove telephone from MailingListAddMember

### DIFF
--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -24,7 +24,6 @@ namespace GetIntoTeachingApi.Models
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
-        public string Telephone { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -63,7 +62,6 @@ namespace GetIntoTeachingApi.Models
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
-            Telephone = candidate.Telephone;
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
@@ -81,7 +79,6 @@ namespace GetIntoTeachingApi.Models
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                Telephone = Telephone,
                 EligibilityRulesPassed = "false",
             };
 

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -34,7 +34,6 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
@@ -49,7 +48,6 @@ namespace GetIntoTeachingApiTests.Models
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
-            response.Telephone.Should().Be(candidate.Telephone);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
 
             response.QualificationId.Should().Be(latestQualification.Id);
@@ -74,7 +72,6 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
             };
 
@@ -88,7 +85,6 @@ namespace GetIntoTeachingApiTests.Models
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.Telephone.Should().Be(request.Telephone);
             candidate.ChannelId.Should().BeNull();
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -38,7 +38,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
                 AddressPostcode = "KY11 9YU",
             };
 


### PR DESCRIPTION
- Remove telephone from MailingListAddMember

We haven't collected the telephone in the mailing list sign up for a while now, but it's still available as an attribute in the mailing list sign up. This removes it to make it consistent.