### PR TITLE
Make DateTime.UtcNow mockable

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -20,15 +20,18 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         private readonly ICandidateAccessTokenService _tokenService;
         private readonly ICrmService _crm;
         private readonly IBackgroundJobClient _jobClient;
+        private readonly IDateTimeProvider _dateTime;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
-            IBackgroundJobClient jobClient)
+            IBackgroundJobClient jobClient,
+            IDateTimeProvider dateTime)
         {
             _crm = crm;
             _tokenService = tokenService;
             _jobClient = jobClient;
+            _dateTime = dateTime;
         }
 
         [HttpPost]
@@ -52,6 +55,9 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
                 return BadRequest(this.ModelState);
             }
 
+            // This is the only way we can mock/freeze the current date/time
+            // in contract tests (there's no other way to inject it into this class).
+            request.DateTimeProvider = _dateTime;
             string json = request.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -291,11 +291,6 @@ namespace GetIntoTeachingApi.Models
         {
             IsNewRegistrant = Id == null;
 
-            if (AssignmentStatusId == (int)AssignmentStatus.WaitingToBeAssigned)
-            {
-                StatusIsWaitingToBeAssignedAt = DateTime.UtcNow;
-            }
-
             var changingEventSubscriptionType = !IsNewRegistrant && EventsSubscriptionTypeId != null;
 
             if (changingEventSubscriptionType && crm.CandidateAlreadyHasLocalEventSubscriptionType((Guid)Id))

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_name")]
         public string Description { get; set; } = "Online consent as part of web registration";
         [EntityField("dfe_timeofconsent")]
-        public DateTime AcceptedAt { get; set; } = DateTime.UtcNow;
+        public DateTime AcceptedAt { get; set; }
 
         public CandidatePrivacyPolicy()
             : base()

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -33,6 +33,8 @@ namespace GetIntoTeachingApi.Models
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
+        [JsonIgnore]
+        public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
 
         public MailingListAddMember()
         {
@@ -110,11 +112,13 @@ namespace GetIntoTeachingApi.Models
 
         private void ConfigureSubscriptions(Candidate candidate)
         {
-            SubscriptionManager.SubscribeToMailingList(candidate, ChannelId);
+            var utcNow = DateTimeProvider.UtcNow;
+
+            SubscriptionManager.SubscribeToMailingList(candidate, utcNow, ChannelId);
 
             if (!string.IsNullOrWhiteSpace(AddressPostcode))
             {
-                SubscriptionManager.SubscribeToEvents(candidate, ChannelId);
+                SubscriptionManager.SubscribeToEvents(candidate, utcNow, ChannelId);
             }
         }
 
@@ -122,7 +126,11 @@ namespace GetIntoTeachingApi.Models
         {
             if (AcceptedPolicyId != null)
             {
-                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy()
+                {
+                    AcceptedPolicyId = (Guid)AcceptedPolicyId,
+                    AcceptedAt = DateTimeProvider.UtcNow,
+                };
             }
         }
     }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -47,6 +47,8 @@ namespace GetIntoTeachingApi.Models
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
+        [JsonIgnore]
+        public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
 
         public TeacherTrainingAdviserSignUp()
         {
@@ -153,7 +155,7 @@ namespace GetIntoTeachingApi.Models
             SetAdviserEligibility(candidate);
             DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow);
 
             return candidate;
         }
@@ -211,7 +213,11 @@ namespace GetIntoTeachingApi.Models
         {
             if (AcceptedPolicyId != null)
             {
-                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy()
+                {
+                    AcceptedPolicyId = (Guid)AcceptedPolicyId,
+                    AcceptedAt = DateTimeProvider.UtcNow,
+                };
             }
         }
 
@@ -267,6 +273,7 @@ namespace GetIntoTeachingApi.Models
                 candidate.AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned;
                 candidate.AdviserEligibilityId = (int)Candidate.AdviserEligibility.Yes;
                 candidate.AdviserRequirementId = (int)Candidate.AdviserRequirement.Yes;
