### PR TITLE
Establish link for existing entities

### DIFF
--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -274,10 +274,7 @@ namespace GetIntoTeachingApi.Models
                     }
 
                     var target = relatedModel.ToEntity(crm, context);
-                    if (target?.EntityState == EntityState.Created)
-                    {
-                        crm.AddLink(source, new Relationship(attribute.Name), target, context);
-                    }
+                    crm.AddLink(source, new Relationship(attribute.Name), target, context);
                 }
             }
         }

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -348,8 +348,10 @@ namespace GetIntoTeachingApiTests.Models
 
             mock.ToEntity(_crm, _context);
 
+            // Ensure a pre-existing related entity is linked (if it is already linked to the entity this
+            // will have no effect, which is desirable).
             _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mock"),
-                relatedMockEntity, _context), Times.Never);
+                relatedMockEntity, _context), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Previously we were not establishing a link between an entity and an existing entity; this was to avoid the scenario whereby, for example, a candidate is created with a qualification and later updated. I was under the impression re-linking an existing entity (in this case the existing qualification) would result in a duplicate relationship. This is not the case and it turns out its safe to re-link existing entities.

It also has the benefit of being able to link new entities to existing entities. This is required for the work to create teaching events; some will be associated with existing buildings and with the code as it was before the link was not being established.