### PR TITLE
Only validate readableId of existing event when it has changed

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System;
+using FluentValidation;
 using FluentValidation.Validators;
 using GetIntoTeachingApi.Services;
 
@@ -7,19 +8,38 @@ namespace GetIntoTeachingApi.Models.Validators
     public class TeachingEventValidator : AbstractValidator<TeachingEvent>
     {
         private readonly ICrmService _crm;
+        private readonly IStore _store;
 
-        public TeachingEventValidator(ICrmService crm, IDateTimeProvider dateTime)
+        public TeachingEventValidator(ICrmService crm, IStore store)
         {
             _crm = crm;
+            _store = store;
 
             RuleFor(teachingEvent => teachingEvent.ReadableId)
                 .NotEmpty()
                 .Must(BeUnique)
-                .When(teachingEvent => teachingEvent.Id == null)
+                .When(teachingEvent => teachingEvent.Id == null || ReadableIdHasChanged(teachingEvent))
                 .WithMessage("Must be unique");
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
-            RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+            RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
+        }
+
+        private bool ReadableIdHasChanged(TeachingEvent teachingEvent)
+        {
+            if (teachingEvent.Id == null)
+            {
+                return false;
+            }
+
+            // Possible to have duplicate readableIds but chances are low and checking the CRM is slow
+            var existingTeachingEvent = _store.GetTeachingEventAsync((Guid)teachingEvent.Id).GetAwaiter().GetResult();
+            if (existingTeachingEvent != null)
+            {
+                return existingTeachingEvent.ReadableId != teachingEvent.ReadableId;
+            }
+
+            return false;
         }
 
         private bool BeUnique(string readableId)

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -33,16 +33,8 @@ namespace GetIntoTeachingApi.Models.Validators
                 return true;
             }
 
-            var existingTeachingEvent = _store.GetTeachingEventAsync((Guid)teachingEvent.Id).GetAwaiter().GetResult();
-
-            // Should never happen, but can if an event is created in the CRM but not yet synced.
-            // As the readable id is unlikey to be changed we skip the unique check in this case.
-            if (existingTeachingEvent == null)
-            {
-                return false;
-            }
-
-            return existingTeachingEvent.ReadableId != teachingEvent.ReadableId;
+            // Best effort check - Checking the CRM is much slower
+            return !_store.TeachingEventExistsWithReadableId(teachingEvent.Id.Value, teachingEvent.ReadableId);
         }
 
         private bool BeUnique(string readableId)

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -21,5 +21,6 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
+        bool TeachingEventExistsWithReadableId(Guid id, string readableId);
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -141,6 +141,11 @@ namespace GetIntoTeachingApi.Services
             await _dbContext.SaveChangesAsync();
         }
 
+        public bool TeachingEventExistsWithReadableId(Guid id, string readableId)
+        {
+            return _dbContext.TeachingEvents.Any(te => te.Id == id && te.ReadableId == readableId);
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -73,20 +73,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_IdIsNotNullAndEventNotInStore_HasNoError()
-        {
-            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid(), ReadableId = "readable-id" };
-
-            _mockStore
-                .Setup(mock => mock.GetTeachingEventAsync((Guid)teachingEvent.Id))
-                .ReturnsAsync(null as TeachingEvent);
-
-            var result = _validator.TestValidate(teachingEvent);
-
-            result.ShouldNotHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId);
-        }
-
-        [Fact]
         public void Validate_IdIsNotNullAndReadableIdHasChanged_HasError()
         {
             var existingTeachingEvent1 = new TeachingEvent
@@ -101,8 +87,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
             };
 
             _mockStore
-                .Setup(mock => mock.GetTeachingEventAsync((Guid)existingTeachingEvent1.Id))
-                .ReturnsAsync(existingTeachingEvent1);
+                .Setup(mock => mock.TeachingEventExistsWithReadableId(
+                    (Guid)existingTeachingEvent1.Id, existingTeachingEvent2.ReadableId))
+                .Returns(false);
 
             _mockCrm
                 .Setup(mock => mock.GetTeachingEvent("not_unique"))

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -606,6 +606,39 @@ namespace GetIntoTeachingApiTests.Services
             teachingEventNames.ForEach(name => name.Should().Contain("Updated"));
         }
 
+        [Fact]
+        public async Task TeachingEventExistsWithReadableId_EventExistsWithReadableId_ReturnsTrue()
+        {
+            var events = await SeedMockTeachingEventsAndBuildingsAsync();
+            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
+
+            bool result = _store.TeachingEventExistsWithReadableId(existingEvent.Id.Value, existingEvent.ReadableId);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task TeachingEventExistsWithReadableId_WhenEventExistsWithDifferentId_ReturnsFalse()
+        {
+            var events = await SeedMockTeachingEventsAndBuildingsAsync();
+            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
+
+            bool result = _store.TeachingEventExistsWithReadableId(Guid.NewGuid(), existingEvent.ReadableId);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TeachingEventExistsWithReadableId_WhenEventExistsWithDifferentReadableId_ReturnsFalse()
+        {
+            var events = await SeedMockTeachingEventsAndBuildingsAsync();
+            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
+
+            bool result = _store.TeachingEventExistsWithReadableId(existingEvent.Id.Value, "Different_readable_id");
+
+            result.Should().BeFalse();
+        }
+
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);
@@ -703,7 +736,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "8",
                 Name = "Event 8",
-                StatusId = (int) TeachingEvent.Status.Pending
+                StatusId = (int)TeachingEvent.Status.Pending
             };
 
             return new List<TeachingEvent>() { event1, event2, event3, event4, event5, event6, event7, event8 };


### PR DESCRIPTION
The `ReadableId` of a teaching event is validated to ensure that it is unique.

Currently, validation for the `ReadableId` of an existing event will be skipped because of the `When` check in the validator. This means that if the event is updated to have an existing `ReadableId` (in this situation the event will have a `Id` and non-unique `ReadableId`), then the event will try to save in the CRM and throw a `Microsoft.Xrm.Sdk.SaveChangesException`

This PR updates the validator to also validate events which do exist (have an `id`), but have a new `readableId`

