### PR TITLE
Remove event start at greater than now validation criteria

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -19,7 +19,6 @@ namespace GetIntoTeachingApi.Models.Validators
                 .WithMessage("Must be unique");
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(teachingEvent => teachingEvent.StartAt).GreaterThan(dateTime.UtcNow);
             RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
         }
 

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -92,12 +92,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_StartAtIsEarlierThanNow_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.StartAt, DateTime.UtcNow.AddDays(-1));
-        }
-
-        [Fact]
         public void Validate_EndAtIsEarlierThanStartAt_HasError()
         {
             var invalidTeachingEvent = new TeachingEvent


### PR DESCRIPTION
We want new events to be dated in the future, but existing/past events are still valid (as we show an archive of online events).

With this validation in place the event.StartAt was failing the validation criteria during mapping and being nullified, which results in the earliest `DateTime` value by default. We would be better checking that the type accepts a `null` value in the mapping operation to avoid this in the future.