### PR TITLE
Support compact logging of verbose requests/responses

### DIFF
--- a/GetIntoTeachingApi/Middleware/IRequestResponseLoggingConfiguration.cs
+++ b/GetIntoTeachingApi/Middleware/IRequestResponseLoggingConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.RegularExpressions;
+
+namespace GetIntoTeachingApi.Middleware
+{
+    public interface IRequestResponseLoggingConfiguration
+    {
+        public Regex[] CompactLoggingPatterns { get; }
+    }
+}

--- a/GetIntoTeachingApi/Middleware/RequestResponseLoggingConfiguration.cs
+++ b/GetIntoTeachingApi/Middleware/RequestResponseLoggingConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace GetIntoTeachingApi.Middleware
+{
+    public class RequestResponseLoggingConfiguration : IRequestResponseLoggingConfiguration
+    {
+        public Regex[] CompactLoggingPatterns
+        {
+            get
+            {
+                var options = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+
+                return new Regex[]
+                {
+                    new Regex(@"^GET /api/callback_booking_quotas", options),
+                    new Regex(@"^GET /api/lookup_items", options),
+                    new Regex(@"^GET /api/pick_list_items", options),
+                    new Regex(@"^GET /api/privacy_policies", options),
+                    new Regex(@"^GET /api/teaching_event_buildings", options),
+                    new Regex(@"^GET /api/teaching_events", options),
+                };
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -10,6 +10,7 @@ using GetIntoTeachingApi.Auth;
 using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.JsonConverters;
+using GetIntoTeachingApi.Middleware;
 using GetIntoTeachingApi.ModelBinders;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.OperationFilters;
@@ -79,6 +80,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
             services.AddSingleton<IEnv>(env);
+            services.AddSingleton<IRequestResponseLoggingConfiguration, RequestResponseLoggingConfiguration>();
 
             var connectionString = DbConfiguration.DatabaseConnectionString(env);
             services.AddDbContext<GetIntoTeachingDbContext>(b => DbConfiguration.ConfigPostgres(connectionString, b));

--- a/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingConfigurationTests.cs
+++ b/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingConfigurationTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using FluentAssertions;
+using GetIntoTeachingApi.Middleware;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Middleware
+{
+    public class RequestResponseLoggingConfigurationTests
+    {
+        private readonly RequestResponseLoggingConfiguration _config;
+
+        public RequestResponseLoggingConfigurationTests()
+        {
+            _config = new RequestResponseLoggingConfiguration();
+        }
+
+        [Theory]
+        [InlineData("GET /api/callback_booking_quotas", true)]
+        [InlineData("GET /api/lookup_items/item", true)]
+        [InlineData("GET /api/pick_list_items/item", true)]
+        [InlineData("GET /api/privacy_policies/latest", true)]
+        [InlineData("GET /api/privacy_policies/item", true)]
+        [InlineData("GET /api/teaching_event_buildings", true)]
+        [InlineData("GET /api/teaching_events/search_indexed_by_type", true)]
+        [InlineData("POST /api/teaching_events", false)]
+        public void CompactLoggingPatterns_Match(string input, bool expectedOutcome)
+        {
+            _config.CompactLoggingPatterns.Any(regex => regex.IsMatch(input)).Should().Be(expectedOutcome);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-1530](https://trello.com/c/m8LU4RBK/1530-logitio-stack)

Currently we enable request/response logging for all API endpoints, however some of these endpoints return quite a lot of not necessarily all that useful information when it comes to debugging issues. Its mainly the POST/PUT request/response payloads that we want to log out (but not exclusively - there are some GET request payloads like the health check that are useful).

Add support for configuring the `RequestResponseLoggingMiddleware` with a set of `CompactLoggingPattern`s - any request/response that matches a compact regex pattern will not have its payload included in the log.