### PR TITLE
Make error response format consistent on manual validation

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -179,7 +180,7 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> Upsert([FromBody] TeachingEvent teachingEvent)
+        public async Task<IActionResult> Upsert([FromBody] TeachingEvent teachingEvent, [FromServices] IOptions<ApiBehaviorOptions> apiBehaviorOptions)
         {
             var operation = new TeachingEventUpsertOperation(teachingEvent);
             var validator = new TeachingEventUpsertOperationValidator(_crm);
@@ -189,7 +190,7 @@ namespace GetIntoTeachingApi.Controllers
 
             if (!ModelState.IsValid)
             {
-                return BadRequest(ModelState);
+                return apiBehaviorOptions.Value.InvalidModelStateResponseFactory(ControllerContext);
             }
 
             // Save independently so that the building gets an Id populated immediately.


### PR DESCRIPTION
When we check for duplicate `ReadableId` values we end up returning a `BadRequest(ModelState)` if there is a duplicate, which results in a response in the format:

```
{
  "ReadableId": "'Readable Id' must be unique."
}
```

This is because the validation is performed manually/explicitly. Instead, we want to use the default error response format (which is used for all our other, automated validators by default) defined in an `InvalidModelStateResponseFactory` as part of the `ApiBehaviorOptions`:

```
{
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "traceId": "|b0171620-4495860d4208836f.",
  "errors": {
    "ReadableId": [
      "'Readable Id' must be unique."
    ]
  }
}
```