### PR TITLE
Remove the `Telephone` field from request models

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -35,7 +35,6 @@ namespace GetIntoTeachingApi.Models
         public DateTime? DateOfBirth { get; set; }
         public string TeacherId { get; set; }
         public string DegreeSubject { get; set; }
-        public string Telephone { get; set; }
         public string AddressTelephone { get; set; }
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }
@@ -86,7 +85,6 @@ namespace GetIntoTeachingApi.Models
             LastName = candidate.LastName;
             DateOfBirth = candidate.DateOfBirth;
             TeacherId = candidate.TeacherId;
-            Telephone = candidate.AddressTelephone;
             AddressTelephone = candidate.AddressTelephone;
             AddressLine1 = candidate.AddressLine1;
             AddressLine2 = candidate.AddressLine2;
@@ -131,7 +129,7 @@ namespace GetIntoTeachingApi.Models
                 AddressLine2 = AddressLine2,
                 AddressCity = AddressCity,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                AddressTelephone = Telephone ?? AddressTelephone,
+                AddressTelephone = AddressTelephone,
                 TeacherId = TeacherId,
                 TypeId = TypeId,
                 InitialTeacherTrainingYearId = InitialTeacherTrainingYearId,
@@ -230,8 +228,8 @@ namespace GetIntoTeachingApi.Models
                 candidate.EligibilityRulesPassed = "true";
                 candidate.PhoneCall = new PhoneCall()
                 {
-                    Telephone = Telephone ?? AddressTelephone,
-                    DestinationId = DestinationForTelephone(Telephone ?? AddressTelephone),
+                    Telephone = AddressTelephone,
+                    DestinationId = DestinationForTelephone(AddressTelephone),
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.CallbackRequest,
                     Subject = $"Scheduled phone call requested by {candidate.FullName}",

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -25,7 +25,6 @@ namespace GetIntoTeachingApi.Models
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
-        public string Telephone { get; set; }
         public string AddressTelephone { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
@@ -69,7 +68,6 @@ namespace GetIntoTeachingApi.Models
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
-            Telephone = candidate.AddressTelephone;
             AddressTelephone = candidate.AddressTelephone;
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
@@ -88,7 +86,7 @@ namespace GetIntoTeachingApi.Models
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                AddressTelephone = Telephone ?? AddressTelephone,
+                AddressTelephone = AddressTelephone,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -18,13 +18,8 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.CountryId).NotNull();
             RuleFor(request => request.TypeId).NotNull();
 
-            RuleFor(request => request.Telephone).NotNull()
-                .When(request => request.PhoneCallScheduledAt != null)
-                .Unless(request => request.AddressTelephone != null)
-                .WithMessage("Must be set to schedule a callback.");
             RuleFor(request => request.AddressTelephone).NotNull()
                 .When(request => request.PhoneCallScheduledAt != null)
-                .Unless(request => request.Telephone != null)
                 .WithMessage("Must be set to schedule a callback.");
             RuleFor(request => request.PhoneCallScheduledAt).GreaterThan(candidate => dateTime.UtcNow)
                 .When(request => request.PhoneCallScheduledAt != null)
@@ -104,11 +99,7 @@ namespace GetIntoTeachingApi.Models.Validators
 
                 When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent, () =>
                 {
-                    RuleFor(request => request.Telephone).NotNull()
-                        .Unless(request => request.AddressTelephone != null)
-                        .WithMessage("Must be set for candidates with an equivalent degree.");
                     RuleFor(request => request.AddressTelephone).NotNull()
-                        .Unless(request => request.Telephone != null)
                         .WithMessage("Must be set for candidates with an equivalent degree.");
                     RuleFor(request => request.PhoneCallScheduledAt).NotNull()
                         .When(request => request.CountryId == LookupItem.UnitedKingdomCountryId)

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -88,7 +88,6 @@ namespace GetIntoTeachingApiTests.Models
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.TeacherId.Should().Be(candidate.TeacherId);
-            response.Telephone.Should().Be(candidate.AddressTelephone);
             response.AddressTelephone.Should().Be(candidate.AddressTelephone);
             response.AddressLine1.Should().Be(candidate.AddressLine1);
             response.AddressLine2.Should().Be(candidate.AddressLine2);
@@ -133,7 +132,7 @@ namespace GetIntoTeachingApiTests.Models
                 FirstName = "John",
                 LastName = "Doe",
                 DateOfBirth = DateTime.UtcNow,
-                Telephone = "1234567",
+                AddressTelephone = "1234567",
                 TeacherId = "abc123",
                 DegreeSubject = "Maths",
                 AddressLine1 = "Address 1",
@@ -165,7 +164,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.LastName.Should().Be(request.LastName);
             candidate.DateOfBirth.Should().Be(request.DateOfBirth);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.AddressTelephone.Should().Be(request.Telephone);
+            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
             candidate.TeacherId.Should().Be(request.TeacherId);
             candidate.AddressLine1.Should().Be(request.AddressLine1);
             candidate.AddressLine2.Should().Be(request.AddressLine2);
@@ -184,7 +183,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
-            candidate.PhoneCall.Telephone.Should().Be(request.Telephone);
+            candidate.PhoneCall.Telephone.Should().Be(request.AddressTelephone);
             candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
             candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
             candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
@@ -342,7 +341,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData("+447564 375 482")]
         public void Candidate_UkTelephone_PhoneCallDestinationIsCorrect(string telephone)
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
+            var request = new TeacherTrainingAdviserSignUp() { AddressTelephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
         }
@@ -352,7 +351,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData("+57564 375 482")]
         public void Candidate_InternationalTelephone_PhoneCallDestinationIsCorrect(string telephone)
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
+            var request = new TeacherTrainingAdviserSignUp() { AddressTelephone = telephone, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.International);
         }
