### PR TITLE
Serialize attribute names to camelCase instead of PascalCase

### DIFF
--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -59,7 +59,7 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            string json = request.Candidate.SerializeChangedTracked();
+            string json = request.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();
@@ -112,7 +112,7 @@ namespace GetIntoTeachingApi.Controllers
                 return Unauthorized(result);
             }
 
-            string json = result.Candidate.SerializeChangedTracked();
+            string json = result.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return Ok(new MailingListAddMember(result.Candidate));

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -52,7 +52,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 return BadRequest(this.ModelState);
             }
 
-            string json = request.Candidate.SerializeChangedTracked();
+            string json = request.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -131,7 +131,7 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(this.ModelState);
             }
 
-            string json = request.Candidate.SerializeChangedTracked();
+            string json = request.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
             return NoContent();

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -51,7 +51,7 @@ namespace GetIntoTeachingApi.Jobs
             foreach (var candidate in candidates)
             {
                 _magicLinkTokenService.GenerateToken(candidate);
-                string json = candidate.SerializeChangedTracked();
+                string json = candidate.SerializeChangeTracked();
                 _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(json, null));
             }
         }

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -36,9 +35,9 @@ namespace GetIntoTeachingApi.Jobs
 
         public void Run(string json, PerformContext context)
         {
-            var candidate = json.DeserializeChangedTracked<Candidate>();
-
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
+
+            var candidate = json.DeserializeChangeTracked<Candidate>();
 
             if (IsLastAttempt(context, _contextAdapter))
             {

--- a/GetIntoTeachingApi/Utils/JsonExtensions.cs
+++ b/GetIntoTeachingApi/Utils/JsonExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace GetIntoTeachingApi.Utils
 {
@@ -7,14 +8,15 @@ namespace GetIntoTeachingApi.Utils
         private static readonly JsonSerializerSettings _settings = new JsonSerializerSettings()
         {
             NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
         };
 
-        public static T DeserializeChangedTracked<T>(this string json)
+        public static T DeserializeChangeTracked<T>(this string json)
         {
             return JsonConvert.DeserializeObject<T>(json, _settings);
         }
 
-        public static string SerializeChangedTracked<T>(this T value)
+        public static string SerializeChangeTracked<T>(this T value)
         {
             return JsonConvert.SerializeObject(value, Formatting.Indented, _settings);
         }

--- a/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/MailingListControllerTests.cs
@@ -152,7 +152,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -104,7 +104,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -205,7 +205,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
-            var candidateB = candidateBJson.DeserializeChangedTracked<Candidate>();
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
 
             // Compares ignoring date attributes that are dynamic.
             candidateA.Should().BeEquivalentTo(candidateB, options => options

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_UpsertsCandidatesWithMagicLinkTokens()
         {
             var candidate = new Candidate() { MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
-            string json = candidate.SerializeChangedTracked();
+            string json = candidate.SerializeChangeTracked();
             _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(5000)).Returns(new Candidate[] { candidate });
 
             _job.Run();

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Jobs;
@@ -44,7 +43,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
 
-            _job.Run(_candidate.SerializeChangedTracked(), null);
+            _job.Run(_candidate.SerializeChangeTracked(), null);
 
             _mockCrm.Verify(mock => mock.Save(It.Is<Candidate>(c => IsMatch(_candidate, c))), Times.Once);
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (1/24)");
@@ -61,7 +60,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
             _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
 
-            _job.Run(_candidate.SerializeChangedTracked(), null);
+            _job.Run(_candidate.SerializeChangeTracked(), null);
 
             registration.CandidateId = candidateId;
             _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(r => IsMatch(registration, r))), Times.Once);
@@ -80,7 +79,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
             _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
 
-            _job.Run(_candidate.SerializeChangedTracked(), null);
+            _job.Run(_candidate.SerializeChangeTracked(), null);
 
             phoneCall.CandidateId = candidateId.ToString();
             _mockCrm.Verify(mock => mock.Save(It.Is<PhoneCall>(p => IsMatch(phoneCall, p))), Times.Once);
@@ -101,7 +100,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
             _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
 
-            _job.Run(_candidate.SerializeChangedTracked(), null);
+            _job.Run(_candidate.SerializeChangeTracked(), null);
 
             _mockCrm.Verify(mock => mock.Save(It.IsAny<CallbackBookingQuota>()), Times.Never);
             quota.NumberOfBookings.Should().Be(5);
@@ -113,7 +112,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
 
-            _job.Run(_candidate.SerializeChangedTracked(), null);
+            _job.Run(_candidate.SerializeChangeTracked(), null);
 
             _mockCrm.Verify(mock => mock.Save(It.IsAny<Candidate>()), Times.Never);
             _mockNotifyService.Verify(mock => mock.SendEmailAsync(_candidate.Email,

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -11,7 +11,6 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Mocks;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
-using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Moq;
@@ -134,40 +133,6 @@ namespace GetIntoTeachingApiTests.Models
             // Init with changes.
             model = new MockModel() { Field3 = "test", Field2 = 0 };
             model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "FieldDefinedWithValue", "Field3", "Field2" });
-        }
-
-        [Fact]
-        public void ChangedPropertyNames_DuringDeserialization_IsNotAltered()
-        {
-            // Ensures the JSON serializer correctly deserializes
-            // ChangedPropertyNames (and doesn't inadvertently change it
-            // during the deserialization process when writing to attributes).
-            var model = new MockModel() { Id = Guid.NewGuid(), Field3 = "test" };
-
-            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
-
-            // Test serializing/deseriaizing model.
-            var json = model.SerializeChangedTracked();
-            var deserializedModel = json.DeserializeChangedTracked<MockModel>();
-
-            deserializedModel.Id.Should().Be(model.Id);
-            deserializedModel.Field3.Should().Be(model.Field3);
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
-
-            // Test deserializing model with ChangedPropertyNames in different order/combinations.
-            json = "{\"ChangedPropertyNames\":[\"Id\",\"Field1\"],\"Field3\":\"test\",\"Field2\":123}";
-            deserializedModel = json.DeserializeChangedTracked<MockModel>();
-
-            deserializedModel.Field2.Should().Be(123);
-            deserializedModel.Field3.Should().Be("test");
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
-
-            json = "{\"Field3\":\"test\",\"Field2\":123,\"ChangedPropertyNames\":[\"Id\",\"Field1\"]}";
-            deserializedModel = json.DeserializeChangedTracked<MockModel>();
-
-            deserializedModel.Field2.Should().Be(123);
-            deserializedModel.Field3.Should().Be("test");
-            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Utils/JsonExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/JsonExtensionsTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GetIntoTeachingApi.Mocks;
+using GetIntoTeachingApi.Utils;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class JsonExtensionsTests
+    {
+        [Fact]
+        public void SerializeChangeTracked_IgnoresNullValues()
+        {
+            var model = new MockModel() { Id = Guid.NewGuid(), Field3 = null };
+
+            var json = model.SerializeChangeTracked();
+
+            json.Should().NotContain("field3");
+            json.Should().Contain("id");
+        }
+
+        [Fact]
+        public void SerializeChangeTracked_UsesCamelCaseAttributeNames()
+        {
+            var model = new MockModel() { Field3 = "test" };
+
+            var json = model.SerializeChangeTracked();
+
+            json.Should().Contain("\"field3\": \"test\"");
+        }
+
+        [Fact]
+        public void DeserializeChangeTracked_WithCamelCaseAttributeNames_DeserializesCorrectly()
+        {
+            var model = "{\"field3\":\"test\"}".DeserializeChangeTracked<MockModel>();
+
+            model.Field3.Should().Be("test");
+        }
+
+        [Fact]
+        public void DeserializeChangeTracked_WithPascalCaseAttributeNames_DeserializesCorrectly()
+        {
+            // Ensures any jobs in the queue will still deserialize correctly
+            // while we roll out the change to serializing with camelCase attribute names.
+            var model = "{\"Field3\":\"test\"}".DeserializeChangeTracked<MockModel>();
+
+            model.Field3.Should().Be("test");
+        }
+
+        [Fact]
+        public void SerializeAndDeserializeChangeTracked_BehavesCorrectly()
+        {
+            // Ensures the JSON serializer correctly deserializes
+            // ChangedPropertyNames (and doesn't inadvertently change it
+            // during the deserialization process when writing to attributes).
+            var model = new MockModel() { Id = Guid.NewGuid(), Field3 = "test" };
+
+            model.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
+
+            // Test serializing/deseriaizing model.
+            var json = model.SerializeChangeTracked();
+            var deserializedModel = json.DeserializeChangeTracked<MockModel>();
+
+            deserializedModel.Id.Should().Be(model.Id);
+            deserializedModel.Field3.Should().Be(model.Field3);
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field3", "FieldDefinedWithValue" });
+
+            // Test deserializing model with ChangedPropertyNames in different order/combinations.
+            json = "{\"ChangedPropertyNames\":[\"Id\",\"Field1\"],\"Field3\":\"test\",\"Field2\":123}";
+            deserializedModel = json.DeserializeChangeTracked<MockModel>();
+
+            deserializedModel.Field2.Should().Be(123);
+            deserializedModel.Field3.Should().Be("test");
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
+
+            json = "{\"Field3\":\"test\",\"Field2\":123,\"ChangedPropertyNames\":[\"Id\",\"Field1\"]}";
+            deserializedModel = json.DeserializeChangeTracked<MockModel>();
+
+            deserializedModel.Field2.Should().Be(123);
+            deserializedModel.Field3.Should().Be("test");
+            deserializedModel.ChangedPropertyNames.Should().BeEquivalentTo(new HashSet<string>() { "Id", "Field1", "FieldDefinedWithValue" });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Get into Teaching API 
+﻿# Get into Teaching API 
 ![Build](https://github.com/DFE-Digital/get-into-teaching-api/workflows/Build/badge.svg)
 
 > Provides a RESTful API for integrating with the Get into Teaching CRM.
@@ -229,8 +229,8 @@ The application uses two Json serializers; `System.Text.Json` for everything apa
 In an attempt to isolate `Newtonsoft.Json` there are extensions for serializing/deserializing changed tracked objects:
 
 ```
-var myChangedTrackedObject = json.DeserializeChangedTracked<ChangedTrackedObject>();
-var json = myChangeTrackedObject.SerializeChangedTracked();
+var myChangeTrackedObject = json.DeserializeChangeTracked<ChangeTrackedObject>();
+var json = myChangeTrackedObject.SerializeChangeTracked();
 ```
 
 ## CRM Changes


### PR DESCRIPTION
By default `System.Text.Json` serializes attribute names to `camelCase` and `Newtonsoft.Json` will match the casing of the attribute being serialized (`PascalCase` for C# attributes).

Making these consistent will mean that we only have to check for property names in a single case when redacting sensitive data (otherwise we would have to check `firstName` and `FirstName`, for example).

`Newtonsoft.Json` will deserialize both camel and pascal case by default, so the existing jobs in the queue will still deserialize and process fine.

Fixes a typo in `Se/DeserializeChangeTracked` extension methods.

Extracts Json serialization tests out of `BaseModel` and into `JsonExtensionsTests`, which makes more sense.