+                candidate.StatusIsWaitingToBeAssignedAt = DateTimeProvider.UtcNow;
             }
         }
 

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -37,6 +37,8 @@ namespace GetIntoTeachingApi.Models
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
+        [JsonIgnore]
+        public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
 
         public TeachingEventAddAttendee()
         {
@@ -119,11 +121,13 @@ namespace GetIntoTeachingApi.Models
 
         private void ConfigureSubscriptions(Candidate candidate)
         {
-            SubscriptionManager.SubscribeToEvents(candidate);
+            var utcNow = DateTimeProvider.UtcNow;
+
+            SubscriptionManager.SubscribeToEvents(candidate, utcNow);
 
             if (SubscribeToMailingList)
             {
-                SubscriptionManager.SubscribeToMailingList(candidate);
+                SubscriptionManager.SubscribeToMailingList(candidate, utcNow);
             }
         }
 
@@ -145,7 +149,11 @@ namespace GetIntoTeachingApi.Models
         {
             if (AcceptedPolicyId != null)
             {
-                candidate.PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)AcceptedPolicyId };
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy()
+                {
+                    AcceptedPolicyId = (Guid)AcceptedPolicyId,
+                    AcceptedAt = DateTimeProvider.UtcNow,
+                };
             }
         }
     }

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Validators;
@@ -12,12 +11,12 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
-        public CandidateValidator(IStore store)
+        public CandidateValidator(IStore store, IDateTimeProvider dateTime)
         {
             RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => DateTime.UtcNow);
+            RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
             RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);

--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -1,18 +1,18 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using FluentValidation;
 using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class ExistingCandidateRequestValidator : AbstractValidator<ExistingCandidateRequest>
     {
-        public ExistingCandidateRequestValidator()
+        public ExistingCandidateRequestValidator(IDateTimeProvider dateTime)
         {
             RuleFor(request => request.FirstName).MaximumLength(256);
             RuleFor(request => request.LastName).MaximumLength(256);
             RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(request => request.DateOfBirth).LessThan(request => DateTime.UtcNow);
+            RuleFor(request => request.DateOfBirth).LessThan(request => dateTime.UtcNow);
             RuleFor(request => request)
                 .Must(SpecifyTwoAdditionalRequiredAttributes)
                 .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -5,7 +5,7 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class MailingListAddMemberValidator : AbstractValidator<MailingListAddMember>
     {
-        public MailingListAddMemberValidator(IStore store)
+        public MailingListAddMemberValidator(IStore store, IDateTimeProvider dateTime)
         {
             RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.LastName).NotEmpty();
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.DegreeStatusId).NotNull();
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
 
-            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -8,7 +8,7 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeacherTrainingAdviserSignUpValidator : AbstractValidator<TeacherTrainingAdviserSignUp>
     {
-        public TeacherTrainingAdviserSignUpValidator(IStore store)
+        public TeacherTrainingAdviserSignUpValidator(IStore store, IDateTimeProvider dateTime)
         {
             RuleFor(request => request.FirstName).NotNull();
             RuleFor(request => request.LastName).NotNull();
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.Telephone).NotNull()
                 .When(request => request.PhoneCallScheduledAt != null)
                 .WithMessage("Must be set to schedule a callback.");
-            RuleFor(request => request.PhoneCallScheduledAt).GreaterThan(candidate => DateTime.UtcNow)
+            RuleFor(request => request.PhoneCallScheduledAt).GreaterThan(candidate => dateTime.UtcNow)
                 .When(request => request.PhoneCallScheduledAt != null)
                 .WithMessage("Can only be scheduled for future dates.");
 
@@ -108,7 +108,7 @@ namespace GetIntoTeachingApi.Models.Validators
                 });
             });
 
-            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }
 
         private static List<int?> StudyingForADegreeStatus()

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
@@ -5,7 +5,7 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeachingEventAddAttendeeValidator : AbstractValidator<TeachingEventAddAttendee>
     {
-        public TeachingEventAddAttendeeValidator(IStore store)
+        public TeachingEventAddAttendeeValidator(IStore store, IDateTimeProvider dateTime)
         {
             RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.LastName).NotEmpty();
@@ -16,7 +16,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.DegreeStatusId).NotNull().When(request => request.SubscribeToMailingList);
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull().When(request => request.SubscribeToMailingList);
 
-            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store));
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentValidation;
+﻿using FluentValidation;
 using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
 
@@ -9,7 +8,7 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         private readonly ICrmService _crm;
 
-        public TeachingEventValidator(ICrmService crm)
+        public TeachingEventValidator(ICrmService crm, IDateTimeProvider dateTime)
         {
             _crm = crm;
 
@@ -20,7 +19,7 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be unique");
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(teachingEvent => teachingEvent.StartAt).GreaterThan(DateTime.UtcNow);
+            RuleFor(teachingEvent => teachingEvent.StartAt).GreaterThan(dateTime.UtcNow);
             RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
         }
 

