### PR TITLE
Update teaching event

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -182,8 +182,7 @@ namespace GetIntoTeachingApi.Controllers
 
             return CreatedAtAction(
                 actionName: nameof(Get),
-                controllerName: "TeachingEvents",
-                routeValues: new { id = teachingEvent.ReadableId },
+                routeValues: new { readableId = teachingEvent.ReadableId },
                 value: teachingEvent);
         }
 

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -169,11 +169,11 @@ namespace GetIntoTeachingApi.Controllers
             Summary = "Adds or updates a teaching event.",
             Description = "If the `id` is specified then the existing teaching event will be " +
                           "updated, otherwise a new teaching event will be created.",
-            OperationId = "AddOrUpdateTeachingEvent",
+            OperationId = "UpsertTeachingEvent",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> AddOrUpdateTeachingEventAsync([FromBody] TeachingEvent teachingEvent)
+        public async Task<IActionResult> Upsert([FromBody] TeachingEvent teachingEvent)
         {
             if (!ModelState.IsValid)
             {
@@ -183,10 +183,12 @@ namespace GetIntoTeachingApi.Controllers
             if (teachingEvent.Building != null)
             {
                 _crm.Save(teachingEvent.Building);
-                await _store.SaveAsync(teachingEvent.Building);
             }
 
             _crm.Save(teachingEvent);
+
+            // Make the teaching event/building immediately available in the cache
+            await _store.SaveAsync(teachingEvent);
 
             return CreatedAtAction(
                 actionName: nameof(Get),

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -173,11 +173,17 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
-        public IActionResult AddOrUpdateTeachingEvent([FromBody] TeachingEvent teachingEvent)
+        public async Task<IActionResult> AddOrUpdateTeachingEventAsync([FromBody] TeachingEvent teachingEvent)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
+            }
+
+            if (teachingEvent.Building != null)
+            {
+                _crm.Save(teachingEvent.Building);
+                await _store.SaveAsync(teachingEvent.Building);
             }
 
             _crm.Save(teachingEvent);

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -166,12 +166,14 @@ namespace GetIntoTeachingApi.Controllers
         [HttpPost]
         [Route("")]
         [SwaggerOperation(
-            Summary = "Adds a teaching event.",
-            OperationId = "AddTeachingEvent",
+            Summary = "Adds or updates a teaching event.",
+            Description = "If the `id` is specified then the existing teaching event will be " +
+                          "updated, otherwise a new teaching event will be created.",
+            OperationId = "AddOrUpdateTeachingEvent",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
-        public IActionResult AddTeachingEvent([FromBody] TeachingEvent teachingEvent)
+        public IActionResult AddOrUpdateTeachingEvent([FromBody] TeachingEvent teachingEvent)
         {
             if (!ModelState.IsValid)
             {

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -163,6 +163,30 @@ namespace GetIntoTeachingApi.Controllers
             return Ok(new TeachingEventAddAttendee(candidate));
         }
 
+        [HttpPost]
+        [Route("")]
+        [SwaggerOperation(
+            Summary = "Adds a teaching event.",
+            OperationId = "AddTeachingEvent",
+            Tags = new[] { "Teaching Events" })]
+        [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
+        public IActionResult AddTeachingEvent([FromBody] TeachingEvent teachingEvent)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            _crm.Save(teachingEvent);
+
+            return CreatedAtAction(
+                actionName: nameof(Get),
+                controllerName: "TeachingEvents",
+                routeValues: new { id = teachingEvent.ReadableId },
+                value: teachingEvent);
+        }
+
         private static IEnumerable<TeachingEventsByType> GroupTeachingEventsByType(
             IEnumerable<TeachingEvent> teachingEvents,
             int quantityPerType)

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApi.Models
             Open = 222750000,
             Closed = 222750001,
             Draft = 222750002,
+            Pending = 222750003,
         }
 
         public enum EventType

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -5,7 +5,6 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeachingEventValidator : AbstractValidator<TeachingEvent>
     {
-
         public TeachingEventValidator()
         {
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using FluentValidation;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class TeachingEventValidator : AbstractValidator<TeachingEvent>
+    {
+
+        public TeachingEventValidator()
+        {
+            RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
+            RuleFor(teachingEvent => teachingEvent.Summary).NotEmpty();
+            RuleFor(teachingEvent => teachingEvent.Description).NotEmpty();
+            RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress();
+            RuleFor(teachingEvent => teachingEvent.StartAt).GreaterThan(DateTime.UtcNow);
+            RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -7,6 +7,7 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public TeachingEventValidator()
         {
+            RuleFor(teachingEvent => teachingEvent.ReadableId).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.Summary).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.Description).NotEmpty();

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -10,6 +10,8 @@ namespace GetIntoTeachingApi.Services
     {
         Task<string> CheckStatusAsync();
         Task SyncAsync();
+        Task SaveAsync<T>(T model)
+            where T : BaseModel;
         IQueryable<LookupItem> GetLookupItems(string entityName);
         IQueryable<PickListItem> GetPickListItems(string entityName, string attributeName);
         Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -119,6 +119,13 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TeachingEventBuildings;
         }
 
+        public async Task SaveAsync<T>(T model)
+            where T : BaseModel
+        {
+            await _dbContext.AddAsync(model);
+            await _dbContext.SaveChangesAsync();
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -207,26 +207,15 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
-        public void AddTeachingEvent_WhenRequestIsValid_SavesInTheCrm()
+        public void AddTeachingEvent_WhenRequestIsValid_SavesInCrmAndReturnsCreatedEvent()
         {
             const string testName = "test";
             var newTeachingEvent = new TeachingEvent() { Name = testName };
             _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
 
-            _controller.AddTeachingEvent(newTeachingEvent);
-
-            _mockCrm.Verify();
-        }
-
-        [Fact]
-        public void AddTeachingEvent_WhenRequestIsValid_ReturnsCreatedTeachingEvent()
-        {
-            const string testName = "test";
-            var newTeachingEvent = new TeachingEvent() { Name = testName };
-            _mockCrm.Setup(mock => mock.Save(newTeachingEvent));
-
             var response = _controller.AddTeachingEvent(newTeachingEvent);
 
+            _mockCrm.Verify();
             var created = response.Should().BeOfType<CreatedAtActionResult>().Subject;
             var teachingEvent = created.Value.Should().BeAssignableTo<TeachingEvent>().Subject;
             teachingEvent.Name.Should().Be(testName);

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -199,7 +199,7 @@ namespace GetIntoTeachingApiTests.Controllers
             var request = new TeachingEvent();
             _controller.ModelState.AddModelError(expectedErrorKey, expectedErrorMessage);
 
-            var response = _controller.AddTeachingEvent(request);
+            var response = _controller.AddOrUpdateTeachingEvent(request);
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
@@ -213,7 +213,7 @@ namespace GetIntoTeachingApiTests.Controllers
             var newTeachingEvent = new TeachingEvent() { Name = testName };
             _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
 
-            var response = _controller.AddTeachingEvent(newTeachingEvent);
+            var response = _controller.AddOrUpdateTeachingEvent(newTeachingEvent);
 
             _mockCrm.Verify();
             var created = response.Should().BeOfType<CreatedAtActionResult>().Subject;

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -78,21 +78,18 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_StartAtIsEarlierThanNow_HasError()
         {
-            var teachingEvent = new TeachingEvent { StartAt = DateTime.UtcNow.AddDays(-1) };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.StartAt);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.StartAt, DateTime.UtcNow.AddDays(-1));
         }
 
         [Fact]
         public void Validate_EndAtIsEarlierThanStartAt_HasError()
         {
-            var teachingEvent = new TeachingEvent
+            var invalidTeachingEvent = new TeachingEvent
             {
                 StartAt = DateTime.UtcNow.AddDays(2),
                 EndAt = DateTime.UtcNow.AddDays(1)
             };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.EndAt);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.EndAt, invalidTeachingEvent);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -36,43 +36,43 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_ReadableIdIsNull_HasError()
+        public void Validate_ReadableIdIsNullOrEmpty_HasError()
         {
-            var teachingEvent = new TeachingEvent { ReadableId = null };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.ReadableId);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, "");
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, null as string);
         }
 
         [Fact]
-        public void Validate_NameIsNull_HasError()
+        public void Validate_NameIsNullOrEmpty_HasError()
         {
-            var teachingEvent = new TeachingEvent { Name = null };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.Name);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Name, "");
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Name, null as string);
         }
 
         [Fact]