@@ -360,7 +359,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Candidate_NullTelephone_PhoneCallDestinationIsCorrect()
         {
-            var request = new TeacherTrainingAdviserSignUp() { Telephone = null, PhoneCallScheduledAt = DateTime.UtcNow };
+            var request = new TeacherTrainingAdviserSignUp() { AddressTelephone = null, PhoneCallScheduledAt = DateTime.UtcNow };
 
             request.Candidate.PhoneCall.DestinationId.Should().BeNull();
         }

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -49,7 +49,6 @@ namespace GetIntoTeachingApiTests.Models
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
-            response.Telephone.Should().Be(candidate.AddressTelephone);
             response.AddressTelephone.Should().Be(candidate.AddressTelephone);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
 
@@ -76,7 +75,7 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
+                AddressTelephone = "1234567",
                 AddressPostcode = "KY11 9YU",
                 SubscribeToMailingList = true,
             };
@@ -91,7 +90,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.AddressTelephone.Should().Be(request.Telephone);
+            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
             candidate.ChannelId.Should().BeNull();
             candidate.OptOutOfSms.Should().BeFalse();
             candidate.DoNotBulkEmail.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -36,26 +36,26 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenTelephoneIsNull_AndPhoneCallScheduledAtIsNotNull_HasError()
         {
-            _request.Telephone = null;
+            _request.AddressTelephone = null;
             _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(1);
 
             var result = _validator.TestValidate(_request);
 
-            result.ShouldHaveValidationErrorFor(request => request.Telephone)
+            result.ShouldHaveValidationErrorFor(request => request.AddressTelephone)
                 .WithErrorMessage("Must be set to schedule a callback.");
 
-            _request.Telephone = "123456789";
+            _request.AddressTelephone = "123456789";
 
             result = _validator.TestValidate(_request);
 
-            result.ShouldNotHaveValidationErrorFor(request => request.Telephone);
+            result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
 
-            _request.Telephone = null;
+            _request.AddressTelephone = null;
             _request.PhoneCallScheduledAt = null;
 
             result = _validator.TestValidate(_request);
 
-            result.ShouldNotHaveValidationErrorFor(request => request.Telephone);
+            result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
             result = _validator.TestValidate(_request);
 
-            result.ShouldNotHaveValidationErrorFor(request => request.Telephone);
+            result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 _request.Email = "email@address.com";
                 _request.DateOfBirth = DateTime.UtcNow;
                 _request.TeacherId = "abc123";
-                _request.Telephone = "1234567";
+                _request.AddressTelephone = "1234567";
                 _request.AddressLine1 = "Line 1";
                 _request.AddressLine2 = "Line 2";
                 _request.AddressCity = "City";
@@ -191,7 +191,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 _request.LastName = "Doe";
                 _request.Email = "email@address.com";
                 _request.DateOfBirth = DateTime.UtcNow;
-                _request.Telephone = "1234567";
+                _request.AddressTelephone = "1234567";
 
                 var result = _validator.TestValidate(_request);
 
@@ -414,26 +414,26 @@ namespace GetIntoTeachingApiTests.Models.Validators
             [Fact]
             public void Validate_WhenTelephoneIsNull_AndDegreeTypeIsDegreeEquivalent_HasError()
             {
-                _request.Telephone = null;
+                _request.AddressTelephone = null;
                 _request.DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent;
 
                 var result = _validator.TestValidate(_request);
 
-                result.ShouldHaveValidationErrorFor(request => request.Telephone)
+                result.ShouldHaveValidationErrorFor(request => request.AddressTelephone)
                     .WithErrorMessage("Must be set for candidates with an equivalent degree.");
 
-                _request.Telephone = "123456789";
+                _request.AddressTelephone = "123456789";
 
                 result = _validator.TestValidate(_request);
 
-                result.ShouldNotHaveValidationErrorFor(request => request.Telephone);
+                result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
 
-                _request.Telephone = null;
+                _request.AddressTelephone = null;
                 _request.DegreeTypeId = (int)CandidateQualification.DegreeType.Degree;
 
                 result = _validator.TestValidate(_request);
 
-                result.ShouldNotHaveValidationErrorFor(request => request.Telephone);
+                result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
             }
 
             [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -39,7 +39,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                Telephone = "1234567",
+                AddressTelephone = "1234567",
                 AddressPostcode = "KY11 9YU",
             };
 


### PR DESCRIPTION
We have updated the clients to reference the new `AddressTelephone` field, so the original `Telephone` field can now be removed.