### PR TITLE
Rename Telephone to AddressTelephone

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -149,7 +149,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("birthdate")]
         public DateTime? DateOfBirth { get; set; }
         [EntityField("address1_telephone1")]
-        public string Telephone { get; set; }
+        public string AddressTelephone { get; set; }
         [EntityField("address1_line1")]
         public string AddressLine1 { get; set; }
         [EntityField("address1_line2")]

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -36,6 +36,7 @@ namespace GetIntoTeachingApi.Models
         public string TeacherId { get; set; }
         public string DegreeSubject { get; set; }
         public string Telephone { get; set; }
+        public string AddressTelephone { get; set; }
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }
         public string AddressCity { get; set; }
@@ -85,7 +86,8 @@ namespace GetIntoTeachingApi.Models
             LastName = candidate.LastName;
             DateOfBirth = candidate.DateOfBirth;
             TeacherId = candidate.TeacherId;
-            Telephone = candidate.Telephone;
+            Telephone = candidate.AddressTelephone;
+            AddressTelephone = candidate.AddressTelephone;
             AddressLine1 = candidate.AddressLine1;
             AddressLine2 = candidate.AddressLine2;
             AddressCity = candidate.AddressCity;
@@ -129,7 +131,7 @@ namespace GetIntoTeachingApi.Models
                 AddressLine2 = AddressLine2,
                 AddressCity = AddressCity,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                Telephone = Telephone,
+                AddressTelephone = Telephone ?? AddressTelephone,
                 TeacherId = TeacherId,
                 TypeId = TypeId,
                 InitialTeacherTrainingYearId = InitialTeacherTrainingYearId,
@@ -228,8 +230,8 @@ namespace GetIntoTeachingApi.Models
                 candidate.EligibilityRulesPassed = "true";
                 candidate.PhoneCall = new PhoneCall()
                 {
-                    Telephone = Telephone,
-                    DestinationId = DestinationForTelephone(Telephone),
+                    Telephone = Telephone ?? AddressTelephone,
+                    DestinationId = DestinationForTelephone(Telephone ?? AddressTelephone),
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.CallbackRequest,
                     Subject = $"Scheduled phone call requested by {candidate.FullName}",

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -26,6 +26,7 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string Telephone { get; set; }
+        public string AddressTelephone { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -68,7 +69,8 @@ namespace GetIntoTeachingApi.Models
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
-            Telephone = candidate.Telephone;
+            Telephone = candidate.AddressTelephone;
+            AddressTelephone = candidate.AddressTelephone;
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
@@ -86,7 +88,7 @@ namespace GetIntoTeachingApi.Models
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                Telephone = Telephone,
+                AddressTelephone = Telephone ?? AddressTelephone,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
-            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
+            RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApi.Utils
             "firstName",
             "lastName",
             "telephone",
+            "addressTelephone",
             "dateOfBirth",
             "teacherId",
             "addressLine1",

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -68,7 +68,7 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
             type.GetProperty("LastName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "lastname");
             type.GetProperty("DateOfBirth").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "birthdate");
-            type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_telephone1");
+            type.GetProperty("AddressTelephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_telephone1");
             type.GetProperty("AddressLine1").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_line1");
             type.GetProperty("AddressLine2").Should()

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -61,7 +61,7 @@ namespace GetIntoTeachingApiTests.Models
                 FirstName = "John",
                 LastName = "Doe",
                 DateOfBirth = DateTime.UtcNow,
-                Telephone = "1234567",
+                AddressTelephone = "1234567",
                 TeacherId = "abc123",
                 AddressLine1 = "Address 1",
                 AddressLine2 = "Address 2",
@@ -88,7 +88,8 @@ namespace GetIntoTeachingApiTests.Models
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.TeacherId.Should().Be(candidate.TeacherId);
-            response.Telephone.Should().Be(candidate.Telephone);
+            response.Telephone.Should().Be(candidate.AddressTelephone);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
             response.AddressLine1.Should().Be(candidate.AddressLine1);
             response.AddressLine2.Should().Be(candidate.AddressLine2);
             response.AddressCity.Should().Be(candidate.AddressCity);
@@ -164,7 +165,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.LastName.Should().Be(request.LastName);
             candidate.DateOfBirth.Should().Be(request.DateOfBirth);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.Telephone.Should().Be(request.Telephone);
+            candidate.AddressTelephone.Should().Be(request.Telephone);
             candidate.TeacherId.Should().Be(request.TeacherId);
             candidate.AddressLine1.Should().Be(request.AddressLine1);
             candidate.AddressLine2.Should().Be(request.AddressLine2);

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -34,7 +34,7 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
+                AddressTelephone = "1234567",
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
@@ -49,7 +49,8 @@ namespace GetIntoTeachingApiTests.Models
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
-            response.Telephone.Should().Be(candidate.Telephone);
+            response.Telephone.Should().Be(candidate.AddressTelephone);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
 
             response.QualificationId.Should().Be(latestQualification.Id);
@@ -90,7 +91,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.Telephone.Should().Be(request.Telephone);
+            candidate.AddressTelephone.Should().Be(request.Telephone);
             candidate.ChannelId.Should().BeNull();
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -81,7 +81,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 LastName = "last",
                 Email = "email@candidate.com",
                 DateOfBirth = DateTime.UtcNow.AddYears(-18),
-                Telephone = "07584 734 576",
+                AddressTelephone = "07584 734 576",
                 AddressLine1 = "line1",
                 AddressLine2 = "line2",
                 AddressCity = "city",
@@ -242,21 +242,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_TelephoneIsNull_HasNoError()
+        public void Validate_AddressTelephoneIsNull_HasNoError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, null as string);
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, null as string);
         }
 
         [Fact]
-        public void Validate_TelephoneTooLong_HasError()
+        public void Validate_AddressTelephoneTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 21));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 21));
         }
 
         [Fact]
-        public void Validate_TelephoneTooShort_HasError()
+        public void Validate_AddressTelephoneTooShort_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 4));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 4));
         }
 
         [Theory]
@@ -270,15 +270,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("abc2451215", true)]
         [InlineData("42154h53151", true)]
         [InlineData("5325.56fs326.32", true)]
-        public void Validate_TelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
+        public void Validate_AddressTelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
         {
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
+                _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
+                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
             }
         }
 


### PR DESCRIPTION
We are integrating the Candidate modelling for Schools Experience into the API, which references 3 different telephone fields (address_telephone, telephone1, telephone2). To make the naming more consistent we are renaming `Candidate.Telephone` to `Candidate.AddressTelephone` and this will then allow `Candidate.Telephone` and `Candidate.SecondaryTelephone` to reference the telephone1/2 fields that are being introduced.

The request models are backwards-compatible, accepting both `Telephone` and `AddressTelephone`; once the API clients have been updated the `Telephone` attribute can be removed from the request models.