### PR TITLE
Handle non-unique partial URL

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -1,18 +1,32 @@
 ﻿using System;
 using FluentValidation;
 using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeachingEventValidator : AbstractValidator<TeachingEvent>
     {
-        public TeachingEventValidator()
+        private readonly ICrmService _crm;
+
+        public TeachingEventValidator(ICrmService crm)
         {
-            RuleFor(teachingEvent => teachingEvent.ReadableId).NotEmpty();
+            _crm = crm;
+
+            RuleFor(teachingEvent => teachingEvent.ReadableId)
+                .NotEmpty()
+                .Must(BeUnique)
+                .When(teachingEvent => teachingEvent.Id == null)
+                .WithMessage("Must be unique");
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(teachingEvent => teachingEvent.StartAt).GreaterThan(DateTime.UtcNow);
             RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
+        }
+
+        private bool BeUnique(string readableId)
+        {
+            return _crm.GetTeachingEvent(readableId) == null;
         }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -226,6 +226,14 @@ namespace GetIntoTeachingApi.Services
             return entities.Select((entity) => new TeachingEvent(entity, this, _validatorFactory)).ToList();
         }
 
+        public TeachingEvent GetTeachingEvent(string readableId)
+        {
+            return _service.CreateQuery("msevtmgt_event", Context())
+                .Where(entity => entity.GetAttributeValue<string>("dfe_websiteeventpartialurl") == readableId)
+                .Select(entity => new TeachingEvent(entity, this, _validatorFactory))
+                .SingleOrDefault();
+        }
+
         public IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings()
         {
             return _service.CreateQuery("msevtmgt_building", Context())

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -17,6 +17,7 @@ namespace GetIntoTeachingApi.Services
         Candidate GetCandidate(Guid id);
         IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10);
         IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
+        TeachingEvent GetTeachingEvent(string readableId);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
         bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -480,6 +480,28 @@ namespace GetIntoTeachingApiTests.Services
                 options => options.WithStrictOrdering());
         }
 
+        [Fact]
+        public void GetTeachingEvent_WhenTeachingEventExists_ReturnsTeachingEvent()
+        {
+            _mockService.Setup(mock => mock.CreateQuery("msevtmgt_event", _context))
+                .Returns(MockTeachingEvents());
+
+            var result = _crm.GetTeachingEvent("event_one");
+
+            result.ReadableId.Should().Be("event_one");
+        }
+
+        [Fact]
+        public void GetTeachingEvent_WhenTeachingEventDoesNotExist_ReturnsNull()
+        {
+            _mockService.Setup(mock => mock.CreateQuery("msevtmgt_event", _context))
+                .Returns(MockTeachingEvents());
+
+            var result = _crm.GetTeachingEvent("wrong");
+
+            result.Should().BeNull();
+        }
+
         private static IQueryable<Entity> MockTeachingEventBuildings()
         {
             var building1 = new Entity("msevtmgt_building");
@@ -495,6 +517,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var event1 = new Entity("msevtmgt_event");
             event1["dfe_externaleventtitle"] = "Event 1";
+            event1["dfe_websiteeventpartialurl"] = "event_one";
 
             var event2 = new Entity("msevtmgt_event");
             event2["dfe_externaleventtitle"] = "Event 2";


### PR DESCRIPTION
Add model error to the API response when the CRM has a validation error for non-unique partial URL