### PR TITLE
Attach correlation IDs to logs

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -49,6 +49,7 @@
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
+		<PackageReference Include="CorrelationId" Version="3.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
+using CorrelationId;
+using CorrelationId.DependencyInjection;
 using dotenv.net;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Adapters;
@@ -74,6 +76,13 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IEnv>(env);
+
+            services.AddDefaultCorrelationId((options) =>
+            {
+                options.AddToLoggingScope = true;
+                options.RequestHeader = "X-Request-Id";
+                options.ResponseHeader = "X-Request-Id";
+            });
 
             var connectionString = DbConfiguration.DatabaseConnectionString(env);
             services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
@@ -186,6 +195,8 @@ The GIT API aims to provide:
             app.UseAuthentication();
 
             app.UseHttpsRedirection();
+
+            app.UseCorrelationId();
 
             app.UseRequestResponseLogging();
 


### PR DESCRIPTION
We want to be able to track a request from a client as it moves through the API and various log messages are created.

Add `CorrelationId` library that will automatically consume an incoming request ID (from the `X-Request-ID` header, which is the Rails default) and attach it to the scope of any log messages that the API writes.

If an `X-Request-Id` is not present then the library will generate a new one in the form of a GUID.