### PR TITLE
Log postcode when we query Google Geocoding API

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -27,7 +27,7 @@ namespace GetIntoTeachingApi.Adapters
         {
             var response = await _client.GeocodeAddress($"postcode {postcode}");
 
-            _logger.LogInformation($"Google API Status: {response.StatusText}");
+            _logger.LogInformation($"Google API Status [{postcode}]: {response.StatusText}");
 
             if (response.Status != GeocodeStatus.Ok)
             {


### PR DESCRIPTION
When we receive a metric alert for Google API error responses its difficult to find the postcode thats been used. As postcodes are not personally identifiable we can log them out to make debugging easier.