### PR TITLE
Reduce job lock durations

### DIFF
--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApi.Jobs
             _appSettings = appSettings;
         }
 
-        [DisableConcurrentExecution(timeoutInSeconds: 10 * 60)]
+        [DisableConcurrentExecution(timeoutInSeconds: 60)]
         public async Task RunAsync()
         {
             if (_appSettings.IsCrmIntegrationPaused)

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -36,7 +36,7 @@ namespace GetIntoTeachingApi.Jobs
             _metrics = metrics;
         }
 
-        [DisableConcurrentExecution(timeoutInSeconds: 10 * 30)]
+        [DisableConcurrentExecution(timeoutInSeconds: 60)]
         public void Run()
         {
             if (_appSettings.IsCrmIntegrationPaused)


### PR DESCRIPTION
We lock jobs that shouldn't run asynchronously; we've been using quite long lock timeouts and I believe this results in jobs (mainly the CrmSyncJob) taking forever to run locally after restarting your instance; the new job waits for the job that was killed to timeout. Reducing the timeout duration should speed things up locally and a 60s duration should be plenty for both jobs to complete (they both complete in under 10 seconds usually).