### PR TITLE
Save teaching event/building independently

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -180,15 +180,16 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest(ModelState);
             }
 
+            // Save independently so that the building gets an Id populated immediately.
+            // We also persist in the cache so it is immediately available.
             if (teachingEvent.Building != null)
             {
                 _crm.Save(teachingEvent.Building);
+                await _store.SaveAsync(new TeachingEventBuilding[] { teachingEvent.Building });
             }
 
             _crm.Save(teachingEvent);
-
-            // Make the teaching event/building immediately available in the cache
-            await _store.SaveAsync(teachingEvent);
+            await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
 
             return CreatedAtAction(
                 actionName: nameof(Get),

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApi.Services
     {
         Task<string> CheckStatusAsync();
         Task SyncAsync();
-        Task SaveAsync<T>(T model)
+        Task SaveAsync<T>(IEnumerable<T> models)
             where T : BaseModel;
         IQueryable<LookupItem> GetLookupItems(string entityName);
         IQueryable<PickListItem> GetPickListItems(string entityName, string attributeName);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -119,10 +119,13 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TeachingEventBuildings;
         }
 
-        public async Task SaveAsync<T>(T model)
+        public async Task SaveAsync<T>(IEnumerable<T> models)
             where T : BaseModel
         {
-            await _dbContext.AddAsync(model);
+            var existingIds = _dbContext.Set<T>().Select(m => m.Id);
+
+            _dbContext.UpdateRange(models.Where(m => existingIds.Contains(m.Id)));
+            await _dbContext.AddRangeAsync(models.Where(m => !existingIds.Contains(m.Id)));
             await _dbContext.SaveChangesAsync();
         }
 

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -213,7 +213,7 @@ namespace GetIntoTeachingApiTests.Controllers
             const string testName = "test";
             var newTeachingEvent = new TeachingEvent() { Name = testName };
             _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
-            _mockStore.Setup(mock => mock.SaveAsync(newTeachingEvent)).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEvent[] { newTeachingEvent })).Verifiable();
 
             var response = await _controller.Upsert(newTeachingEvent);
 
@@ -232,7 +232,8 @@ namespace GetIntoTeachingApiTests.Controllers
             var newTeachingEvent = new TeachingEvent() { Name = testName, Building = newBuilding };
             _mockCrm.Setup(mock => mock.Save(newBuilding)).Verifiable();
             _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
-            _mockStore.Setup(mock => mock.SaveAsync(newTeachingEvent)).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEventBuilding[] { newBuilding })).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEvent[] { newTeachingEvent })).Verifiable();
 
             var response = await _controller.Upsert(newTeachingEvent);
 


### PR DESCRIPTION
Update events and buildings in cache, so that they are available immediately when updated.