### PR TITLE
Update Gov UK Notify library

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,9 +35,6 @@ jobs:
       with:
         dotnet-version: 3.1.200
 
-    - name: Install NotifyBintray
-      run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
-
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           java-version: '11'
 
-      - name: Install NotifyBintray
-        run:  dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget 
-
       - name: Install dotnet-sonarscanner
         run:  dotnet tool install --global dotnet-sonarscanner --version 4.8.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV ASPNETCORE_URLS=http://+:8080
 COPY *.sln .
 COPY GetIntoTeachingApi/*.csproj ./GetIntoTeachingApi/
 COPY GetIntoTeachingApiTests/*.csproj ./GetIntoTeachingApiTests/
-RUN dotnet nuget add source --name NotifyBintray https://api.bintray.com/nuget/gov-uk-notify/nuget
 RUN dotnet restore -r linux-x64 
 
 # copy everything else and build app

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -26,7 +26,6 @@
 		<PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.2.1-Alpha" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Notify" Version="2.7.0" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="3.1.4" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
@@ -49,6 +48,8 @@
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.3.2" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
+		<PackageReference Include="GovukNotify" Version="4.0.0" />
+		<PackageReference Include="JWT" Version="7.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -76,13 +76,7 @@ More information on rate limiting can be found [below](#rate-limiting).
 
 The API is an ASP.NET Core web application; to get up and running clone the repository and open `GetIntoTeachingApi.sln` in Visual Studio.
 
-Before you build the app you will need to add a package source for the GOV.UK Notify service:
-
-```
-https://api.bintray.com/nuget/gov-uk-notify/nuget
-```
-
-Next you will need to set up the environment (see the `Environment` section below) before booting up the dependent services in Docker with `docker-compose up`.
+You will need to set up the environment (see the `Environment` section below) before booting up the dependent services in Docker with `docker-compose up`.
 
 When the application runs in development it will open the Swagger documentation by default (the development shared secret for the admin client is `secret-admin`).
 


### PR DESCRIPTION
The library was previously hosted on bintray.com, but that will be deprecated on May 1st and the team have moved the latest version to nuget.org.

Update to use latest version on nuget.org.

I got a build warning due to GovUKNotify depending on JWT >= 7.0.0 and < 8.0.0, but v7.0.0 was not found (as there is no v7.0.0) - installing an applicable version manually resolves the warning.