--- a/GetIntoTeachingApi/Services/CallbackBookingService.cs
+++ b/GetIntoTeachingApi/Services/CallbackBookingService.cs
@@ -14,11 +14,13 @@ namespace GetIntoTeachingApi.Services
         public static readonly TimeSpan FallbackBookingQuotaLastTimeSpan = new TimeSpan(16, 30, 0);
         private readonly ICrmService _crm;
         private readonly ILogger<CallbackBookingService> _logger;
+        private readonly IDateTimeProvider _dateTime;
 
-        public CallbackBookingService(ICrmService crm, ILogger<CallbackBookingService> logger)
+        public CallbackBookingService(ICrmService crm, ILogger<CallbackBookingService> logger, IDateTimeProvider dateTime)
         {
             _crm = crm;
             _logger = logger;
+            _dateTime = dateTime;
         }
 
         public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
@@ -87,7 +89,7 @@ namespace GetIntoTeachingApi.Services
         private IEnumerable<CallbackBookingQuota> FallbackBookingQuotas()
         {
             var quotasByDay = new Dictionary<DateTime, IEnumerable<CallbackBookingQuota>>();
-            var day = DateTime.UtcNow.AddDays(1);
+            var day = _dateTime.UtcNow.AddDays(1);
 
             while (quotasByDay.Count < FallbackBookingQuotaWeekdays)
             {

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -15,11 +15,13 @@ namespace GetIntoTeachingApi.Services
         private const int Length = 6;
         private readonly IEnv _env;
         private readonly IMetricService _metrics;
+        private readonly IDateTimeProvider _dateTime;
 
-        public CandidateAccessTokenService(IEnv env, IMetricService metrics)
+        public CandidateAccessTokenService(IEnv env, IMetricService metrics, IDateTimeProvider dateTime)
         {
             _env = env;
             _metrics = metrics;
+            _dateTime = dateTime;
         }
 
         public string GenerateToken(ExistingCandidateRequest request, Guid candidateId)
@@ -33,7 +35,7 @@ namespace GetIntoTeachingApi.Services
 
         public bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId)
         {
-            return IsValid(token, request, candidateId, DateTime.UtcNow);
+            return IsValid(token, request, candidateId, _dateTime.UtcNow);
         }
 
         public bool IsValid(string token, ExistingCandidateRequest request, Guid candidateId, DateTime timestamp)

--- a/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateMagicLinkTokenService.cs
@@ -9,18 +9,20 @@ namespace GetIntoTeachingApi.Services
     {
         public static readonly TimeSpan TokenTimeSpan = new TimeSpan(48, 0, 0);
         private readonly ICrmService _crm;
+        private readonly IDateTimeProvider _dateTime;
         private readonly RNGCryptoServiceProvider _cryptoService;
 
-        public CandidateMagicLinkTokenService(ICrmService crm)
+        public CandidateMagicLinkTokenService(ICrmService crm, IDateTimeProvider dateTime)
         {
             _cryptoService = new RNGCryptoServiceProvider();
             _crm = crm;
+            _dateTime = dateTime;
         }
 
         public void GenerateToken(Candidate candidate)
         {
             candidate.MagicLinkToken = CreateToken();
-            candidate.MagicLinkTokenExpiresAt = DateTime.UtcNow.AddHours(TokenTimeSpan.TotalHours);
+            candidate.MagicLinkTokenExpiresAt = _dateTime.UtcNow.AddHours(TokenTimeSpan.TotalHours);
             candidate.MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Generated;
         }
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -17,11 +17,13 @@ namespace GetIntoTeachingApi.Services
         private const int MaximumCallbackBookingQuotaDaysInAdvance = 14;
         private readonly IOrganizationServiceAdapter _service;
         private readonly IValidatorFactory _validatorFactory;
+        private readonly IDateTimeProvider _dateTime;
 
-        public CrmService(IOrganizationServiceAdapter service, IValidatorFactory validatorFactory)
+        public CrmService(IOrganizationServiceAdapter service, IValidatorFactory validatorFactory, IDateTimeProvider dateTime)
         {
             _service = service;
             _validatorFactory = validatorFactory;
+            _dateTime = dateTime;
         }
 
         public string CheckStatus()
@@ -43,8 +45,8 @@ namespace GetIntoTeachingApi.Services
         public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
         {
             return _service.CreateQuery("dfe_callbackbookingquota", Context())
-                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") > DateTime.UtcNow &&
-                                   entity.GetAttributeValue<DateTime>("dfe_starttime") < DateTime.UtcNow.AddDays(MaximumCallbackBookingQuotaDaysInAdvance))
+                .Where((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime") > _dateTime.UtcNow &&
+                                   entity.GetAttributeValue<DateTime>("dfe_starttime") < _dateTime.UtcNow.AddDays(MaximumCallbackBookingQuotaDaysInAdvance))
                 .OrderBy((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime"))
                 .Select((entity) => new CallbackBookingQuota(entity, this, _validatorFactory))
                 .ToList()
@@ -205,7 +207,7 @@ namespace GetIntoTeachingApi.Services
         {
             if (startAfter == null)
             {
-                startAfter = DateTime.UtcNow;
+                startAfter = _dateTime.UtcNow;
             }
 
             var query = new QueryExpression("msevtmgt_event");

--- a/GetIntoTeachingApi/Services/DateTimeProvider.cs
+++ b/GetIntoTeachingApi/Services/DateTimeProvider.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class DateTimeProvider : IDateTimeProvider
+    {
+        public DateTime UtcNow
+        {
+            get
+            {
+                return DateTime.UtcNow;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/IDateTimeProvider.cs
+++ b/GetIntoTeachingApi/Services/IDateTimeProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface IDateTimeProvider
+    {
+        DateTime UtcNow { get; }
+    }
+}

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -18,12 +18,18 @@ namespace GetIntoTeachingApi.Services
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;
         private readonly ICrmService _crm;
+        private readonly IDateTimeProvider _dateTime;
 
-        public Store(GetIntoTeachingDbContext dbContext, IGeocodeClientAdapter geocodeClient, ICrmService crm)
+        public Store(
+            GetIntoTeachingDbContext dbContext,
+            IGeocodeClientAdapter geocodeClient,
+            ICrmService crm,
+            IDateTimeProvider dateTime)
         {
             _dbContext = dbContext;
             _geocodeClient = geocodeClient;
             _crm = crm;
+            _dateTime = dateTime;
         }
 
         public async Task<string> CheckStatusAsync()
@@ -168,7 +174,7 @@ namespace GetIntoTeachingApi.Services
 
         private async Task SyncTeachingEvents()
         {
-            var afterDate = DateTime.UtcNow.Subtract(TeachingEventArchiveSize);
+            var afterDate = _dateTime.UtcNow.Subtract(TeachingEventArchiveSize);
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
             var teachingEventBuildings = _dbContext.TeachingEventBuildings.ToList();
 

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -5,11 +5,11 @@ namespace GetIntoTeachingApi.Services
 {
     public static class SubscriptionManager
     {
-        public static void SubscribeToMailingList(Candidate candidate, int? channelId = null)
+        public static void SubscribeToMailingList(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasMailingListSubscription = true;
             candidate.MailingListSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.MailingList;
-            candidate.MailingListSubscriptionStartAt = DateTime.UtcNow;
+            candidate.MailingListSubscriptionStartAt = utcNow;
             candidate.MailingListSubscriptionDoNotEmail = false;
             candidate.MailingListSubscriptionDoNotBulkEmail = false;
             candidate.MailingListSubscriptionDoNotBulkPostalMail = true;
@@ -24,11 +24,11 @@ namespace GetIntoTeachingApi.Services
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, false);
         }
 
-        public static void SubscribeToEvents(Candidate candidate, int? channelId = null)
+        public static void SubscribeToEvents(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasEventsSubscription = true;
             candidate.EventsSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Events;
-            candidate.EventsSubscriptionStartAt = DateTime.UtcNow;
+            candidate.EventsSubscriptionStartAt = utcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
             candidate.EventsSubscriptionDoNotBulkEmail = false;
             candidate.EventsSubscriptionDoNotBulkPostalMail = true;
@@ -52,11 +52,11 @@ namespace GetIntoTeachingApi.Services
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, true);
         }
 
-        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate)
+        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow)
         {
             candidate.HasTeacherTrainingAdviserSubscription = true;
             candidate.TeacherTrainingAdviserSubscriptionChannelId = (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
-            candidate.TeacherTrainingAdviserSubscriptionStartAt = DateTime.UtcNow;
+            candidate.TeacherTrainingAdviserSubscriptionStartAt = utcNow;
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = true;

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -73,6 +73,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IRedisService, RedisService>();
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
+            services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
             services.AddSingleton<IEnv>(env);
 
             var connectionString = DbConfiguration.DatabaseConnectionString(env);

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApiTests.Models
             _mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _context = _mockService.Object.Context();
-            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object);
+            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models;
 using Microsoft.Xrm.Sdk;
@@ -42,12 +41,6 @@ namespace GetIntoTeachingApiTests.Models
         public void Description_DefaultValue_IsCorrect()
         {
             new CandidatePrivacyPolicy().Description.Should().Be("Online consent as part of web registration");
-        }
-
-        [Fact]
-        public void AcceptedAt_DefaultValue_IsNow()
-        {
-            new CandidatePrivacyPolicy().AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -313,37 +313,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void ToEntity_WithStatusIdOfWaitingToBeAssigned_SetsStatusIsWaitingToBeAssignedAtToNow()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned };
-            var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(candidateEntity);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            candidateEntity.GetAttributeValue<DateTime>("dfe_waitingtobeassigneddate")
-                .Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(20));
-        }
-
-        [Fact]
-        public void ToEntity_WithNullStatusId_DoesNotSetStatusIsWaitingToBeAssigned()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { AssignmentStatusId = null };
-            var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(candidateEntity);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            candidateEntity.GetAttributeValue<DateTime?>("dfe_waitingtobeassigneddate").Should().BeNull();
-        }
-
-        [Fact]
         public void FullName_ReturnsCorrectly()
         {
             var candidate = new Candidate() { FirstName = "John", LastName = "Doe" };

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -95,6 +95,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.EligibilityRulesPassed.Should().Be("false");
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
 
             candidate.HasMailingListSubscription.Should().BeTrue();
             candidate.HasEventsSubscription.Should().BeTrue();

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -180,6 +180,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotSendMm.Should().BeTrue();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
             candidate.PhoneCall.Telephone.Should().Be(request.Telephone);
@@ -408,6 +409,7 @@ namespace GetIntoTeachingApiTests.Models
             request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
             request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow);
         }
 
         [Fact]
@@ -419,6 +421,7 @@ namespace GetIntoTeachingApiTests.Models
             request.Candidate.AssignmentStatusId.Should().BeNull();
             request.Candidate.AdviserEligibilityId.Should().BeNull();
             request.Candidate.AdviserRequirementId.Should().BeNull();
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeNull();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -100,6 +100,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotSendMm.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
 
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.HasMailingListSubscription.Should().BeTrue();

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -19,7 +19,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public CandidateValidatorTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new CandidateValidator(_mockStore.Object);
+            _validator = new CandidateValidator(_mockStore.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -2,6 +2,7 @@
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
 using System;
 using Xunit;
 
@@ -13,7 +14,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
         public ExistingCandidateRequestValidatorTests()
         {
-            _validator = new ExistingCandidateRequestValidator();
+            _validator = new ExistingCandidateRequestValidator(new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/MailingListAddMemberValidatorTests.cs
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public MailingListAddMemberValidatorTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new MailingListAddMemberValidator(_mockStore.Object);
+            _validator = new MailingListAddMemberValidator(_mockStore.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public TeacherTrainingAdviserSignUpValidatorTests()
         {
             _request = new TeacherTrainingAdviserSignUp();
-            _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object);
+            _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object, new DateTimeProvider());
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             public ReturningToTeacherTraining()
             {
-                _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object);
+                _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object, new DateTimeProvider());
                 _request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
             }
 
@@ -186,7 +186,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             public InterestedInTeacherTraining()
             {
-                _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object);
+                _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object, new DateTimeProvider());
                 _request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
             }
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public TeachingEventAddAttendeeValidatorTests()
         {
             _mockStore = new Mock<IStore>();
-            _validator = new TeachingEventAddAttendeeValidator(_mockStore.Object);
+            _validator = new TeachingEventAddAttendeeValidator(_mockStore.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -1,10 +1,10 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Validators;
 using GetIntoTeachingApi.Services;
 using Moq;
-using System;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.Validators
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public TeachingEventValidatorTests()
         {
             _mockCrm = new Mock<ICrmService>();
-            _validator = new TeachingEventValidator(_mockCrm.Object);
+            _validator = new TeachingEventValidator(_mockCrm.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             _mockCrm = new Mock<ICrmService>();
             _mockLogger = new Mock<ILogger<CallbackBookingService>>();
-            _service = new CallbackBookingService(_mockCrm.Object, _mockLogger.Object);
+            _service = new CallbackBookingService(_mockCrm.Object, _mockLogger.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateAccessTokenServiceTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Services
             _metrics = new MetricService();
             var mockEnv = new Mock<IEnv>();
             mockEnv.Setup(m => m.TotpSecretKey).Returns("secret_key");
-            _service = new CandidateAccessTokenService(mockEnv.Object, _metrics);
+            _service = new CandidateAccessTokenService(mockEnv.Object, _metrics, new DateTimeProvider());
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -16,7 +16,7 @@ namespace GetIntoTeachingApiTests.Services
         public CandidateMagicLinkTokenServiceTests()
         {
             _mockCrm = new Mock<ICrmService>();
-            _service = new CandidateMagicLinkTokenService(_mockCrm.Object);
+            _service = new CandidateMagicLinkTokenService(_mockCrm.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -33,7 +33,7 @@ namespace GetIntoTeachingApiTests.Services
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _context = new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
             _mockService.Setup(mock => mock.Context()).Returns(_context);
-            _crm = new CrmService(_mockService.Object, mockValidatorFactory.Object);
+            _crm = new CrmService(_mockService.Object, mockValidatorFactory.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/DateTimeProviderTests.cs
+++ b/GetIntoTeachingApiTests/Services/DateTimeProviderTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Services;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class DateTimeProviderTests
+    {
+        [Fact]
+        public void UtcNow_ReturnsDateTimeUtcNow()
+        {
+            var provider = new DateTimeProvider();
+
+            provider.UtcNow.Should().BeCloseTo(DateTime.UtcNow);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             _mockGeocodeClient = new Mock<IGeocodeClientAdapter>();
             _mockCrm = new Mock<ICrmService>();
-            _store = new Store(DbContext, _mockGeocodeClient.Object, _mockCrm.Object);
+            _store = new Store(DbContext, _mockGeocodeClient.Object, _mockCrm.Object, new DateTimeProvider());
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToMailingList(candidate);
+            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow);
 
             candidate.HasMailingListSubscription.Should().BeTrue();
             candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToMailingList(candidate, 123);
+            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow, 123);
 
             candidate.MailingListSubscriptionChannelId.Should().Be(123);
         }
@@ -41,7 +41,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToMailingList(candidate);
+            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow);
 
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
@@ -56,7 +56,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate() { DoNotBulkPostalMail = false, DoNotPostalMail = false };
 
-            SubscriptionManager.SubscribeToMailingList(candidate);
+            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow);
 
             candidate.DoNotBulkPostalMail.Should().BeFalse();
             candidate.DoNotPostalMail.Should().BeFalse();
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate() { AddressPostcode = "TE5 7IN" };
 
-            SubscriptionManager.SubscribeToEvents(candidate);
+            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow);
 
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
@@ -85,7 +85,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToEvents(candidate, 123);
+            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow, 123);
 
             candidate.EventsSubscriptionChannelId.Should().Be(123);
             candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
@@ -96,7 +96,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToEvents(candidate);
+            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow);
 
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
@@ -111,7 +111,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate() { DoNotBulkPostalMail = false, DoNotPostalMail = false };
 
-            SubscriptionManager.SubscribeToEvents(candidate);
+            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow);
 
             candidate.DoNotBulkPostalMail.Should().BeFalse();
             candidate.DoNotPostalMail.Should().BeFalse();
@@ -125,7 +125,7 @@ namespace GetIntoTeachingApiTests.Services
                 TypeId = (int)Candidate.Type.InterestedInTeacherTraining,
             };
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
@@ -145,7 +145,7 @@ namespace GetIntoTeachingApiTests.Services
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
@@ -162,7 +162,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();
@@ -177,7 +177,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeTrue();
@@ -199,7 +199,7 @@ namespace GetIntoTeachingApiTests.Services
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
             };
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.DoNotBulkEmail.Should().BeFalse();
             candidate.DoNotBulkPostalMail.Should().BeFalse();


### PR DESCRIPTION
[Trello-1458](https://trello.com/c/CgUPWYjx/1458-contract-testing-spike)

We reference `DateTime.UtcNow` in a number of places, primarily to default an attribute to the current UTC date/time. Up until now this has been fine and we can test the logic by matching these attributes with "a value that is close to DateTime.UtcNow".

Going forward we are snapshot matching in the contract tests, which requires the `DateTime` strings to be an exact match (or otherwise we would have to write custom code to process any `DateTime` attributes, which would end up being quite messy). The only way to reliably achieve this is to wrap `DateTime.UtcNow` in our own interface that can then be mocked out for the
tests.

This commit replaces (almost) all uses of `DateTime.UtcNow` with `IDateTimeProvider` - the couple of instances that haven't been updated won't effect the contract tests and are in difficult areas to change, due to the models being instantiated by the framework and not being able to provide an injected dependency easily.