### PR TITLE
Add Teaching Event Building validator

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventBuildingValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventBuildingValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Validators;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class TeachingEventBuildingValidator : AbstractValidator<TeachingEventBuilding>
+    {
+        public TeachingEventBuildingValidator()
+        {
+            RuleFor(building => building.Venue).NotEmpty();
+            RuleFor(building => building.AddressPostcode).SetValidator(new PostcodeValidator());
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventBuildingValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventBuildingValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Validators;
 
 namespace GetIntoTeachingApi.Models.Validators
@@ -8,7 +9,7 @@ namespace GetIntoTeachingApi.Models.Validators
         public TeachingEventBuildingValidator()
         {
             RuleFor(building => building.Venue).NotEmpty();
-            RuleFor(building => building.AddressPostcode).SetValidator(new PostcodeValidator());
+            RuleFor(building => building.AddressPostcode).SetValidator(new PostcodeValidator<TeachingEventBuilding>());
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventBuildingValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventBuildingValidatorTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models.Validators;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class TeachingEventBuildingValidatorTests
+    {
+        private readonly TeachingEventBuildingValidator _validator;
+
+        public TeachingEventBuildingValidatorTests()
+        {
+            _validator = new TeachingEventBuildingValidator();
+        }
+
+        [Fact]
+        public void Validate_NameIsNullOrEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(building => building.Venue, "");
+            _validator.ShouldHaveValidationErrorFor(building => building.Venue, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsNullOrEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, "");
+            _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, null as string);
+        }
+
+        [Theory]
+        [InlineData("KY119YU", false)]
+        [InlineData("KY11 9YU", false)]
+        [InlineData("CA48LE", false)]
+        [InlineData("CA4 8LE", false)]
+        [InlineData("ky119yu", false)]
+        [InlineData("KY999 9YU", true)]
+        [InlineData("AZ1VS1", true)]
+        public void Validate_AddressPostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
+        {
+            if (hasError)
+            {
+                _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, postcode);
+            }
+            else
+            {
+                _validator.ShouldNotHaveValidationErrorFor(building => building.AddressPostcode, postcode);
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventBuildingValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventBuildingValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.Validators;
 using Xunit;
 
@@ -14,18 +15,22 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_NameIsNullOrEmpty_HasError()
+        public void Validate_NameAndPostcodeIsNullOrEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(building => building.Venue, "");
-            _validator.ShouldHaveValidationErrorFor(building => building.Venue, null as string);
+            var building = new TeachingEventBuilding() { Venue = "", AddressPostcode = "" };
+            var result = _validator.TestValidate(building);
+
+            result.ShouldHaveValidationErrorFor(building => building.Venue);
+            result.ShouldHaveValidationErrorFor(building => building.AddressPostcode);
+
+            building.Venue = null;
+            building.AddressPostcode = null;
+            result = _validator.TestValidate(building);
+
+            result.ShouldHaveValidationErrorFor(building => building.Venue);
+            result.ShouldHaveValidationErrorFor(building => building.AddressPostcode);
         }
 
-        [Fact]
-        public void Validate_AddressPostcodeIsNullOrEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, "");
-            _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, null as string);
-        }
 
         [Theory]
         [InlineData("KY119YU", false)]
@@ -37,13 +42,16 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("AZ1VS1", true)]
         public void Validate_AddressPostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
         {
+            var building = new TeachingEventBuilding() { AddressPostcode = postcode };
+            var result = _validator.TestValidate(building);
+
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(building => building.AddressPostcode, postcode);
+                result.ShouldHaveValidationErrorFor(building => building.AddressPostcode);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(building => building.AddressPostcode, postcode);
+                result.ShouldNotHaveValidationErrorFor(building => building.AddressPostcode);
             }
         }
     }


### PR DESCRIPTION
Teaching Event Buildings should always have a Venue name and a Postcode.