### PR TITLE
Correct TeachingEvent.BuildingId CRM reference

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -70,7 +70,7 @@ namespace GetIntoTeachingApi.Models
         [EntityRelationship("msevtmgt_event_building", typeof(TeachingEventBuilding))]
         public TeachingEventBuilding Building { get; set; }
         [JsonIgnore]
-        [EntityField("msevtmgt_building", typeof(EntityReference), "msevtmgt_buildingid")]
+        [EntityField("msevtmgt_building", typeof(EntityReference), "msevtmgt_building")]
         public Guid? BuildingId { get; set; }
         public bool IsVirtual => IsOnline && !string.IsNullOrWhiteSpace(Building?.AddressPostcode);
 

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("EndAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_eventenddate");
             type.GetProperty("ProvidersList").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_providerslist");
             type.GetProperty("BuildingId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "msevtmgt_building" && a.Type == typeof(EntityReference));
+                a => a.Name == "msevtmgt_building" && a.Type == typeof(EntityReference) && a.Reference == "msevtmgt_building");
 
             type.GetProperty("Building").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "msevtmgt_event_building" && a.Type == typeof(TeachingEventBuilding));


### PR DESCRIPTION
The CRM reference for the `TeachingEvent.BuildingId` was incorrectly set, which was causing mapping errors when serialising to a Dynamics entity. This commit corrects the reference, fixing the error.