-        public void Validate_SummaryIsNull_HasError()
+        public void Validate_SummaryIsNullOrEmpty_HasError()
         {
-            var teachingEvent = new TeachingEvent { Summary = null };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.Summary);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Summary, "");
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Summary, null as string);
         }
 
         [Fact]
-        public void Validate_DescriptionIsNull_HasError()
+        public void Validate_DescriptionIsNullOrEmpty_HasError()
         {
-            var teachingEvent = new TeachingEvent { Description = null };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.Description);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Description, "");
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Description, null as string);
+        }
+
+        [Fact]
+        public void Validate_ProviderContactEmailIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(teachingEvent => teachingEvent.ProviderContactEmail, null as string);
         }
 
         [Fact]
         public void Validate_ProviderContactEmailIsPresentAndInvalid_HasError()
         {
-            var teachingEvent = new TeachingEvent { ProviderContactEmail = "invalid email" };
-            var validationResult = _validator.TestValidate(teachingEvent);
-            validationResult.ShouldHaveValidationErrorFor(request => request.ProviderContactEmail);
+            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ProviderContactEmail, "Invalid email");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -1,0 +1,90 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class TeachingEventValidatorTests
+    {
+        private readonly TeachingEventValidator _validator;
+
+        public TeachingEventValidatorTests()
+        {
+            _validator = new TeachingEventValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var client = new TeachingEvent()
+            {
+                Name = "Test name",
+                Summary = "Test summary",
+                Description = "Test description",
+                ProviderContactEmail = "test@test.com",
+                StartAt = DateTime.UtcNow.AddDays(1),
+                EndAt = DateTime.UtcNow.AddDays(1),
+            };
+
+            var result = _validator.Validate(client);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_NameIsNull_HasError()
+        {
+            var teachingEvent = new TeachingEvent { Name = null };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.Name);
+        }
+
+        [Fact]
+        public void Validate_SummaryIsNull_HasError()
+        {
+            var teachingEvent = new TeachingEvent { Summary = null };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.Summary);
+        }
+
+        [Fact]
+        public void Validate_DescriptionIsNull_HasError()
+        {
+            var teachingEvent = new TeachingEvent { Description = null };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.Description);
+        }
+
+        [Fact]
+        public void Validate_ProviderContactEmailIsPresentAndInvalid_HasError()
+        {
+            var teachingEvent = new TeachingEvent { ProviderContactEmail = "invalid email" };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.ProviderContactEmail);
+        }
+
+        [Fact]
+        public void Validate_StartAtIsEarlierThanNow_HasError()
+        {
+            var teachingEvent = new TeachingEvent { StartAt = DateTime.UtcNow.AddDays(-1) };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.StartAt);
+        }
+
+        [Fact]
+        public void Validate_EndAtIsEarlierThanStartAt_HasError()
+        {
+            var teachingEvent = new TeachingEvent
+            {
+                StartAt = DateTime.UtcNow.AddDays(2),
+                EndAt = DateTime.UtcNow.AddDays(1)
+            };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.EndAt);
+        }
+    }
+}
+

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -21,6 +21,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var client = new TeachingEvent()
             {
+                ReadableId = "Test",
                 Name = "Test name",
                 Summary = "Test summary",
                 Description = "Test description",
@@ -32,6 +33,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.Validate(client);
 
             result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_ReadableIdIsNull_HasError()
+        {
+            var teachingEvent = new TeachingEvent { ReadableId = null };
+            var validationResult = _validator.TestValidate(teachingEvent);
+            validationResult.ShouldHaveValidationErrorFor(request => request.ReadableId);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -534,6 +534,26 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().HaveCount(5);
         }
 
+        [Fact]
+        public async Task SaveAsync_WillAddAndSaveGivenEntity()
+        {
+            await SeedMockTeachingEventBuildingsAsync();
+            int initialBuildingCount = _store.GetTeachingEventBuildings().ToList().Count;
+            var newBuilding = new TeachingEventBuilding()
+            {
+                Id = new Guid("5d836cd9-436c-4a20-baf2-62b2c1117197"),
+                AddressPostcode = "M33 3DE"
+            };
+
+            await _store.SaveAsync(newBuilding);
+
+            var buildings = _store.GetTeachingEventBuildings().ToList();
+            int expectedCount = initialBuildingCount + 1;
+
+            buildings.Should().HaveCount(expectedCount);
+            buildings.Contains(newBuilding).Should().Be(true);
+        }
+
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -535,23 +535,23 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async Task SaveAsync_WillAddAndSaveGivenEntity()
+        public async Task SaveAsync_WithModelAndRelatedModel_PersistsBoth()
         {
-            await SeedMockTeachingEventBuildingsAsync();
-            int initialBuildingCount = _store.GetTeachingEventBuildings().ToList().Count;
-            var newBuilding = new TeachingEventBuilding()
+            var building = new TeachingEventBuilding()
             {
-                Id = new Guid("5d836cd9-436c-4a20-baf2-62b2c1117197"),
-                AddressPostcode = "M33 3DE"
+                Id = new Guid("5d836cd9-436c-4a20-baf2-62b2c1117197")
             };
 
-            await _store.SaveAsync(newBuilding);
+            var teachingEvent = new TeachingEvent()
+            {
+                Id = new Guid("db06077d-0034-4c0b-8b32-a585357434d7"),
+                Building = building,
+            };
 
-            var buildings = _store.GetTeachingEventBuildings().ToList();
-            int expectedCount = initialBuildingCount + 1;
+            await _store.SaveAsync(teachingEvent);
 
-            buildings.Should().HaveCount(expectedCount);
-            buildings.Contains(newBuilding).Should().Be(true);
+            var createdEvent = DbContext.TeachingEvents.First(e => e.Id == teachingEvent.Id);
+            createdEvent.Building.Id.Should().Be(building.Id);
         }
 
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)


### PR DESCRIPTION
A new form will be added to the app to add teaching events. As part of this, teaching events should be able to be updated, so that their `status` can be changed.

This PR:
- Adds a new status to teaching event
- Updates the name and description of the teaching event add/update endpoint
- Update teaching event add/update endpoint to immediately cache building so that it can be retrieved straight away before sync
- Saves building in CRM separately so that it returns an ID.
- Caches event and building, so that they are immediately available