### PR TITLE
Add mechanism to pause/resume the CRM integration

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -17,15 +17,18 @@ namespace GetIntoTeachingApi.Controllers
         private readonly ICandidateAccessTokenService _accessTokenService;
         private readonly INotifyService _notifyService;
         private readonly ICrmService _crm;
+        private readonly IAppSettings _appSettings;
 
         public CandidatesController(
             ICandidateAccessTokenService accessTokenService,
             INotifyService notifyService,
-            ICrmService crm)
+            ICrmService crm,
+            IAppSettings appSettings)
         {
             _accessTokenService = accessTokenService;
             _notifyService = notifyService;
             _crm = crm;
+            _appSettings = appSettings;
         }
 
         [HttpPost]
@@ -46,6 +49,11 @@ namespace GetIntoTeachingApi.Controllers
             if (!ModelState.IsValid)
             {
                 return BadRequest(this.ModelState);
+            }
+
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                return NotFound();
             }
 
             var candidate = _crm.MatchCandidate(request);

--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -20,3 +20,8 @@
   description: "A service to enable candidates to sign up for a Teacher Training Adviser (TTA)"
   api_key_prefix: TTA
   role: GetAnAdviser
+-
+  name: CRM
+  description: "The Microsoft Dynamics CRM (GiTiS)"
+  api_key_prefix: CRM
+  role: Crm

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi.Jobs
         private readonly INotifyService _notifyService;
         private readonly IPerformContextAdapter _contextAdapter;
         private readonly IMetricService _metrics;
