### PR TITLE
Revert "Attach correlation IDs to logs"

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -49,7 +49,6 @@
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
-		<PackageReference Include="CorrelationId" Version="3.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -2,8 +2,6 @@ using System;
 using System.Linq;
 using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
-using CorrelationId;
-using CorrelationId.DependencyInjection;
 using dotenv.net;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Adapters;
@@ -76,13 +74,6 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IEnv>(env);
-
-            services.AddDefaultCorrelationId((options) =>
-            {
-                options.AddToLoggingScope = true;
-                options.RequestHeader = "X-Request-Id";
-                options.ResponseHeader = "X-Request-Id";
-            });
 
             var connectionString = DbConfiguration.DatabaseConnectionString(env);
             services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));
@@ -195,8 +186,6 @@ The GIT API aims to provide:
             app.UseAuthentication();
 
             app.UseHttpsRedirection();
-
-            app.UseCorrelationId();
 
             app.UseRequestResponseLogging();
 


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#545

It turns out asp.net core 3 has support for correlation ids built in (following the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard); if we set a request header `traceparent` or `Request-Id` with the request id from the Rails apps it will automagically be attached to the log scope of all the log messages from the API.