### PR TITLE
Remove entity relationships

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -21,5 +21,6 @@ namespace GetIntoTeachingApi.Adapters
         Entity NewEntity(string entityName, OrganizationServiceContext context);
         void SaveChanges(OrganizationServiceContext context);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -102,5 +102,10 @@ namespace GetIntoTeachingApi.Adapters
         {
             context.AddLink(source, relationship, target);
         }
+
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            context.DeleteLink(source, relationship, target);
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -262,28 +262,23 @@ namespace GetIntoTeachingApi.Models
 
                 if (attribute == null)
                 {
-
                     continue;
                 }
 
-                try
+                var relationship = new Relationship(attribute.Name);
+
+                if (value == null)
                 {
-                    if (value == null && source.RelatedEntities.Values.Count > 0)
+                    context.LoadProperty(source, relationship);
+
+                    if (source.RelatedEntities.ContainsKey(relationship))
                     {
-                        var relationship = new Relationship(attribute.Name);
-
                         Entity relatedEntity = source.RelatedEntities.Values.First().Entities.First();
-
                         crm.DeleteLink(source, relationship, target: relatedEntity, context);
-                        continue;
                     }
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e);
-                    throw;
-                }
 
+                    continue;
+                }
 
                 foreach (var relatedModel in EnumerableRelationshipModels(value))
                 {
@@ -294,7 +289,7 @@ namespace GetIntoTeachingApi.Models
                     }
 
                     var target = relatedModel.ToEntity(crm, context);
-                    crm.AddLink(source, new Relationship(attribute.Name), target, context);
+                    crm.AddLink(source, relationship, target, context);
                 }
             }
         }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -268,21 +268,13 @@ namespace GetIntoTeachingApi.Models
 
                 try
                 {
-                    if (value == null)
+                    if (value == null && source.RelatedEntities.Values.Count > 0)
                     {
-
                         var relationship = new Relationship(attribute.Name);
-                        context.LoadProperty(source, relationship);
 
+                        Entity relatedEntity = source.RelatedEntities.Values.First().Entities.First();
 
-                        var target = (BaseModel)Activator.CreateInstance(property.PropertyType);
-
-                        var relatedEntity = source.RelatedEntities;
-
-                        Entity entity = relatedEntity.Values.First().Entities.First();
-
-                        // crm.DeleteLink(source, relationship, target.ToEntity(crm, context), context);
-                        crm.DeleteLink(source, relationship, entity, context);
+                        crm.DeleteLink(source, relationship, target: relatedEntity, context);
                         continue;
                     }
                 }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -42,9 +42,9 @@ namespace GetIntoTeachingApi.Models
             NullifyInvalidFieldAttributes(vaidatorFactory);
         }
 
-        #pragma warning disable 67
+#pragma warning disable 67
         public event PropertyChangedEventHandler PropertyChanged;
-        #pragma warning restore 67
+#pragma warning restore 67
 
         public static string[] EntityFieldAttributeNames(Type type)
         {
@@ -260,10 +260,38 @@ namespace GetIntoTeachingApi.Models
                 var attribute = EntityRelationshipAttribute(property);
                 var value = property.GetValue(this);
 
-                if (attribute == null || value == null)
+                if (attribute == null)
                 {
+
                     continue;
                 }
+
+                try
+                {
+                    if (value == null)
+                    {
+
+                        var relationship = new Relationship(attribute.Name);
+                        context.LoadProperty(source, relationship);
+
+
+                        var target = (BaseModel)Activator.CreateInstance(property.PropertyType);
+
+                        var relatedEntity = source.RelatedEntities;
+
+                        Entity entity = relatedEntity.Values.First().Entities.First();
+
+                        // crm.DeleteLink(source, relationship, target.ToEntity(crm, context), context);
+                        crm.DeleteLink(source, relationship, entity, context);
+                        continue;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw;
+                }
+
 
                 foreach (var relatedModel in EnumerableRelationshipModels(value))
                 {

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -273,7 +273,7 @@ namespace GetIntoTeachingApi.Models
 
                     if (source.RelatedEntities.ContainsKey(relationship))
                     {
-                        Entity relatedEntity = source.RelatedEntities.Values.First().Entities.First();
+                        Entity relatedEntity = source.RelatedEntities.First(entity => entity.Key == relationship).Value.Entities.First();
                         crm.DeleteLink(source, relationship, target: relatedEntity, context);
                     }
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -170,6 +170,11 @@ namespace GetIntoTeachingApi.Services
             _service.AddLink(source, relationship, target, context);
         }
 
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            _service.DeleteLink(source, relationship, target, context);
+        }
+
         public IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName)
         {
             var relatedEntityKeys = entity.Attributes.Keys.Where(k => k.StartsWith($"{relationshipName}.")).ToList();

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApi.Services
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -430,6 +430,18 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void DeleteLink_ProxiesToService()
+        {
+            var source = new Entity("parent");
+            var target = new Entity("child");
+            var relationship = new Relationship("child");
+
+            _crm.DeleteLink(source, relationship, target, _context);
+
+            _mockService.Verify(mock => mock.DeleteLink(source, relationship, target, _context));
+        }
+
+        [Fact]
         public void RelatedEntities_ProxiesToService()
         {
             var entity = new Entity("parent");


### PR DESCRIPTION
Existing relationships do not get deleted when the related object is removed. 

Currently, related objects will be removed in the cache. However, because the relationship still exists, they will be added back when the CRM sync runs. 