+        private readonly IAppSettings _appSettings;
         private readonly ILogger<UpsertCandidateJob> _logger;
 
         public UpsertCandidateJob(
@@ -23,7 +24,8 @@ namespace GetIntoTeachingApi.Jobs
             INotifyService notifyService,
             IPerformContextAdapter contextAdapter,
             IMetricService metrics,
-            ILogger<UpsertCandidateJob> logger)
+            ILogger<UpsertCandidateJob> logger,
+            IAppSettings appSettings)
             : base(env)
         {
             _crm = crm;
@@ -31,10 +33,16 @@ namespace GetIntoTeachingApi.Jobs
             _contextAdapter = contextAdapter;
             _metrics = metrics;
             _logger = logger;
+            _appSettings = appSettings;
         }
 
         public void Run(string json, PerformContext context)
         {
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException("UpsertCandidateJob - Aborting (CRM integration paused).");
+            }
+
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
             _logger.LogInformation($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
 

--- a/GetIntoTeachingApi/Models/AppSettings.cs
+++ b/GetIntoTeachingApi/Models/AppSettings.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Globalization;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class AppSettings : IAppSettings
+    {
+        private const string DateFormat = "O";
+        private const string CrmOfflineUntilKey = "app_settings.crm_offline_until";
+        private readonly IRedisService _redis;
+
+        public DateTime? CrmIntegrationPausedUntil
+        {
+            get
+            {
+                var dateStr = _redis.Database.StringGet(CrmOfflineUntilKey);
+
+                if (dateStr.IsNullOrEmpty)
+                {
+                    return null;
+                }
+
+                return DateTime.ParseExact(
+                    dateStr,
+                    DateFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind);
+            }
+
+            set
+            {
+                var dateStr = value?.ToString(DateFormat);
+
+                _redis.Database.StringSet(CrmOfflineUntilKey, dateStr);
+            }
+        }
+
+        public bool IsCrmIntegrationPaused => CrmIntegrationPausedUntil > DateTime.UtcNow;
+
+        public AppSettings(IRedisService redis)
+        {
+            _redis = redis;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/HealthCheckResponse.cs
+++ b/GetIntoTeachingApi/Models/HealthCheckResponse.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using GetIntoTeachingApi.Attributes;
 
 namespace GetIntoTeachingApi.Models
 {
     public class HealthCheckResponse
     {
         public const string StatusOk = "ok";
+        public const string StatusIntegrationPaused = "integration-paused";
         public string GitCommitSha { get; set; }
         public string Environment { get; set; }
         public string Database { get; set; }

--- a/GetIntoTeachingApi/Models/IAppSettings.cs
+++ b/GetIntoTeachingApi/Models/IAppSettings.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public interface IAppSettings
+    {
+        DateTime? CrmIntegrationPausedUntil { get; set; }
+        bool IsCrmIntegrationPaused { get; }
+    }
+}

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -18,9 +18,15 @@ namespace GetIntoTeachingApi.Services
         private readonly IOrganizationServiceAdapter _service;
         private readonly IValidatorFactory _validatorFactory;
         private readonly IDateTimeProvider _dateTime;
+        private readonly IAppSettings _appSettings;
 
-        public CrmService(IOrganizationServiceAdapter service, IValidatorFactory validatorFactory, IDateTimeProvider dateTime)
+        public CrmService(
+            IOrganizationServiceAdapter service,
+            IValidatorFactory validatorFactory,
+            IAppSettings appSettings,
+            IDateTimeProvider dateTime)
         {
+            _appSettings = appSettings;
             _service = service;
             _validatorFactory = validatorFactory;
             _dateTime = dateTime;
@@ -28,6 +34,11 @@ namespace GetIntoTeachingApi.Services
 
         public string CheckStatus()
         {
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                return HealthCheckResponse.StatusIntegrationPaused;
+            }
+
             return _service.CheckStatus();
         }
 

--- a/GetIntoTeachingApi/Services/IRedisService.cs
+++ b/GetIntoTeachingApi/Services/IRedisService.cs
@@ -1,9 +1,11 @@
 ﻿using System.Threading.Tasks;
+using StackExchange.Redis;
 
 namespace GetIntoTeachingApi.Services
 {
     public interface IRedisService
     {
         Task<string> CheckStatusAsync();
+        IDatabase Database { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/RedisService.cs
+++ b/GetIntoTeachingApi/Services/RedisService.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApi.Services
         private readonly ConnectionMultiplexer _redis;
         private readonly ConfigurationOptions _options;
 
+        public IDatabase Database => _redis.GetDatabase();
+
         public RedisService(IEnv env)
         {
             _options = RedisConfiguration.ConfigurationOptions(env);

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -10,6 +10,7 @@ using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.JsonConverters;
 using GetIntoTeachingApi.ModelBinders;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.OperationFilters;
 using GetIntoTeachingApi.RateLimiting;
 using GetIntoTeachingApi.Redis;
@@ -52,6 +53,8 @@ namespace GetIntoTeachingApi
             {
                 DotEnv.Config(true, ".env.development");
             }
+
+            services.AddSingleton<IAppSettings, AppSettings>();
 
             services.AddSingleton<CdsServiceClientWrapper, CdsServiceClientWrapper>();
             services.AddTransient<IOrganizationService>(sp => sp.GetService<CdsServiceClientWrapper>().CdsServiceClient?.Clone());

--- a/GetIntoTeachingApiTests/Models/AppSettingsTests.cs
+++ b/GetIntoTeachingApiTests/Models/AppSettingsTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class AppSettingsTests
+    {
+        private readonly AppSettings _settings;
+        private readonly Mock<IDatabase> _database;
+
+        public AppSettingsTests()
+        {
+            _database = new Mock<IDatabase>();
+            var redis = new Mock<IRedisService>();
+            redis.Setup(m => m.Database).Returns(_database.Object);
+
+            _settings = new AppSettings(redis.Object);
+        }
+
+        [Fact]
+        public void CrmIntegrationPausedUntil_SetAndGetWithDate_WorkCorrectly()
+        {
+            var date = DateTime.UtcNow;
+            var dateStr = date.ToString("O");
+            _database.Setup(m => m.StringSet("app_settings.crm_offline_until", dateStr, null, When.Always, CommandFlags.None));
+            _database.Setup(m => m.StringGet("app_settings.crm_offline_until", CommandFlags.None)).Returns(dateStr);
+
+            _settings.CrmIntegrationPausedUntil = date;
+            _settings.CrmIntegrationPausedUntil.Should().Be(date);
+        }
+
+        [Fact]
+        public void CrmIntegrationPausedUntil_SetAndGetWithNull_WorkCorrectly()
+        {
+            _database.Setup(m => m.StringSet("app_settings.crm_offline_until", null as string, null, When.Always, CommandFlags.None));
+            _database.Setup(m => m.StringGet("app_settings.crm_offline_until", CommandFlags.None)).Returns(null as string);
+
+            _settings.CrmIntegrationPausedUntil = null;
+            _settings.CrmIntegrationPausedUntil.Should().BeNull();
+        }
+
+        [Fact]
+        public void IsCrmIntegrationPaused_WhenCrmOfflineUntilIsNull_ReturnsFalse()
+        {
+            _database.Setup(m => m.StringGet("app_settings.crm_offline_until", CommandFlags.None)).Returns<string>(null);
+
+            _settings.IsCrmIntegrationPaused.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsCrmIntegrationPaused_WhenCrmOfflineUntilIsAFutureDate_ReturnsTrue()
+        {
+            var dateStr = DateTime.UtcNow.AddDays(1).ToString("O");
+            _database.Setup(m => m.StringGet("app_settings.crm_offline_until", CommandFlags.None)).Returns(dateStr);
+
+            _settings.IsCrmIntegrationPaused.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsCrmIntegrationPaused_WhenCrmOfflineUntilIsAPastDate_ReturnsFalse()
+        {
+            var dateStr = DateTime.UtcNow.AddDays(-1).ToString("O");
+            _database.Setup(m => m.StringGet("app_settings.crm_offline_until", CommandFlags.None)).Returns(dateStr);
+
+            _settings.IsCrmIntegrationPaused.Should().BeFalse();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -27,11 +27,12 @@ namespace GetIntoTeachingApiTests.Models
 
         public BaseModelTests()
         {
+            var mockAppSettings = new Mock<IAppSettings>();
             _mockValidatorFactory = new Mock<IValidatorFactory>();
             _mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _context = _mockService.Object.Context();
-            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object, new DateTimeProvider());
+            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object, mockAppSettings.Object, new DateTimeProvider());
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-1426](https://trello.com/c/ByTdLhsq/1426-add-endpoint-for-crm-team-to-call-when-they-are-doing-an-update-with-downtime)

The CRM is often taken offline for a short time when the CRM team perform a production update. This results in a flurry of errors from the API that - whilst not effecting end users - is creating noise in our error monitoring for something we can do nothing about.

To avoid this we want to add a mechanism for the CRM team to inform the API that they are taking the CRM offline. The API can then avoid calling the CRM whilst its unavailable and the errors will stop.

- Add AppSettings model

We want to be able to flag the CRM as unavailable when it has been intentionally taken offline by the CRM team (for an update, for example).

Storing this in Postgres felt like overkill, so there is now a simple `AppSettings` model that is backed by Redis. It has a single writable attribute to set how long we want to pause the CRM integration for (this is a `DateTime` so that we can auto-resume the integration and avoid potential user-error).

The idea is that the CRM will call an endpoint in the API and flag itself as being unavailable before an update is carried out. We can then prevent any calls to the CRM, which would otherwise result in errors.

- Add CRM client

Add a client for the CRM; this will enable the CRM team to call specific operations endpoints that pause/resume the API's integration with the CRM.

- Allow CRM integration to be paused/resumed

Adds two new operations endpoints for pausing/resuming the integration with the CRM.

This could have been more rest-ful by accepting a payload with the integration date, but I imagine if we get more `AppSettings` that can be modified externally we will want tight access control, which is currently at the routing
layer so I think having individual endpoints is the way to go for now.

Updates the health check operation to return `integration-paused` as the CRM status if applicable (the overall state will also be moved to `degraded`).

- Don't call CRM if the integration is paused

If we know the CRM is unavailable we should not call out to it (as it results in an error we can do nothing about).

Updates to prevent access tokens being generated when the CRM is offline (instead we return `404` not found which results in the user being treated as a new candidate/mirroring the current behavior sans error).

It is still possible for the API to call out to the CRM as part of the token verification process if:

1. The user generates a token
2. The CRM goes offline
3. The user attempts to verify the token

This should be unlikely to happen often and, whilst we could potentially handle it gracefully, its going to be a fair amount of work. I think we should see if/how often it occurs before committing to handling it explicitly.

- Skip sync/magic link generation jobs when CRM integration paused

When the CRM is unavailable we are unable to perform a sync/generate magic link tokens.

Ideally we would prevent the jobs from being picked up at all when the API is in this state, but Hangfire doesn't support this out of the box and the workarounds aren't ideal. It also means we don't have to monitor the `AppSettings` state to know when to resume processing jobs.

If the CRM is offline these jobs succeed immediately and log out that they have been effectively 'skipped'.

- Abort UpsertCandidateJob when CRM integration paused

Ideally we would fail the job silently or prevent it from being picked up by pausing the queue, but Hangfire does not support either of these.

Instead, we raise an error with a clear explanation so when we are alerted we don't have to investigate the source of the error.