### PR TITLE
Add crm name teaching event

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
 using FluentValidation;
 using GetIntoTeachingApi.Attributes;
@@ -11,6 +12,8 @@ namespace GetIntoTeachingApi.Models
     [Entity("msevtmgt_event")]
     public class TeachingEvent : BaseModel
     {
+        private string _name;
+
         public enum Status
         {
             Open = 222750000,
@@ -40,7 +43,20 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_isonlineevent")]
         public bool IsOnline { get; set; }
         [EntityField("dfe_externaleventtitle")]
-        public string Name { get; set; }
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                InternalName = value;
+            }
+        }
+
+        [NotMapped]
+        [JsonIgnore]
+        [EntityField("msevtmgt_name")]
+        public string InternalName { get; set; }
         [EntityField("dfe_eventsummary_ml")]
         public string Summary { get; set; }
         [EntityField("dfe_miscellaneousmessage_ml")]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(TeachingEvent);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_event");
-            
+
             type.GetProperty("TypeId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_event_type" && a.Type == typeof(OptionSetValue));
             type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
@@ -24,6 +24,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("WebFeedId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventwebfeedid");
             type.GetProperty("IsOnline").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_isonlineevent");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_externaleventtitle");
+            type.GetProperty("InternalName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_name");
             type.GetProperty("Description").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msevtmgt_description");
             type.GetProperty("Summary").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_eventsummary_ml");
             type.GetProperty("VideoUrl").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_videolink");
@@ -81,6 +82,13 @@ namespace GetIntoTeachingApiTests.Models
             }
 
             teachingEvent.IsInPerson.Should().Be(expected);
+        }
+
+        [Fact]
+        public void InternalName_Set_ReturnsName()
+        {
+            var teachingEvent = new TeachingEvent() { Name = "name" };
+            teachingEvent.InternalName.Should().Be(teachingEvent.Name);
         }
     }
 }


### PR DESCRIPTION
Teaching Events have an `Event name` in the CRM (See left column of image below), and an `External event title` (`TeachingEvent.Name` in the API)

When adding a Teaching Event, the `Event name` should be set to equal the `External event title`. This will allow the CRM team to work with the events more easily (e.g. searching events will be easier)

![image](https://user-images.githubusercontent.com/47089130/115265181-e3f53e80-a12e-11eb-92b8-db3e8cdffcd1.png)