### PR TITLE
Record in-person event search result metrics

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -70,7 +70,14 @@ namespace GetIntoTeachingApi.Controllers
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);
 
-            _metrics.TeachingEventSearchResults.WithLabels(request.TypeId.ToString(), request.Radius.ToString()).Observe(teachingEvents.Count());
+            _metrics.TeachingEventSearchResults
+                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .Observe(teachingEvents.Count());
+
+            var inPesonTeachingEvents = teachingEvents.Where(e => e.IsInPerson);
+            _metrics.InPersonTeachingEventResults
+                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .Observe(inPesonTeachingEvents.Count());
 
             return Ok(GroupTeachingEventsByType(teachingEvents, quantityPerType));
         }

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -70,6 +70,11 @@ namespace GetIntoTeachingApi.Models
         public Guid? BuildingId { get; set; }
         public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 
+        // The department refers to 'virtual' events as "in-person" (as
+        // well as offline events), so whilst virtual events are in fact online,
+        // they are deemed in-person here for consistency.
+        public bool IsInPerson => !IsOnline || IsVirtual;
+
         public TeachingEvent()
             : base()
         {

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -9,6 +9,7 @@ namespace GetIntoTeachingApi.Services
         Histogram MagicLinkTokenGenerationDuration { get; }
         Histogram HangfireJobQueueDuration { get; }
         Histogram TeachingEventSearchResults { get; }
+        Histogram InPersonTeachingEventResults { get; }
         Gauge HangfireJobs { get; }
         Counter GoogleApiCalls { get; }
         Counter CacheLookups { get; }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -20,6 +20,11 @@ namespace GetIntoTeachingApi.Services
             {
                 LabelNames = new[] { "type_id", "radius" },
             });
+        private static readonly Histogram _inPersonTeachingEventResults = Metrics
+            .CreateHistogram("api_in_person_teaching_event_results_count", "Histogram of teaching event search results (in person).", new HistogramConfiguration
+            {
+                LabelNames = new[] { "type_id", "radius" },
+            });
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");
         private static readonly Counter _googleApiCalls = Metrics
@@ -45,6 +50,7 @@ namespace GetIntoTeachingApi.Services
         public Histogram MagicLinkTokenGenerationDuration => _magicLinkTokenGenerationDuration;
         public Histogram HangfireJobQueueDuration => _hangfireJobQueueDuration;
         public Histogram TeachingEventSearchResults => _teachingEventSearchResults;
+        public Histogram InPersonTeachingEventResults => _inPersonTeachingEventResults;
         public Gauge HangfireJobs => _hangfireJobs;
         public Counter GoogleApiCalls => _googleApiCalls;
         public Counter CacheLookups => _cacheLookups;

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -131,6 +131,7 @@ namespace GetIntoTeachingApiTests.Controllers
             _mockLogger.VerifyInformationWasCalled("SearchGroupedByType: KY12 8FG");
 
             _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
+            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -58,6 +58,26 @@ namespace GetIntoTeachingApiTests.Models
             };
 
             teachingEvent.IsVirtual.Should().Be(expected);
-    }
+        }
+
+        [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, true)]
+        public void IsInPerson_ReturnsCorrectly(bool isOnline, bool isVirtual, bool expected)
+        {
+            var teachingEvent = new TeachingEvent()
+            {
+                IsOnline = isOnline,
+            };
+
+            if (isVirtual || !isOnline)
+            {
+                teachingEvent.Building = new TeachingEventBuilding() { AddressPostcode = "KY11 9YU" };
+            }
+
+            teachingEvent.IsInPerson.Should().Be(expected);
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -77,5 +77,13 @@ namespace GetIntoTeachingApiTests.Services
             _metrics.TeachingEventSearchResults.Name.Should().Be("api_teaching_event_search_results_count");
             _metrics.TeachingEventSearchResults.LabelNames.Should().BeEquivalentTo(new[] { "type_id", "radius" });
         }
+
+
+        [Fact]
+        public void InPersonTeachingEventResults_ReturnsMetric()
+        {
+            _metrics.InPersonTeachingEventResults.Name.Should().Be("api_in_person_teaching_event_results_count");
+            _metrics.InPersonTeachingEventResults.LabelNames.Should().BeEquivalentTo(new[] { "type_id", "radius" });
+        }
     }
 }

--- a/monitoring/grafana/dashboards/get_into_teaching_api_event_search.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api_event_search.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
+  "id": 6,
   "links": [],
   "panels": [
     {
@@ -239,7 +239,7 @@
       },
       "id": 73,
       "panels": [],
-      "title": "Results by Radius (Train to Teach)",
+      "title": "In-person Results by Radius (Train to Teach)",
       "type": "row"
     },
     {
@@ -285,25 +285,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -357,25 +357,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -429,25 +429,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -501,25 +501,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id=\"222750001\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id=\"222750001\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -531,6 +531,7 @@
       "type": "stat"
     },
     {
+      "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
@@ -539,7 +540,8 @@
         "y": 30
       },
       "id": 6,
-      "title": "Results by Radius",
+      "panels": [],
+      "title": "In-person Results by Radius",
       "type": "row"
     },
     {
@@ -585,25 +587,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius!~\".+\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius!~\".+\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -657,25 +659,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"30\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"30\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -729,25 +731,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"50\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"50\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -801,25 +803,25 @@
       "pluginVersion": "7.2.2",
       "targets": [
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"+Inf\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "> 10",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"10\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "6 - 10",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"5\",radius=\"100\",type_id!~\".+\"}[$__interval])) - sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "1 - 5",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(api_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
+          "expr": "sum(increase(api_in_person_teaching_event_search_results_count_bucket{le=\"0.75\",radius=\"100\",type_id!~\".+\"}[$__interval]))",
           "interval": "",
           "legendFormat": "0",
           "refId": "D"
@@ -844,6 +846,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Get into Teaching Api - Event Search",
-  "uid": null,
-  "version": 0
+  "uid": "rSpgdKUGz",
+  "version": 1
 }


### PR DESCRIPTION
- Collect metric on in person event result counts

When a teaching event search is performed we want to know how many in-person events are returned (as well as total events, including online).

Add a second metric that observes how many in-person events are returned in a search result.

Add convenience method to `TeachingEvent` to determine if it is `InPerson`.

- Update event search dashboard to show in-person results

We are interested in how many in-person event results are returned on radius searches (as online events are always returned, skewing the data we're interested in).