### PR TITLE
Add CRM time zone property

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApi.Models
     [Entity("msevtmgt_event")]
     public class TeachingEvent : BaseModel
     {
+        private const int GmtTimeZoneCode = 85;
+
         private string _name;
 
         public enum Status
@@ -77,6 +79,10 @@ namespace GetIntoTeachingApi.Models
         public string ProviderOrganiser { get; set; }
         [EntityField("dfe_providercontactemailaddress")]
         public string ProviderContactEmail { get; set; }
+        [NotMapped]
+        [JsonIgnore]
+        [EntityField("msevtmgt_eventtimezone")]
+        public int InternalTimeZone { get; set; } = GmtTimeZoneCode;
         [EntityField("msevtmgt_eventstartdate")]
         public DateTime StartAt { get; set; }
         [EntityField("msevtmgt_eventenddate")]

--- a/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventTests.cs
@@ -90,5 +90,12 @@ namespace GetIntoTeachingApiTests.Models
             var teachingEvent = new TeachingEvent() { Name = "name" };
             teachingEvent.InternalName.Should().Be(teachingEvent.Name);
         }
+
+        [Fact]
+        public void InternalTimeZone_Default_ReturnsGmtCode()
+        {
+            var teachingEvent = new TeachingEvent();
+            teachingEvent.InternalTimeZone.Should().Be(85);
+        }
     }
 }


### PR DESCRIPTION
Feedback from the CRM team is that all created teaching events should have a time zone property with the value 85 which represents GMT.