### PR TITLE
Add new fields to event/building

### DIFF
--- a/GetIntoTeachingApi/Migrations/20210322100102_AddImageUrlAndProvidersListToTeachingEvent.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20210322100102_AddImageUrlAndProvidersListToTeachingEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210322100102_AddImageUrlAndProvidersListToTeachingEvent")]
+    partial class AddImageUrlAndProvidersListToTeachingEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20210322100102_AddImageUrlAndProvidersListToTeachingEvent.cs
+++ b/GetIntoTeachingApi/Migrations/20210322100102_AddImageUrlAndProvidersListToTeachingEvent.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class AddImageUrlAndProvidersListToTeachingEvent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProvidersList",
+                table: "TeachingEvents",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ImageUrl",
+                table: "TeachingEventBuildings",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProvidersList",
+                table: "TeachingEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ImageUrl",
+                table: "TeachingEventBuildings");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -64,6 +64,8 @@ namespace GetIntoTeachingApi.Models
         public DateTime StartAt { get; set; }
         [EntityField("msevtmgt_eventenddate")]
         public DateTime EndAt { get; set; }
+        [EntityField("dfe_providerslist")]
+        public string ProvidersList { get; set; }
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]

--- a/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventBuilding.cs
@@ -24,6 +24,8 @@ namespace GetIntoTeachingApi.Models
         public string AddressCity { get; set; }
         [EntityField("msevtmgt_postalcode")]
         public string AddressPostcode { get; set; }
+        [EntityField("dfe_eventvenueimageurl")]
+        public string ImageUrl { get; set; }
         [JsonIgnore]
         [Column(TypeName = "geography")]
         public Point Coordinate { get; set; }

--- a/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventBuildingTests.cs
@@ -20,6 +20,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("AddressLine3").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_addressline3");
             type.GetProperty("AddressCity").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_city");
             type.GetProperty("AddressPostcode").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_postalcode");
+            type.GetProperty("ImageUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventvenueimageurl");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -35,6 +35,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("Message").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_miscellaneousmessage_ml");
             type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventstartdate");
             type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventenddate");
+            type.GetProperty("ProvidersList").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerslist");
 
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));


### PR DESCRIPTION
[Trello-1440](https://trello.com/c/iydAl0Dm/1440-test-and-implement-ability-to-render-bullet-point-list-of-providers-for-ttt-events)

We want to display a list of providers on the TTT events and event buildings will optionally have an image URL that we can display as well.