### PR TITLE
Set buildingId before saving in CRM

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -192,6 +192,7 @@ namespace GetIntoTeachingApi.Controllers
             {
                 _crm.Save(teachingEvent.Building);
                 await _store.SaveAsync(new TeachingEventBuilding[] { teachingEvent.Building });
+                teachingEvent.BuildingId = teachingEvent.Building.Id;
             }
 
             _crm.Save(teachingEvent);

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -70,7 +70,6 @@ namespace GetIntoTeachingApi.Models
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]
-        [EntityField("msevtmgt_building", typeof(EntityReference), "msevtmgt_buildingid")]
         public Guid? BuildingId { get; set; }
         public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -233,10 +233,11 @@ namespace GetIntoTeachingApiTests.Controllers
         public async Task AddTeachingEvent_ValidRequestWithBuilding_SavesInCrmAndCaches()
         {
             const string testName = "test";
-            var newBuilding = new TeachingEventBuilding();
+            var buildingId = Guid.NewGuid();
+            var newBuilding = new TeachingEventBuilding() { Id = buildingId };
             var newTeachingEvent = new TeachingEvent() { Name = testName, Building = newBuilding };
             _mockCrm.Setup(mock => mock.Save(newBuilding)).Verifiable();
-            _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
+            _mockCrm.Setup(mock => mock.Save(It.Is<TeachingEvent>(e => e.BuildingId == buildingId))).Verifiable();
             _mockStore.Setup(mock => mock.SaveAsync(new TeachingEventBuilding[] { newBuilding })).Verifiable();
             _mockStore.Setup(mock => mock.SaveAsync(new TeachingEvent[] { newTeachingEvent })).Verifiable();
 

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -39,8 +39,6 @@ namespace GetIntoTeachingApiTests.Models
 
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));
-            type.GetProperty("BuildingId").Should().BeDecoratedWith<EntityFieldAttribute>(
-               a => a.Name == "msevtmgt_building" && a.Type == typeof(EntityReference));
         }
 
         [Theory]


### PR DESCRIPTION
When the CRM teaching event sync runs, it checks for a `buildingId`, if one isn't present, it does not attach a building to that event. 

This explicitly sets `buildingId` for posted events before adding them to the CRM.