### PR TITLE
Only validate ReadableId on upsert action

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
@@ -181,6 +183,12 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Upsert([FromBody] TeachingEvent teachingEvent)
         {
+            var operation = new TeachingEventUpsertOperation(teachingEvent);
+            var validator = new TeachingEventUpsertOperationValidator(_crm);
+            var result = validator.Validate(operation);
+
+            result.AddToModelState(ModelState, null);
+
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);

--- a/GetIntoTeachingApi/Models/TeachingEventUpsertOperation.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventUpsertOperation.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class TeachingEventUpsertOperation
+    {
+        public Guid? Id { get; set; }
+        public string ReadableId { get; set; }
+
+        public TeachingEventUpsertOperation(TeachingEvent teachingEvent)
+        {
+            Id = teachingEvent.Id;
+            ReadableId = teachingEvent.ReadableId;
+        }
+
+        public TeachingEventUpsertOperation()
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventUpsertOperationValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventUpsertOperationValidator.cs
@@ -1,0 +1,36 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class TeachingEventUpsertOperationValidator : AbstractValidator<TeachingEventUpsertOperation>
+    {
+        private readonly ICrmService _crm;
+
+        public TeachingEventUpsertOperationValidator(ICrmService crm)
+        {
+            _crm = crm;
+
+            RuleFor(operation => operation.ReadableId)
+                .Must((te, _) => BeUniqueReadableId(te))
+                .WithMessage("Must be unique");
+        }
+
+        private bool BeUniqueReadableId(TeachingEventUpsertOperation operation)
+        {
+            var existingTeachingEvent = _crm.GetTeachingEvent(operation.ReadableId);
+
+            if (existingTeachingEvent == null)
+            {
+                return true;
+            }
+
+            if (existingTeachingEvent.Id == operation.Id)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -21,6 +21,5 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
-        bool TeachingEventExistsWithReadableId(Guid id, string readableId);
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -141,11 +141,6 @@ namespace GetIntoTeachingApi.Services
             await _dbContext.SaveChangesAsync();
         }
 
-        public bool TeachingEventExistsWithReadableId(Guid id, string readableId)
-        {
-            return _dbContext.TeachingEvents.Any(te => te.Id == id && te.ReadableId == readableId);
-        }
-
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Models/TeachingEventUpsertOperationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventUpsertOperationTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class TeachingEventUpsertOperationTests
+    {
+        [Fact]
+        public void Constructor_WithTeachingEvent()
+        {
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid(), ReadableId = "test-1" };
+
+            var operation = new TeachingEventUpsertOperation(teachingEvent);
+
+            operation.Id.Should().Be(teachingEvent.Id);
+            operation.ReadableId.Should().Be(teachingEvent.ReadableId);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventUpsertOperationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventUpsertOperationValidatorTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class TeachingEventUpsertOperationValidatorTests
+    {
+        private readonly TeachingEventUpsertOperationValidator _validator;
+        private readonly Mock<ICrmService> _mockCrm;
+
+        public TeachingEventUpsertOperationValidatorTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _validator = new TeachingEventUpsertOperationValidator(_mockCrm.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenExistingEventWithReadableIdIsNotFound_HasNoErrors()
+        {
+            var operation = new TeachingEventUpsertOperation() { ReadableId = "new" };
+
+            _mockCrm.Setup(m => m.GetTeachingEvent("new")).Returns<TeachingEvent>(null);
+
+            var result = _validator.Validate(operation);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_WhenExistingEventWithReadableIdHasSameTeachingEventId_HasNoErrors()
+        {
+            var operation = new TeachingEventUpsertOperation() { Id = Guid.NewGuid(), ReadableId = "existing" };
+            var existingTeachingEvent = new TeachingEvent() { Id = operation.Id };
+
+            _mockCrm.Setup(m => m.GetTeachingEvent("existing")).Returns(existingTeachingEvent);
+
+            var result = _validator.Validate(operation);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_WhenExistingEventWithReadableIdHasDifferentTeachingEventId_HasErrors()
+        {
+            var operation = new TeachingEventUpsertOperation() { Id = Guid.NewGuid(), ReadableId = "existing" };
+            var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
+
+            _mockCrm.Setup(m => m.GetTeachingEvent("existing")).Returns(teachingEvent);
+
+            var result = _validator.Validate(operation);
+
+            result.IsValid.Should().BeFalse();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -606,39 +606,6 @@ namespace GetIntoTeachingApiTests.Services
             teachingEventNames.ForEach(name => name.Should().Contain("Updated"));
         }
 
-        [Fact]
-        public async Task TeachingEventExistsWithReadableId_EventExistsWithReadableId_ReturnsTrue()
-        {
-            var events = await SeedMockTeachingEventsAndBuildingsAsync();
-            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
-
-            bool result = _store.TeachingEventExistsWithReadableId(existingEvent.Id.Value, existingEvent.ReadableId);
-
-            result.Should().BeTrue();
-        }
-
-        [Fact]
-        public async Task TeachingEventExistsWithReadableId_WhenEventExistsWithDifferentId_ReturnsFalse()
-        {
-            var events = await SeedMockTeachingEventsAndBuildingsAsync();
-            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
-
-            bool result = _store.TeachingEventExistsWithReadableId(Guid.NewGuid(), existingEvent.ReadableId);
-
-            result.Should().BeFalse();
-        }
-
-        [Fact]
-        public async Task TeachingEventExistsWithReadableId_WhenEventExistsWithDifferentReadableId_ReturnsFalse()
-        {
-            var events = await SeedMockTeachingEventsAndBuildingsAsync();
-            var existingEvent = await _store.GetTeachingEventAsync((Guid)events.First().Id);
-
-            bool result = _store.TeachingEventExistsWithReadableId(existingEvent.Id.Value, "Different_readable_id");
-
-            result.Should().BeFalse();
-        }
-
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);


### PR DESCRIPTION
Validating the `ReadableId` during the sync is expensive (as we have to query the CRM for each event to ensure uniqueness). Instead, we can assume that the events coming back from the CRM have a unique `ReadableId` and we only need to perform the validation when we are adding or updating an event via the app/API.