### PR TITLE
Fix test environment for integration tests

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -235,18 +235,22 @@ The GIT API aims to provide:
                 dbConfiguration.Migrate();
             }
 
-            // Configure recurring jobs.
-            const string everyFifthMinute = "*/5 * * * *";
-            const string everyMinute = "* * * * *";
-            RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
-            RecurringJob.AddOrUpdate<LocationSyncJob>(
-                JobConfiguration.LocationSyncJobId,
-                (x) => x.RunAsync(LocationSyncJob.FreeMapToolsUrl),
-                Cron.Weekly());
-            RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
-                JobConfiguration.MagicLinkTokenGenerationJobId,
-                (x) => x.Run(),
-                everyMinute);
+            // Don't run recurring jobs in test environment.
+            if (!env.IsTest)
+            {
+                // Configure recurring jobs.
+                const string everyFifthMinute = "*/5 * * * *";
+                const string everyMinute = "* * * * *";
+                RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
+                RecurringJob.AddOrUpdate<LocationSyncJob>(
+                    JobConfiguration.LocationSyncJobId,
+                    (x) => x.RunAsync(LocationSyncJob.FreeMapToolsUrl),
+                    Cron.Weekly());
+                RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
+                    JobConfiguration.MagicLinkTokenGenerationJobId,
+                    (x) => x.Run(),
+                    everyMinute);
+            }
 
             // Don't seed test environment.
             if (!env.IsTest)

--- a/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GetIntoTeachingApi.Database;
+﻿using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 
 namespace GetIntoTeachingApiTests.Helpers
@@ -14,13 +13,6 @@ namespace GetIntoTeachingApiTests.Helpers
         {
             TemplateDatabaseName = $"gis_test";
             ConnectionString = $"Host=localhost;Database={TemplateDatabaseName};Username=docker;Password=docker";
-
-            // Set environment for integration tests using the database.
-            Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", TemplateDatabaseName);
-            Environment.SetEnvironmentVariable("VCAP_SERVICES",
-                $"{{\"postgres\": [{{\"instance_name\": \"{TemplateDatabaseName}\",\"credentials\": {{\"host\": \"localhost\"," +
-                $"\"name\": \"{TemplateDatabaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}}}]," +
-                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
 
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
             DbConfiguration.ConfigPostgres(ConnectionString, builder);

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApiTests.Helpers
 
             CloneTemplateDatabase(databaseFixture, databaseName);
             SetupDbContext(databaseName);
+            SetupIntegrationEnvironment(databaseName);
         }
 
         public void Dispose()
@@ -47,6 +48,16 @@ namespace GetIntoTeachingApiTests.Helpers
 
             using var command = new NpgsqlCommand($"CREATE DATABASE {databaseName} WITH TEMPLATE {databaseFixture.TemplateDatabaseName};", templateConnection);
             command.ExecuteNonQuery();
+        }
+
+        private static void SetupIntegrationEnvironment(string databaseName)
+        {
+            // Set environment for integration tests using the database.
+            Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", databaseName);
+            Environment.SetEnvironmentVariable("VCAP_SERVICES",
+                $"{{\"postgres\": [{{\"instance_name\": \"{databaseName}\",\"credentials\": {{\"host\": \"localhost\"," +
+                $"\"name\": \"{databaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}}}]," +
+                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -11,21 +11,20 @@ using Xunit;
 namespace GetIntoTeachingApiTests.Integration
 {
     [Collection("Database")]
-    public class RateLimitTests : IClassFixture<GitWebApplicationFactory<Startup>>
+    public class RateLimitTests : DatabaseTests
     {
-        private readonly GitWebApplicationFactory<Startup> _factory;
         private readonly HttpClient _httpClient;
         private readonly StringContent _emptyBody;
 
-        public RateLimitTests(GitWebApplicationFactory<Startup> factory)
+        public RateLimitTests(DatabaseFixture databaseFixture)
+            : base(databaseFixture)
         {
             Environment.SetEnvironmentVariable($"GIT_API_KEY", "git-secret");
             Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
             Environment.SetEnvironmentVariable($"TTA_API_KEY", "tta-secret");
 
-            _factory = factory;
-
-            _httpClient = _factory.CreateClient();
+            var factory = new GitWebApplicationFactory<Startup>();
+            _httpClient = factory.CreateClient();
             _emptyBody = new StringContent("{}", Encoding.UTF8, "application/json");
         }
 


### PR DESCRIPTION
[Trello-1458](https://trello.com/c/CgUPWYjx/1458-contract-testing-spike)

To set up contract testing in the API we need to fix a couple of issues with the test environment when running integration tests:

- Don't run recurring jobs in test environment

We will be manually seeding the data in the test environment and not talking to the CRM, so halting the jobs makes sense.

- Point integration tests at per-test database

Previously the integration tests were pointing to `gis_test`, which is the template database we clone per-test.

Instead, we want the integration tests to point at the cloned database that is cleaned up once the test has finished.

- Fix flakey rate limit specs

Now the integration tests point at a per-test database it highlights a flakey spec. The rate limit tests were re-using the `WebApplicationFactory` across all tests by way of the `ClassFixture`. As our database is now setup/torn down per-test we need to recreate the factory as well, otherwise the factory is pointing to a destroyed database and we get an error (depending on if the tests run faster than the database is cleaned up or not, sometimes it would work other times it would fail).
