### PR TITLE
Fix TeachingEvent not linking to Buildings

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -70,6 +70,7 @@ namespace GetIntoTeachingApi.Models
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]
+        [EntityField("msevtmgt_building", typeof(EntityReference), "msevtmgt_buildingid")]
         public Guid? BuildingId { get; set; }
         public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -36,6 +36,8 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("StartAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventstartdate");
             type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventenddate");
             type.GetProperty("ProvidersList").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerslist");
+            type.GetProperty("BuildingId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "msevtmgt_building" && a.Type == typeof(EntityReference));
 
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));


### PR DESCRIPTION
The teaching events were not being linked to the correct building as the `TeachingEvent.BuildingId` field was not being mapped from the CRM entity (this is then used to establish the relationship before persisting the event).

Update to map the `BuildingId` so it gets populated correctly and the building gets linked.