### PR TITLE
Improved request/response and job payload logging

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -48,6 +48,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -56,6 +57,7 @@
 	  <Folder Include="Fixtures\" />
 	  <Folder Include="JsonConverters\" />
 	  <Folder Include="Mocks\" />
+	  <Folder Include="Middleware\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -36,6 +36,7 @@ namespace GetIntoTeachingApi.Jobs
         public void Run(string json, PerformContext context)
         {
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
+            _logger.LogInformation($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
 
             var candidate = json.DeserializeChangeTracked<Candidate>();
 

--- a/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
@@ -1,0 +1,100 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.IO;
+
+namespace GetIntoTeachingApi.Middleware
+{
+    public class RequestResponseLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<RequestResponseLoggingMiddleware> _logger;
+        private readonly RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
+
+        public RequestResponseLoggingMiddleware(
+            RequestDelegate next, ILogger<RequestResponseLoggingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+            _recyclableMemoryStreamManager = new RecyclableMemoryStreamManager();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            await LogRequest(context);
+            await LogResponse(context);
+        }
+
+        private static string ReadStream(Stream stream)
+        {
+            const int bufferSize = 4096;
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using var writer = new StringWriter();
+            using var reader = new StreamReader(stream);
+            var chunk = new char[bufferSize];
+            int chunkSize;
+
+            do
+            {
+                chunkSize = reader.ReadBlock(chunk, 0, bufferSize);
+                writer.Write(chunk, 0, chunkSize);
+            }
+            while (chunkSize > 0);
+
+            return writer.ToString();
+        }
+
+        private void LogInformation(string identifier, string payload, HttpContext context)
+        {
+            var info = new
+            {
+                context.Request.Scheme,
+                context.Request.Host,
+                context.Request.Path,
+                context.Request.QueryString,
+                Payload = Redactor.RedactJson(payload),
+            };
+
+            _logger.LogInformation($"{identifier}: {info}");
+        }
+
+        private async Task LogRequest(HttpContext context)
+        {
+            context.Request.EnableBuffering();
+
+            // Copy request body stream, resetting position for next middleware.
+            await using var stream = _recyclableMemoryStreamManager.GetStream();
+            await context.Request.Body.CopyToAsync(stream);
+            context.Request.Body.Position = 0;
+
+            LogInformation("HTTP Request", ReadStream(stream), context);
+        }
+
+        private async Task LogResponse(HttpContext context)
+        {
+            // Keep track of the original response body stream (its read-once).
+            var bodyStream = context.Response.Body;
+
+            // Get a new stream.
+            await using var stream = _recyclableMemoryStreamManager.GetStream();
+
+            // Write the downstream response into our stream.
+            context.Response.Body = stream;
+            await _next(context);
+
+            // Extract response body as text, resetting position for next middleware.
+            stream.Seek(0, SeekOrigin.Begin);
+            var text = await new StreamReader(stream).ReadToEndAsync();
+            stream.Seek(0, SeekOrigin.Begin);
+
+            LogInformation("HTTP Response", text, context);
+
+            // Copy back into the original response body stream.
+            await stream.CopyToAsync(bodyStream);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -187,6 +187,8 @@ The GIT API aims to provide:
 
             app.UseHttpsRedirection();
 
+            app.UseRequestResponseLogging();
+
             var hangfireOptions = new BackgroundJobServerOptions();
             if (!env.IsDevelopment)
             {

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using MoreLinq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class Redactor
+    {
+        private static readonly string _redactedValue = "******";
+        private static readonly IEnumerable<string> _sensitivePropertyNames = new string[]
+        {
+            "password",
+            "email",
+            "fullName",
+            "firstName",
+            "lastName",
+            "telephone",
+            "dateOfBirth",
+            "teacherId",
+            "addressLine1",
+            "addressLine2",
+        };
+
+        public static string RedactJson(string json)
+        {
+            try
+            {
+                var rootToken = JToken.Parse(json);
+                var jsonPath = $"$..['{string.Join("','", _sensitivePropertyNames)}']";
+
+                rootToken
+                    .SelectTokens(jsonPath)
+                    .ForEach(t => t.Replace(new JValue(_redactedValue)));
+
+                return JsonConvert.SerializeObject(rootToken);
+            }
+            catch (JsonReaderException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Utils/RequestResponseLoggingMiddlewareExtensions.cs
+++ b/GetIntoTeachingApi/Utils/RequestResponseLoggingMiddlewareExtensions.cs
@@ -1,0 +1,13 @@
+﻿using GetIntoTeachingApi.Middleware;
+using Microsoft.AspNetCore.Builder;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class RequestResponseLoggingMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseRequestResponseLogging(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<RequestResponseLoggingMiddleware>();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -46,6 +46,7 @@
     <Folder Include="Redis\" />
     <Folder Include="Validators\" />
     <Folder Include="JsonConverters\" />
+    <Folder Include="Middleware\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -43,10 +43,12 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
 
-            _job.Run(_candidate.SerializeChangeTracked(), null);
+            var json = _candidate.SerializeChangeTracked();
+            _job.Run(json, null);
 
             _mockCrm.Verify(mock => mock.Save(It.Is<Candidate>(c => IsMatch(_candidate, c))), Times.Once);
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
             _mockLogger.VerifyInformationWasCalled($"UpsertCandidateJob - Succeeded - {_candidate.Id}");
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
         }

--- a/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
+++ b/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
@@ -1,0 +1,97 @@
+﻿using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GetIntoTeachingApi.Middleware;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Middleware
+{
+    public class RequestResponseLoggingMiddlewareTests
+    {
+        private readonly Mock<ILogger<RequestResponseLoggingMiddleware>> _mockLogger;
+        private readonly DefaultHttpContext _context;
+
+        public RequestResponseLoggingMiddlewareTests()
+        {
+            _mockLogger = new Mock<ILogger<RequestResponseLoggingMiddleware>>();
+            _context = new DefaultHttpContext();
+
+            _context.Request.Scheme = "https";
+            _context.Request.Host = new HostString("host", 80);
+            _context.Request.Path = "/path";
+            _context.Request.QueryString = new QueryString("?key=value");
+        }
+
+        [Fact]
+        public async void Invoke_WithJsonPayload_LogsRequestAndResponseWithRedactedPayloads()
+        {
+            string json = JsonSerializer.Serialize(new
+                {
+                    password = "abc123",
+                    addressPostcode = "TE7 1NG",
+                }
+            );
+
+            string redactedJson = JsonSerializer.Serialize(
+                new
+                {
+                    password = "******",
+                    addressPostcode = "TE7 1NG",
+                }
+            );
+
+            await MiddlewareWithPayload(json).Invoke(_context);
+
+            var expectedInfo = new
+            {
+                _context.Request.Scheme,
+                _context.Request.Host,
+                _context.Request.Path,
+                _context.Request.QueryString,
+                Payload = redactedJson,
+            };
+
+            _mockLogger.VerifyInformationWasCalled($"HTTP Request: {expectedInfo}");
+            _mockLogger.VerifyInformationWasCalled($"HTTP Response: {expectedInfo}");
+        }
+
+        [Fact]
+        public async void Invoke_WithNonJsonPayload_LogsRequestAndResponseWithEmptyPayloads()
+        {
+            var text = "my password is 123456";
+
+            await MiddlewareWithPayload(text).Invoke(_context);
+
+            var expectedInfo = new
+            {
+                _context.Request.Scheme,
+                _context.Request.Host,
+                _context.Request.Path,
+                _context.Request.QueryString,
+                Payload = string.Empty,
+            };
+
+            _mockLogger.VerifyInformationWasCalled($"HTTP Request: {expectedInfo}");
+            _mockLogger.VerifyInformationWasCalled($"HTTP Response: {expectedInfo}");
+        }
+
+        private RequestResponseLoggingMiddleware MiddlewareWithPayload(string payload)
+        {
+            _context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            return new RequestResponseLoggingMiddleware(
+                next: (innerHttpContext) =>
+                {
+                    innerHttpContext.Response.WriteAsync(payload);
+                    return Task.CompletedTask;
+                },
+                _mockLogger.Object
+            );
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/RedactorTests.cs
+++ b/GetIntoTeachingApiTests/Utils/RedactorTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Text.Json;
+using FluentAssertions;
+using GetIntoTeachingApi.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class RedactorTests
+    {
+        [Fact]
+        public void RedactJson_WithValidJson_RedactsSensitiveData()
+        {
+            string json = JsonSerializer.Serialize(
+                new
+                {
+                    password = "abc123",
+                    firstName = "Ross",
+                    nested = new
+                    {
+                        addressLine1 = "6 main street",
+                        password = "abc123",
+                    },
+                    email = new string[] { "first", "second" },
+                    addressPostcode = "TE7 1NG",
+                }
+            );
+
+            string redactedJson = JsonSerializer.Serialize(
+                new
+                {
+                    password = "******",
+                    firstName = "******",
+                    nested = new
+                    {
+                        addressLine1 = "******",
+                        password = "******",
+                    },
+                    email = "******",
+                    addressPostcode = "TE7 1NG",
+                }
+            );
+
+            var result = Redactor.RedactJson(json);
+
+            result.Should().Be(redactedJson);
+        }
+
+        [Fact]
+        public void RedactJson_WithInvalidJson_ReturnsEmpty()
+        {
+            var invalidJson = "my password is 123456";
+
+            var result = Redactor.RedactJson(invalidJson);
+
+            result.Should().Be(string.Empty);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -221,10 +221,11 @@ We use postcodes to support searching for events around a given location. The ap
 
 ### JSON Serializers
 
-The application uses two Json serializers; `System.Text.Json` for everything apart from serializing Hangfire payloads (changed tracked objects), for which we use `Newtonsoft.Json`. The reasons for this are:
+The application uses two Json serializers; `System.Text.Json` for everything apart from serializing Hangfire payloads (changed tracked objects) and redacting personally identifiable information from our logs, for which we use `Newtonsoft.Json`. The reasons for this are:
 
 1. `System.Text.Json` does not support conditional serialization and we want to serialize `ChangedPropertyNames` _only_ when serializing a Hangfire payload (omitting the attribute in API responses).
 2. `System.Text.Json` supports on deserializing/ed but not our particular use case of pausing change tracking during deserialization. `Newtonsoft.Json` supports `System.Runtime.Serialization.OnDeserializing/OnDeserialized` which can be used for this purpose.
+3. `System.Text.Json` does not support JSONPath, which we use to redact PII from logged payloads.
 
 In an attempt to isolate `Newtonsoft.Json` there are extensions for serializing/deserializing changed tracked objects:
 


### PR DESCRIPTION
- Add utilty class to redact sensitive data from JSON

We want to be able to log out the request/response bodies and Hangfire job paylaods to aid in debugging when something goes wrong. While doing this we need to ensure no personally identifiable information is sent to our logstash.

Add a `Redactor` utility class that redacts sensitive data (identified by payload keys) from JSON.

Update README to explain why we have to use Newtonsoft.Json for this.

- Log out request/response payloads

Add middleware that intercepts request/response payloads, redacts sensitive data and them logs the request information.

So as not to upset other middleware in the chain the request/response body streams are copied and rewound. `RecyclableMemoryStreamManager` is used for performance/to avoid memory leaks.

Query parameters are assumed to be safe/not sensitive.

- Log out JSON job payloads

To better understand issues in production its helpful to have the full job payloads; this logs them out after redacting sensitive information.