### PR TITLE
Remove unique readable id validation

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventValidator.cs
@@ -1,45 +1,16 @@
-﻿using System;
-using FluentValidation;
+﻿using FluentValidation;
 using FluentValidation.Validators;
-using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class TeachingEventValidator : AbstractValidator<TeachingEvent>
     {
-        private readonly ICrmService _crm;
-        private readonly IStore _store;
-
-        public TeachingEventValidator(ICrmService crm, IStore store)
+        public TeachingEventValidator()
         {
-            _crm = crm;
-            _store = store;
-
-            RuleFor(teachingEvent => teachingEvent.ReadableId)
-                .NotEmpty()
-                .Must(BeUnique)
-                .When(teachingEvent => ReadableIdHasChanged(teachingEvent))
-                .WithMessage("Must be unique");
+            RuleFor(teachingEvent => teachingEvent.ReadableId).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.Name).NotEmpty();
             RuleFor(teachingEvent => teachingEvent.ProviderContactEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(teachingEvent => teachingEvent.EndAt).GreaterThanOrEqualTo(rule => rule.StartAt);
-        }
-
-        private bool ReadableIdHasChanged(TeachingEvent teachingEvent)
-        {
-            // Always changes on creation.
-            if (teachingEvent.Id == null)
-            {
-                return true;
-            }
-
-            // Best effort check - Checking the CRM is much slower
-            return !_store.TeachingEventExistsWithReadableId(teachingEvent.Id.Value, teachingEvent.ReadableId);
-        }
-
-        private bool BeUnique(string readableId)
-        {
-            return _crm.GetTeachingEvent(readableId) == null;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventValidatorTests.cs
@@ -12,14 +12,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
     public class TeachingEventValidatorTests
     {
         private readonly TeachingEventValidator _validator;
-        private readonly Mock<ICrmService> _mockCrm;
-        private readonly Mock<IStore> _mockStore;
 
         public TeachingEventValidatorTests()
         {
-            _mockCrm = new Mock<ICrmService>();
-            _mockStore = new Mock<IStore>();
-            _validator = new TeachingEventValidator(_mockCrm.Object, _mockStore.Object);
+            _validator = new TeachingEventValidator();
         }
 
         [Fact]
@@ -46,66 +42,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, "");
             _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, null as string);
-        }
-
-        [Fact]
-        public void Validate_IdIsNullAndReadableIdIsNotUnique_HasError()
-        {
-            var existingTeachingEvent = new TeachingEvent
-            {
-                ReadableId = "not_unique",
-            };
-
-            _mockCrm
-                .Setup(mock => mock.GetTeachingEvent("not_unique"))
-                .Returns(existingTeachingEvent);
-
-            var newTeachingEvent = new TeachingEvent
-            {
-                ReadableId = "not_unique",
-            };
-
-            var result = _validator.TestValidate(newTeachingEvent);
-
-            result
-                .ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId)
-                .WithErrorMessage("Must be unique");
-        }
-
-        [Fact]
-        public void Validate_IdIsNotNullAndReadableIdHasChanged_HasError()
-        {
-            var existingTeachingEvent1 = new TeachingEvent
-            {
-                Id = Guid.NewGuid(),
-                ReadableId = "unique",
-            };
-
-            var existingTeachingEvent2 = new TeachingEvent
-            {
-                ReadableId = "not_unique",
-            };
-
-            _mockStore
-                .Setup(mock => mock.TeachingEventExistsWithReadableId(
-                    (Guid)existingTeachingEvent1.Id, existingTeachingEvent2.ReadableId))
-                .Returns(false);
-
-            _mockCrm
-                .Setup(mock => mock.GetTeachingEvent("not_unique"))
-                .Returns(existingTeachingEvent2);
-
-            var teachingEvent = new TeachingEvent
-            {
-                Id = existingTeachingEvent1.Id,
-                ReadableId = "not_unique",
-            };
-
-            var result = _validator.TestValidate(teachingEvent);
-
-            result
-                .ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId)
-                .WithErrorMessage("Must be unique");
         }
 
         [Fact]


### PR DESCRIPTION
We're seeing errors in the rolling environment where we think the validator gets stuck in a loop and results in a stack overflow, causing the instance to run out of memory.

Reverting this validation check for now until we can debug it further offline.