### PR TITLE
Add initial support for Schools Experience service

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers.SchoolsExperience
+{
+    [Route("api/schools_experience/candidates")]
+    [ApiController]
+    [Authorize(Roles = "Admin,SchoolsExperience")]
+    public class CandidatesController : ControllerBase
+    {
+        private readonly ICandidateAccessTokenService _tokenService;
+        private readonly ICrmService _crm;
+        private readonly IBackgroundJobClient _jobClient;
+        private readonly IDateTimeProvider _dateTime;
+
+        public CandidatesController(
+            ICandidateAccessTokenService tokenService,
+            ICrmService crm,
+            IBackgroundJobClient jobClient,
+            IDateTimeProvider dateTime)
+        {
+            _crm = crm;
+            _tokenService = tokenService;
+            _jobClient = jobClient;
+            _dateTime = dateTime;
+        }
+
+        [HttpPost]
+        [SwaggerOperation(
+            Summary = "Sign up a candidate for the Schools Experience service.",
+            Description = "Validation errors may be present on the `SchoolsExperienceSignUp` object as " +
+                          "well as the hidden `Candidate` model that is mapped to; property names are " +
+                          "consistent, so you should check for inclusion of the field in the key " +
+                          "when linking an error message back to a property on the request model. For " +
+                          "example, an error on `DegreeSubject` can return under the keys " +
+                          "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
+            OperationId = "SignUpSchoolsExperienceCandidate",
+            Tags = new[] { "Schools Experience" })]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
+        public IActionResult SignUp(
+            [FromBody, SwaggerRequestBody("Candidate to sign up for the Schools Experience service.", Required = true)] SchoolsExperienceSignUp request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // This is the only way we can mock/freeze the current date/time
+            // in contract tests (there's no other way to inject it into this class).
+            request.DateTimeProvider = _dateTime;
+            string json = request.Candidate.SerializeChangeTracked();
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("exchange_access_token/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated SchoolsExperienceSignUp for the candidate.",
+            Description = @"
+                Retrieves a pre-populated SchoolsExperienceSignUp for the candidate. The `accessToken` is obtained from a 
+                `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+                exchanged for your token matches the request payload here).",
+            OperationId = "ExchangeAccessTokenForSchoolsExperienceSignUp",
+            Tags = new[] { "Schools Experience" })]
+        [ProducesResponseType(typeof(SchoolsExperienceSignUp), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult ExchangeAccessToken(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new SchoolsExperienceSignUp(candidate));
+        }
+    }
+}

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -59,6 +59,7 @@
 	  <Folder Include="JsonConverters\" />
 	  <Folder Include="Mocks\" />
 	  <Folder Include="Middleware\" />
+	  <Folder Include="Controllers\SchoolsExperience\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -135,11 +135,11 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_isadvisorrequiredos", typeof(OptionSetValue))]
         public int? AdviserRequirementId { get; set; }
         [EntityField("dfe_preferredphonenumbertype", typeof(OptionSetValue))]
-        public int? PreferredPhoneNumberTypeId { get; set; } = (int)PhoneNumberType.Home;
+        public int? PreferredPhoneNumberTypeId { get; set; }
         [EntityField("preferredcontactmethodcode", typeof(OptionSetValue))]
-        public int? PreferredContactMethodId { get; set; } = (int)ContactMethod.Any;
+        public int? PreferredContactMethodId { get; set; }
         [EntityField("msgdpr_gdprconsent", typeof(OptionSetValue))]
-        public int? GdprConsentId { get; set; } = (int)GdprConsent.Consent;
+        public int? GdprConsentId { get; set; }
         [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue))]
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
@@ -197,7 +197,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_optoutsms")]
         public bool? OptOutOfSms { get; set; }
         [EntityField("msdyn_gdproptout")]
-        public bool? OptOutOfGdpr { get; set; } = false;
+        public bool? OptOutOfGdpr { get; set; }
         [EntityField("dfe_newregistrant")]
         public bool IsNewRegistrant { get; set; }
         [EntityField("dfe_websitemltoken")]

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -80,6 +80,7 @@ namespace GetIntoTeachingApi.Models
             MailingList = 222750028,
             Event = 222750029,
             TeacherTrainingAdviser = 222750027,
+            SchoolsExperience = 222750021,
         }
 
         public enum GcseStatus

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -96,7 +97,7 @@ namespace GetIntoTeachingApi.Models
             Exchanged = 222750004,
         }
 
-        public string FullName => $"{this.FirstName} {this.LastName}";
+        public string FullName => $"{FirstName} {LastName}".NullIfEmptyOrWhitespace();
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
         [EntityField("dfe_preferredteachingsubject02", typeof(EntityReference), "dfe_teachingsubjectlist")]
@@ -178,7 +179,7 @@ namespace GetIntoTeachingApi.Models
         [EntityField("dfe_dateofissueofdbscertificate")]
         public DateTime? DbsCertificateIssuedAt { get; set; }
         [EntityField("dfe_notesforclassroomexperience")]
-        public string ClassroomExperienceNotes { get; set; }
+        public string ClassroomExperienceNotesRaw { get; set; }
         [EntityField("dfe_dfesnumber")]
         public string TeacherId { get; set; }
         [EntityField("dfe_eligibilityrulespassed")]
@@ -278,6 +279,16 @@ namespace GetIntoTeachingApi.Models
         public Candidate(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
             : base(entity, crm, validatorFactory)
         {
+        }
+
+        public void AddClassroomExperienceNote(ClassroomExperienceNote note)
+        {
+            if (string.IsNullOrWhiteSpace(ClassroomExperienceNotesRaw))
+            {
+                ClassroomExperienceNotesRaw = ClassroomExperienceNote.Header;
+            }
+
+            ClassroomExperienceNotesRaw += note.ToString();
         }
 
         public bool HasTeacherTrainingAdviser()

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -98,6 +98,8 @@ namespace GetIntoTeachingApi.Models
         public string FullName => $"{this.FirstName} {this.LastName}";
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
+        [EntityField("dfe_preferredteachingsubject02", typeof(EntityReference), "dfe_teachingsubjectlist")]
+        public Guid? SecondaryPreferredTeachingSubjectId { get; set; }
         [EntityField("dfe_country", typeof(EntityReference), "dfe_country")]
         public Guid? CountryId { get; set; }
         [EntityField("owningbusinessunit", typeof(EntityReference), "businessunit")]
@@ -142,22 +144,40 @@ namespace GetIntoTeachingApi.Models
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
+        [EntityField("emailaddress2")]
+        public string SecondaryEmail { get; set; }
         [EntityField("firstname")]
         public string FirstName { get; set; }
         [EntityField("lastname")]
         public string LastName { get; set; }
         [EntityField("birthdate")]
         public DateTime? DateOfBirth { get; set; }
+        [EntityField("mobilephone")]
+        public string MobileTelephone { get; set; }
         [EntityField("address1_telephone1")]
         public string AddressTelephone { get; set; }
         [EntityField("address1_line1")]
         public string AddressLine1 { get; set; }
         [EntityField("address1_line2")]
         public string AddressLine2 { get; set; }
+        [EntityField("address1_line3")]
+        public string AddressLine3 { get; set; }
         [EntityField("address1_city")]
         public string AddressCity { get; set; }
+        [EntityField("address1_stateorprovince")]
+        public string AddressStateOrProvince { get; set; }
         [EntityField("address1_postalcode")]
         public string AddressPostcode { get; set; }
+        [EntityField("telephone1")]
+        public string Telephone { get; set; }
+        [EntityField("telephone2")]
+        public string SecondaryTelephone { get; set; }
+        [EntityField("dfe_hasdbscertificate")]
+        public bool? HasDbsCertificate { get; set; }
+        [EntityField("dfe_dateofissueofdbscertificate")]
+        public DateTime? DbsCertificateIssuedAt { get; set; }
+        [EntityField("dfe_notesforclassroomexperience")]
+        public string ClassroomExperienceNotes { get; set; }
         [EntityField("dfe_dfesnumber")]
         public string TeacherId { get; set; }
         [EntityField("dfe_eligibilityrulespassed")]

--- a/GetIntoTeachingApi/Models/ClassroomExperienceNote.cs
+++ b/GetIntoTeachingApi/Models/ClassroomExperienceNote.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class ClassroomExperienceNote
+    {
+        public static readonly string Header = "RECORDED   ACTION                 EXP DATE   URN    NAME\r\n\r\n";
+        public static readonly string EntryFormat = "{0,10} {1,-22} {2,10} {3,-6} {4}\r\n";
+        private static readonly string DateFormat = "dd/MM/yyyy";
+
+        [SwaggerSchema(Format = "date")]
+        public DateTime? RecordedAt { get; set; }
+        public string Action { get; set; }
+        [SwaggerSchema(Format = "date")]
+        public DateTime? Date { get; set; }
+        public string SchoolUrn { get; set; }
+        public string SchoolName { get; set; }
+
+        public ClassroomExperienceNote()
+        {
+        }
+
+        public override string ToString()
+        {
+            return string.Format(
+                EntryFormat,
+                RecordedAt?.ToString(DateFormat),
+                Action,
+                Date?.ToString(DateFormat),
+                SchoolUrn,
+                SchoolName);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/MailingListAddMember.cs
@@ -82,6 +82,10 @@ namespace GetIntoTeachingApi.Models
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 EligibilityRulesPassed = "false",
+                PreferredPhoneNumberTypeId = (int)Candidate.PhoneNumberType.Home,
+                PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
+                GdprConsentId = (int)Candidate.GdprConsent.Consent,
+                OptOutOfGdpr = false,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class SchoolsExperienceSignUp
+    {
+        public Guid? CandidateId { get; set; }
+        public Guid? PreferredTeachingSubjectId { get; set; }
+        public Guid? SecondaryPreferredTeachingSubjectId { get; set; }
+        public Guid? CountryId { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
+        public Guid? AcceptedPolicyId { get; set; }
+
+        public string Email { get; set; }
+        public string SecondaryEmail { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        [SwaggerSchema(Format = "date")]
+        public DateTime? DateOfBirth { get; set; }
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string AddressCity { get; set; }
+        public string AddressStateOrProvince { get; set; }
+        public string AddressPostcode { get; set; }
+        public string AddressTelephone { get; set; }
+        public string Telephone { get; set; }
+        public string SecondaryTelephone { get; set; }
+        public string MobileTelephone { get; set; }
+        public bool? HasDbsCertificate { get; set; }
+        public DateTime? DbsCertificateIssuedAt { get; set; }
+
+        [JsonIgnore]
+        public Candidate Candidate => CreateCandidate();
+        [JsonIgnore]
+        public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
+
+        public SchoolsExperienceSignUp()
+        {
+        }
+
+        public SchoolsExperienceSignUp(Candidate candidate)
+        {
+            PopulateWithCandidate(candidate);
+        }
+
+        private void PopulateWithCandidate(Candidate candidate)
+        {
+            CandidateId = candidate.Id;
+            PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
+            SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
+            CountryId = candidate.CountryId;
+
+            Email = candidate.Email;
+            SecondaryEmail = candidate.SecondaryEmail;
+            FirstName = candidate.FirstName;
+            LastName = candidate.LastName;
+            DateOfBirth = candidate.DateOfBirth;
+            AddressLine1 = candidate.AddressLine1;
+            AddressLine2 = candidate.AddressLine2;
+            AddressLine3 = candidate.AddressLine3;
+            AddressCity = candidate.AddressCity;
+            AddressStateOrProvince = candidate.AddressStateOrProvince;
+            AddressPostcode = candidate.AddressPostcode;
+            AddressTelephone = candidate.AddressTelephone;
+            Telephone = candidate.Telephone;
+            SecondaryTelephone = candidate.SecondaryTelephone;
+            MobileTelephone = candidate.MobileTelephone;
+            HasDbsCertificate = candidate.HasDbsCertificate;
+            DbsCertificateIssuedAt = candidate.DbsCertificateIssuedAt;
+        }
+
+        private Candidate CreateCandidate()
+        {
+            var candidate = new Candidate()
+            {
+                Id = CandidateId,
+                PreferredTeachingSubjectId = PreferredTeachingSubjectId,
+                SecondaryPreferredTeachingSubjectId = SecondaryPreferredTeachingSubjectId,
+                CountryId = CountryId,
+                Email = Email,
+                SecondaryEmail = SecondaryEmail,
+                FirstName = FirstName,
+                LastName = LastName,
+                DateOfBirth = DateOfBirth,
+                AddressLine1 = AddressLine1,
+                AddressLine2 = AddressLine2,
+                AddressLine3 = AddressLine3,
+                AddressCity = AddressCity,
+                AddressStateOrProvince = AddressStateOrProvince,
+                AddressPostcode = AddressPostcode.AsFormattedPostcode(),
+                AddressTelephone = AddressTelephone,
+                Telephone = Telephone,
+                SecondaryTelephone = SecondaryTelephone,
+                MobileTelephone = MobileTelephone,
+                HasDbsCertificate = HasDbsCertificate,
+                DbsCertificateIssuedAt = DbsCertificateIssuedAt,
+            };
+
+            ConfigureChannel(candidate);
+            AcceptPrivacyPolicy(candidate);
+
+            return candidate;
+        }
+
+        private void ConfigureChannel(Candidate candidate)
+        {
+            if (CandidateId == null)
+            {
+                candidate.ChannelId = (int?)Candidate.Channel.SchoolsExperience;
+            }
+        }
+
+        private void AcceptPrivacyPolicy(Candidate candidate)
+        {
+            if (AcceptedPolicyId != null)
+            {
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy()
+                {
+                    AcceptedPolicyId = (Guid)AcceptedPolicyId,
+                    AcceptedAt = DateTimeProvider.UtcNow,
+                };
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -144,6 +144,10 @@ namespace GetIntoTeachingApi.Models
                 AdviserRequirementId = null,
                 AdviserEligibilityId = null,
                 AssignmentStatusId = null,
+                PreferredPhoneNumberTypeId = (int)Candidate.PhoneNumberType.Home,
+                PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
+                GdprConsentId = (int)Candidate.GdprConsent.Consent,
+                OptOutOfGdpr = false,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -87,6 +87,10 @@ namespace GetIntoTeachingApi.Models
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 AddressTelephone = AddressTelephone,
+                PreferredPhoneNumberTypeId = (int)Candidate.PhoneNumberType.Home,
+                PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
+                GdprConsentId = (int)Candidate.GdprConsent.Consent,
+                OptOutOfGdpr = false,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
             RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
             RuleFor(candidate => candidate.DbsCertificateIssuedAt).NotNull().When(c => c.HasDbsCertificate == true);
-            RuleFor(candidate => candidate.ClassroomExperienceNotes).MaximumLength(10000);
+            RuleFor(candidate => candidate.ClassroomExperienceNotesRaw).MaximumLength(10000);
             RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
             RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
             RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -9,6 +9,7 @@ namespace GetIntoTeachingApi.Models.Validators
 {
     public class CandidateValidator : AbstractValidator<Candidate>
     {
+        private static readonly string TelephoneRegex = @"^[^a-zA-Z]+$";
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
         public CandidateValidator(IStore store, IDateTimeProvider dateTime)
@@ -16,11 +17,19 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+            RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
             RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
+            RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
+            RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
+            RuleFor(candidate => candidate.DbsCertificateIssuedAt).NotNull().When(c => c.HasDbsCertificate == true);
+            RuleFor(candidate => candidate.ClassroomExperienceNotes).MaximumLength(10000);
+            RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
+            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
+            RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
             RuleFor(candidate => candidate.AddressPostcode)
                 .SetValidator(new PostcodeValidator())
                 .Unless(candidate => candidate.AddressPostcode == null);
@@ -38,6 +47,9 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.PreferredTeachingSubjectId)
                 .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store))
                 .Unless(candidate => candidate.PreferredTeachingSubjectId == null);
+            RuleFor(candidate => candidate.SecondaryPreferredTeachingSubjectId)
+                .SetValidator(new LookupItemIdValidator("dfe_teachingsubjectlist", store))
+                .Unless(candidate => candidate.SecondaryPreferredTeachingSubjectId == null);
             RuleFor(candidate => candidate.CountryId)
                 .SetValidator(new LookupItemIdValidator("dfe_country", store))
                 .Unless(candidate => candidate.CountryId == null);

--- a/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class ClassroomExperienceNoteValidator : AbstractValidator<ClassroomExperienceNote>
+    {
+        private static readonly string ActionRegex =
+            "\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z";
+
+        public ClassroomExperienceNoteValidator()
+        {
+            RuleFor(request => request.Action).NotEmpty().Matches(ActionRegex);
+            RuleFor(request => request.SchoolUrn).NotEmpty().MaximumLength(6);
+            RuleFor(request => request.SchoolName).NotEmpty();
+            RuleFor(request => request.RecordedAt).NotNull();
+            RuleFor(request => request.Date).NotNull();
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class SchoolsExperienceSignUpValidator : AbstractValidator<SchoolsExperienceSignUp>
+    {
+        public SchoolsExperienceSignUpValidator(IStore store, IDateTimeProvider dateTime)
+        {
+            RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
+            RuleFor(request => request.SecondaryPreferredTeachingSubjectId).NotNull();
+            RuleFor(request => request.CountryId).NotNull();
+            RuleFor(request => request.AcceptedPolicyId).NotNull();
+
+            RuleFor(request => request.Email).NotEmpty();
+            RuleFor(request => request.FirstName).NotEmpty();
+            RuleFor(request => request.LastName).NotEmpty();
+            RuleFor(request => request.DateOfBirth).NotNull();
+            RuleFor(request => request.AddressLine1).NotNull();
+            RuleFor(request => request.AddressCity).NotNull();
+            RuleFor(request => request.AddressStateOrProvince).NotNull();
+            RuleFor(request => request.AddressPostcode).NotNull();
+            RuleFor(request => request.AddressTelephone).NotNull();
+            RuleFor(request => request.HasDbsCertificate).NotNull();
+            RuleFor(request => request.Telephone).NotNull();
+            RuleFor(request => request.SecondaryTelephone).NotNull();
+
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+    }
+}

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -25,7 +25,6 @@ namespace GetIntoTeachingApi.Utils
             "addressLine1",
             "addressLine2",
             "addressLine3",
-            "classroomExperienceNotes",
         };
 
         public static string RedactJson(string json)

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -12,15 +12,20 @@ namespace GetIntoTeachingApi.Utils
         {
             "password",
             "email",
+            "secondaryEmail",
             "fullName",
             "firstName",
             "lastName",
             "telephone",
+            "secondaryTelephone",
             "addressTelephone",
+            "mobileTelephone",
             "dateOfBirth",
             "teacherId",
             "addressLine1",
             "addressLine2",
+            "addressLine3",
+            "classroomExperienceNotes",
         };
 
         public static string RedactJson(string json)

--- a/GetIntoTeachingApi/Utils/StringExtensions.cs
+++ b/GetIntoTeachingApi/Utils/StringExtensions.cs
@@ -15,5 +15,10 @@ namespace GetIntoTeachingApi.Utils
 
             return str.ToUpper().Insert(str.Length - Location.InwardPostcodeLength, " ");
         }
+
+        public static string NullIfEmptyOrWhitespace(this string str)
+        {
+            return string.IsNullOrWhiteSpace(str) ? null : str;
+        }
     }
 }

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -35,6 +35,11 @@
         "Endpoint": "POST:/api/teaching_events/attendees",
         "Period": "1m",
         "Limit": 60
+      },
+      {
+        "Endpoint": "POST:/api/schools_experience/candidates",
+        "Period": "1m",
+        "Limit": 60
       }
     ]
   },
@@ -82,6 +87,11 @@
             "Endpoint": "POST:/api/candidates/access_tokens",
             "Period": "1m",
             "Limit": 500
+          },
+          {
+            "Endpoint": "POST:/api/schools_experience/candidates",
+            "Period": "1m",
+            "Limit": 250
           }
         ]
       }

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesController.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Xunit;
+using Moq;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Controllers.SchoolsExperience;
+using FluentAssertions;
+using GetIntoTeachingApi.Jobs;
+using Microsoft.AspNetCore.Mvc;
+using GetIntoTeachingApi.Models;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Utils;
+
+namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
+{
+    public class CandidatesControllerTests
+    {
+        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        private readonly Mock<IDateTimeProvider> _mockDateTime;
+        private readonly CandidatesController _controller;
+        private readonly ExistingCandidateRequest _request;
+
+        public CandidatesControllerTests()
+        {
+            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
+            _mockDateTime = new Mock<IDateTimeProvider>();
+            _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _controller = new CandidatesController(_mockTokenService.Object, _mockCrm.Object, _mockJobClient.Object, _mockDateTime.Object);
+
+            // Freeze time.
+            _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void Authorize_IsPresent()
+        {
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,SchoolsExperience");
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_ValidToken_RespondsWithSchoolsExperienceSignUp()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as SchoolsExperienceSignUp;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_MissingCandidate_RespondsWithUnauthorized()
+        {
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void SignUp_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var request = new SchoolsExperienceSignUp { Email = "invalid-email@" };
+            _controller.ModelState.AddModelError("Email", "Email is invalid.");
+
+            var response = _controller.SignUp(request);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
+
+        [Fact]
+        public void SignUp_ValidRequest_EnqueuesJobAndRespondsWithSuccess()
+        {
+            var request = new SchoolsExperienceSignUp { FirstName = "first" };
+
+            var response = _controller.SignUp(request);
+
+            response.Should().BeOfType<NoContentResult>();
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                IsMatch(request.Candidate, (string)job.Args[0])),
+                It.IsAny<EnqueuedState>()));
+        }
+
+        private static bool IsMatch(Candidate candidateA, string candidateBJson)
+        {
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
+            candidateA.Should().BeEquivalentTo(candidateB);
+            return true;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -47,6 +47,7 @@
     <Folder Include="Validators\" />
     <Folder Include="JsonConverters\" />
     <Folder Include="Middleware\" />
+    <Folder Include="Controllers\SchoolsExperience\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -47,7 +47,6 @@
     <Folder Include="Validators\" />
     <Folder Include="JsonConverters\" />
     <Folder Include="Middleware\" />
-    <Folder Include="Controllers\SchoolsExperience\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -36,6 +36,7 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/candidates/access_tokens", "TTA", 500)]
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
         [InlineData("/api/candidates/access_tokens", "SE", 500)]
+        [InlineData("/api/schools_experience/candidates", "SE", 250)]
         public async Task Post_Endpoint_AppliesRateLimit(string path, string client, int limit)
         {
             var apiKey = $"{client.ToLower()}-secret";

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -359,30 +359,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void PreferredPhoneNumberType_DefaultValue_IsCorrect()
-        {
-            new Candidate().PreferredPhoneNumberTypeId.Should().Be((int)Candidate.PhoneNumberType.Home);
-        }
-
-        [Fact]
-        public void PreferredContactMethod_DefaultValue_IsCorrect()
-        {
-            new Candidate().PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
-        }
-
-        [Fact]
-        public void GdprConsentId_DefaultValue_IsCorrect()
-        {
-            new Candidate().GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
-        }
-
-        [Fact]
-        public void OptOutOfGdpr_DefaultValue_IsCorrect()
-        {
-            new Candidate().OptOutOfGdpr.Should().BeFalse();
-        }
-
-        [Fact]
         public void IsReturningToTeaching_WhenTypeIsReturningToTeaching_ReturnsTrue()
         {
             var candidate = new Candidate() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -23,6 +23,9 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("PreferredTeachingSubjectId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_preferredteachingsubject01" && a.Type == typeof(EntityReference) &&
                      a.Reference == "dfe_teachingsubjectlist");
+            type.GetProperty("SecondaryPreferredTeachingSubjectId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_preferredteachingsubject02" && a.Type == typeof(EntityReference) &&
+                     a.Reference == "dfe_teachingsubjectlist");
             type.GetProperty("CountryId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_country" && a.Type == typeof(EntityReference) &&
                      a.Reference == "dfe_country");
@@ -65,6 +68,7 @@ namespace GetIntoTeachingApiTests.Models
 
 
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
+            type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
             type.GetProperty("LastName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "lastname");
             type.GetProperty("DateOfBirth").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "birthdate");
@@ -73,10 +77,20 @@ namespace GetIntoTeachingApiTests.Models
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_line1");
             type.GetProperty("AddressLine2").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_line2");
+            type.GetProperty("AddressLine3").Should()
+                .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_line3");
             type.GetProperty("AddressCity").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_city");
+            type.GetProperty("AddressStateOrProvince").Should()
+                .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_stateorprovince");
             type.GetProperty("AddressPostcode").Should()
                 .BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "address1_postalcode");
+            type.GetProperty("Telephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "telephone1");
+            type.GetProperty("SecondaryTelephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "telephone2");
+            type.GetProperty("MobileTelephone").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "mobilephone");
+            type.GetProperty("HasDbsCertificate").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_hasdbscertificate");
+            type.GetProperty("DbsCertificateIssuedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_dateofissueofdbscertificate");
+            type.GetProperty("ClassroomExperienceNotes").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_notesforclassroomexperience");
             type.GetProperty("StatusIsWaitingToBeAssignedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_waitingtobeassigneddate");
             type.GetProperty("DoNotBulkEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotbulkemail");
             type.GetProperty("DoNotBulkPostalMail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "donotbulkpostalmail");

--- a/GetIntoTeachingApiTests/Models/ClassroomExperienceNoteTests.cs
+++ b/GetIntoTeachingApiTests/Models/ClassroomExperienceNoteTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class ClassroomExperienceNoteTests
+    {
+        [Fact]
+        public void ToString_FormatsWithConsistentPadding()
+        {
+            var note = new ClassroomExperienceNote()
+            {
+                Action = "RECORDED",
+                RecordedAt = new DateTime(2020, 1, 1),
+                Date = new DateTime(2020, 3, 2),
+                SchoolUrn = "123456",
+                SchoolName = "John Doe Primary",
+            };
+
+            note.ToString().Should().Be("01/01/2020 RECORDED               02/03/2020 123456 John Doe Primary\r\n");
+
+            note.Action = "CANCELLED BY SCHOOL";
+            note.SchoolUrn = "123";
+            note.SchoolName = "Test";
+
+            note.ToString().Should().Be("01/01/2020 CANCELLED BY SCHOOL    02/03/2020 123    Test\r\n");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/MailingListAddMemberTests.cs
@@ -93,6 +93,10 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
             candidate.EligibilityRulesPassed.Should().Be("false");
+            candidate.PreferredPhoneNumberTypeId.Should().Be((int)Candidate.PhoneNumberType.Home);
+            candidate.PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
+            candidate.GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
+            candidate.OptOutOfGdpr.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -1,0 +1,145 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class SchoolsExperienceSignUpTests
+    {
+        [Fact]
+        public void Constructor_WithCandidate_MapsCorrectly()
+        {
+            var candidate = new Candidate()
+            {
+                Id = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
+                CountryId = Guid.NewGuid(),
+                Email = "email@address.com",
+                SecondaryEmail = "email2@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                DateOfBirth = DateTime.UtcNow,
+                AddressLine1 = "Address 1",
+                AddressLine2 = "Address 2",
+                AddressLine3 = "Address 3",
+                AddressCity = "City",
+                AddressStateOrProvince = "County",
+                AddressPostcode = "KY11 9YU",
+                AddressTelephone = "123456789",
+                Telephone = "234567890",
+                SecondaryTelephone = "345678901",
+                MobileTelephone = "456789012",
+                HasDbsCertificate = true,
+                DbsCertificateIssuedAt = DateTime.UtcNow,
+            };
+
+            var response = new SchoolsExperienceSignUp(candidate);
+
+            response.CandidateId.Should().Be(candidate.Id);
+            response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
+            response.SecondaryPreferredTeachingSubjectId.Should().Be(candidate.SecondaryPreferredTeachingSubjectId);
+            response.CountryId.Should().Be(candidate.CountryId);
+            response.Email.Should().Be(candidate.Email);
+            response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
+            response.FirstName.Should().Be(candidate.FirstName);
+            response.LastName.Should().Be(candidate.LastName);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
+            response.AddressLine1.Should().Be(candidate.AddressLine1);
+            response.AddressLine2.Should().Be(candidate.AddressLine2);
+            response.AddressLine3.Should().Be(candidate.AddressLine3);
+            response.AddressCity.Should().Be(candidate.AddressCity);
+            response.AddressStateOrProvince.Should().Be(candidate.AddressStateOrProvince);
+            response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
+            response.Telephone.Should().Be(candidate.Telephone);
+            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
+            response.MobileTelephone.Should().Be(candidate.MobileTelephone);
+            response.HasDbsCertificate.Should().Be(candidate.HasDbsCertificate);
+            response.DbsCertificateIssuedAt.Should().Be(candidate.DbsCertificateIssuedAt);
+        }
+
+        [Fact]
+        public void Candidate_MapsCorrectly()
+        {
+            var request = new SchoolsExperienceSignUp()
+            {
+                CandidateId = Guid.NewGuid(),
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
+                CountryId = Guid.NewGuid(),
+                AcceptedPolicyId = Guid.NewGuid(),
+                Email = "email@address.com",
+                SecondaryEmail = "email2@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                DateOfBirth = DateTime.UtcNow,
+                AddressLine1 = "Address 1",
+                AddressLine2 = "Address 2",
+                AddressLine3 = "Address 3",
+                AddressCity = "City",
+                AddressStateOrProvince = "County",
+                AddressPostcode = "KY11 9YU",
+                AddressTelephone = "123456789",
+                Telephone = "234567890",
+                SecondaryTelephone = "345678901",
+                MobileTelephone = "456789012",
+                HasDbsCertificate = true,
+                DbsCertificateIssuedAt = DateTime.UtcNow,
+            };
+
+            var candidate = request.Candidate;
+
+            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
+            candidate.SecondaryPreferredTeachingSubjectId.Should().Equals(request.SecondaryPreferredTeachingSubjectId);
+            candidate.CountryId.Should().Equals(request.CountryId);
+            candidate.Email.Should().Be(request.Email);
+            candidate.SecondaryEmail.Should().Be(request.SecondaryEmail);
+            candidate.FirstName.Should().Be(request.FirstName);
+            candidate.LastName.Should().Be(request.LastName);
+            candidate.DateOfBirth.Should().Be(request.DateOfBirth);
+            candidate.AddressLine1.Should().Be(request.AddressLine1);
+            candidate.AddressLine2.Should().Be(request.AddressLine2);
+            candidate.AddressLine3.Should().Be(request.AddressLine3);
+            candidate.AddressCity.Should().Be(request.AddressCity);
+            candidate.AddressStateOrProvince.Should().Be(request.AddressStateOrProvince);
+            candidate.AddressPostcode.Should().Be(request.AddressPostcode);
+            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
+            candidate.Telephone.Should().Be(request.Telephone);
+            candidate.SecondaryTelephone.Should().Be(request.SecondaryTelephone);
+            candidate.MobileTelephone.Should().Be(request.MobileTelephone);
+            candidate.HasDbsCertificate.Should().Be(request.HasDbsCertificate);
+            candidate.DbsCertificateIssuedAt.Should().Be(request.DbsCertificateIssuedAt);
+
+            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void Candidate_ChannelIdWhenCandidateIdIsNull_IsSchoolsExperience()
+        {
+            var request = new SchoolsExperienceSignUp() { CandidateId = null };
+
+            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.SchoolsExperience);
+        }
+
+        [Fact]
+        public void Candidate_ChannelIdWhenCandidateIdIsNotNull_IsNotChanged()
+        {
+            var request = new SchoolsExperienceSignUp() { CandidateId = Guid.NewGuid() };
+
+            request.Candidate.ChannelId.Should().BeNull();
+            request.Candidate.ChangedPropertyNames.Should().NotContain("ChannelId");
+        }
+
+        [Fact]
+        public void Candidate_AddressPostcode_IsFormatted()
+        {
+            var request = new SchoolsExperienceSignUp() { AddressPostcode = "ky119yu" };
+
+            request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -178,6 +178,10 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotBulkPostalMail.Should().BeTrue();
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeTrue();
+            candidate.PreferredPhoneNumberTypeId.Should().Be((int)Candidate.PhoneNumberType.Home);
+            candidate.PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
+            candidate.GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
+            candidate.OptOutOfGdpr.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -98,6 +98,10 @@ namespace GetIntoTeachingApiTests.Models
             candidate.DoNotBulkPostalMail.Should().BeTrue();
             candidate.DoNotPostalMail.Should().BeTrue();
             candidate.DoNotSendMm.Should().BeFalse();
+            candidate.PreferredPhoneNumberTypeId.Should().Be((int)Candidate.PhoneNumberType.Home);
+            candidate.PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
+            candidate.GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
+            candidate.OptOutOfGdpr.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -84,8 +84,16 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 AddressTelephone = "07584 734 576",
                 AddressLine1 = "line1",
                 AddressLine2 = "line2",
+                AddressLine3 = "line3",
                 AddressCity = "city",
+                AddressStateOrProvince = "county",
                 AddressPostcode = "KY119YU",
+                Telephone = "07584 734 576",
+                SecondaryTelephone = "07584 734 576",
+                MobileTelephone = "07584 734 576",
+                ClassroomExperienceNotes = "notes",
+                HasDbsCertificate = true,
+                DbsCertificateIssuedAt = DateTime.UtcNow.AddYears(-1),
                 HasGcseMathsId = mockPickListItem.Id,
                 HasGcseEnglishId = mockPickListItem.Id,
                 AdviserEligibilityId = mockPickListItem.Id,
@@ -206,6 +214,36 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_SecondaryEmailAddressIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryEmail, null as string);
+        }
+
+        [Fact]
+        public void Validate_SecondaryEmailAddressIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "");
+        }
+
+        [Fact]
+        public void Validate_SecondaryEmailAddressIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "invalid-email@");
+        }
+
+        [Fact]
+        public void Validate_SecondaryEmailAddressTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, $"{new string('a', 50)}@{new string('a', 50)}.com");
+        }
+
+        [Fact]
+        public void Validate_SecondaryEmailAddressPresent_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "valid@email.com");
+        }
+
+        [Fact]
         public void Validate_DateOfBirthIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.DateOfBirth, null as DateTime?);
@@ -242,21 +280,30 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_AddressTelephoneIsNull_HasNoError()
+        public void Validate_TelephoneIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, null as string);
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.MobileTelephone, null as string);
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, null as string);
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, null as string);
         }
 
         [Fact]
-        public void Validate_AddressTelephoneTooLong_HasError()
+        public void Validate_TelephoneTooLong_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 21));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 21));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 21));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 21));
         }
 
         [Fact]
-        public void Validate_AddressTelephoneTooShort_HasError()
+        public void Validate_TelephoneTooShort_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 4));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 4));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 4));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 4));
         }
 
         [Theory]
@@ -270,15 +317,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("abc2451215", true)]
         [InlineData("42154h53151", true)]
         [InlineData("5325.56fs326.32", true)]
-        public void Validate_AddressTelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
+        public void Validate_TelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
         {
             if (hasError)
             {
                 _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
+                _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, telephone);
+                _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
+                _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, telephone);
             }
             else
             {
                 _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
+                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.MobileTelephone, telephone);
+                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
+                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, telephone);
             }
         }
 
@@ -301,6 +354,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_AddressLine3IsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressLine3, new string('a', 1025));
+        }
+
+        [Fact]
         public void Validate_AddressCityIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressCity, null as string);
@@ -310,6 +369,18 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_AddressCityIsTooLong_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressCity, new string('a', 129));
+        }
+
+        [Fact]
+        public void Validate_AddressStateOrProvinceIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressStateOrProvince, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressStateOrProvinceIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressStateOrProvince, new string('a', 101));
         }
 
         [Fact]
@@ -363,6 +434,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
+        public void Validate_SecondaryPreferredTeachingSubjectIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryPreferredTeachingSubjectId, Guid.NewGuid());
+        }
+
+        [Fact]
         public void Validate_CountryIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.CountryId, null as Guid?);
@@ -378,6 +455,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_PreferredTeachingSubjectIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PreferredTeachingSubjectId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryPreferredTeachingSubjectId, null as Guid?);
         }
 
         [Fact]
@@ -570,6 +653,21 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_ConsiderationJourneyStageIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.ConsiderationJourneyStageId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_HasDbsCertificateAndDbsCertificateIssuedAtIsNull_HasError()
+        {
+            var candidate = new Candidate() { HasDbsCertificate = true, DbsCertificateIssuedAt = null };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor("DbsCertificateIssuedAt");
+        }
+
+        [Fact]
+        public void Validate_ClassroomExperienceNotesIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ClassroomExperienceNotes, new string('a', 10001));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -91,7 +91,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 Telephone = "07584 734 576",
                 SecondaryTelephone = "07584 734 576",
                 MobileTelephone = "07584 734 576",
-                ClassroomExperienceNotes = "notes",
+                ClassroomExperienceNotesRaw = "notes",
                 HasDbsCertificate = true,
                 DbsCertificateIssuedAt = DateTime.UtcNow.AddYears(-1),
                 HasGcseMathsId = mockPickListItem.Id,
@@ -665,9 +665,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_ClassroomExperienceNotesIsTooLong_HasError()
+        public void Validate_ClassroomExperienceNotesRawIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ClassroomExperienceNotes, new string('a', 10001));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ClassroomExperienceNotesRaw, new string('a', 10001));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/ClassroomExperienceNoteValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ClassroomExperienceNoteValidatorTests.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class ClassroomExperienceNoteValidatorTests
+    {
+        private readonly ClassroomExperienceNoteValidator _validator;
+
+        public ClassroomExperienceNoteValidatorTests()
+        {
+            _validator = new ClassroomExperienceNoteValidator();
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var request = new ClassroomExperienceNote
+            {
+                Action = "REQUEST",
+                RecordedAt = DateTime.UtcNow.AddDays(-5),
+                Date = DateTime.UtcNow,
+                SchoolName = "John Reed Primary",
+                SchoolUrn = "123456",
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_ActionIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Action, "");
+        }
+
+        [Fact]
+        public void Validate_DateIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Date, null as DateTime?);
+        }
+
+        [Fact]
+        public void Validate_RecordedAtIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.RecordedAt, null as DateTime?);
+        }
+
+        [Theory]
+        [InlineData("REQUEST", false)]
+        [InlineData("ACCEPTED", false)]
+        [InlineData("ATTENDED", false)]
+        [InlineData("DID NOT ATTEND", false)]
+        [InlineData("CANCELLED BY SCHOOL", false)]
+        [InlineData("CANCELLED BY CANDIDATE", false)]
+        [InlineData("REQ", true)]
+        [InlineData("NOT ATTEND", true)]
+        [InlineData("CANCELLED BY", true)]
+        [InlineData("CANCELLED BY JOHN", true)]
+        public void Validate_ActionFormat_ValidatesCorrectly(string action, bool hasError)
+        {
+            if (hasError)
+            {
+                _validator.ShouldHaveValidationErrorFor(request => request.Action, action);
+            }
+            else
+            {
+                _validator.ShouldNotHaveValidationErrorFor(request => request.Action, action);
+            }
+        }
+
+        [Fact]
+        public void Validate_SchoolNameIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SchoolName, "");
+        }
+
+        [Fact]
+        public void Validate_SchoolUrnIsTooLong_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, "1234567");
+        }
+
+        [Fact]
+        public void Validate_SchoolUrnIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, "");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class SchoolsExperienceSignUpValidatorTests
+    {
+        private readonly SchoolsExperienceSignUpValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public SchoolsExperienceSignUpValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new SchoolsExperienceSignUpValidator(_mockStore.Object, new DateTimeProvider());
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPickListItem = new PickListItem { Id = 123 };
+            var mockLookupItem = new LookupItem { Id = Guid.NewGuid() };
+            var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+
+            var request = new SchoolsExperienceSignUp()
+            {
+                CandidateId = null,
+                PreferredTeachingSubjectId = mockLookupItem.Id,
+                SecondaryPreferredTeachingSubjectId = mockLookupItem.Id,
+                CountryId = (Guid)mockLookupItem.Id,
+                AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                DateOfBirth = new DateTime(2000, 1, 1),
+                AddressLine1 = "Address 1",
+                AddressCity = "City",
+                AddressStateOrProvince = "County",
+                AddressPostcode = "KY11 9YU",
+                AddressTelephone = "123456789",
+                Telephone = "123456789",
+                SecondaryTelephone = "123456789",
+                HasDbsCertificate = false,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            // Ensure no validation errors on root object (we expect errors on the Candidate
+            // properties as we can't mock them).
+            var propertiesWithErrors = result.Errors.Select(e => e.PropertyName);
+            propertiesWithErrors.All(p => p.StartsWith("Candidate.")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_CandidateIsInvalid_HasError()
+        {
+            var request = new SchoolsExperienceSignUp
+            {
+                HasDbsCertificate = true,
+                DbsCertificateIssuedAt = null,
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("Candidate.DbsCertificateIssuedAt");
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
+        }
+
+        [Fact]
+        public void Validate_LastNameIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
+        }
+
+        [Fact]
+        public void Validate_EmailIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
+        }
+
+        [Fact]
+        public void Validate_DateOfBirthIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, null as DateTime?);
+        }
+
+        [Fact]
+        public void Validate_AddressLine1IsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressLine1, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressCityIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressCity, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressStateOrProvinceIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressStateOrProvince, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressPostcodeIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
+        }
+
+        [Fact]
+        public void Validate_AddressTelephoneIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressTelephone, null as string);
+        }
+
+        [Fact]
+        public void Validate_TelephoneIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.Telephone, null as string);
+        }
+
+        [Fact]
+        public void Validate_SecondaryTelephoneIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SecondaryTelephone, null as string);
+        }
+
+        [Fact]
+        public void Validate_HasDbsCertificateIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.HasDbsCertificate, null as bool?);
+        }
+
+        [Fact]
+        public void Validate_AcceptedPolicyIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_PreferredTeachingSubjectIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SecondaryPreferredTeachingSubjectId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_CountryIdIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.CountryId, null as Guid?);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -19,5 +19,16 @@ namespace GetIntoTeachingApiTests.Utils
         {
             input.AsFormattedPostcode().Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("  ", null)]
+        [InlineData("test", "test")]
+        [InlineData(" test ", " test ")]
+        public void NullIfEmptyOrWhitespace_ReturnsConrrectly(string input, string expected)
+        {
+            input.NullIfEmptyOrWhitespace().Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
[Trello-66](https://trello.com/c/ETWHyQJu/66-implement-api-endpoints-for-se)

This is the first pass at adding support for the Schools Experience service to the API; it will likely change as we start to integrate the API client into the service, but it should cover the main scenarios and data set used by SE. Best reviewed by-commit.

- Add Schools Experience fields to Candidate model

For the most part the Schools Experience application uses a subset of the fields already used by the Get into Teaching apps.

There are, however, a small number of new fields that needed adding:

```
- AddressLine3
- AddressStateOrProvince
- SecondaryEmail
- Telephone
- SecondaryTelephone
- MobileTelephone
- HasDbsCertificate
- DbsCertificateIssuedAt
- SecondaryPreferredTeachingSubjectId
```

- Support matchback Schools Experience requests

Add a new `SchoolExperienceSignUp` and associated validator to model the main transaction payload for signing up to the Schools Experience service.

Update rate limiting to ensure the sign up endpoint can only receive at most 250 requests/min.

- Add modelling for classroom experience

A `Candidate` is able to have associated classroom experience notes with their `contact` record. This is stored as a single field in the CRM on the `contact` entity, however we abstract this from the clients with the `ClassroomExperienceNote` model. It accepts the required parameters and has a `ToString()` method to format it appropriately for the underlying field.

Add string extension to nullify an empty string; we make use of this in `Candidate.FullName` to avoid it being included in the change tracking when not set (previously it was an empty string which would count as a change on the computed property).

- Add endpoint to associate classroom experience notes with candidates

Add an endpoint that will allow POSTing of new candidate experience notes against a given candidate.

- Remove default values from Candidate model

These were specific to the GiT website/TTA services and may not apply to Schools Experience, so they have been deferred to the request models.

| Endpoints      | Data Structures |
| ----------- | ----------- |
| <img width="1289" alt="Screenshot 2021-05-17 at 08 09 00" src="https://user-images.githubusercontent.com/29867726/118446109-263a7d00-b6e7-11eb-9bb0-39f060c09cae.png"> | <img width="1248" alt="Screenshot 2021-05-17 at 08 09 49" src="https://user-images.githubusercontent.com/29867726/118446201-436f4b80-b6e7-11eb-8ba9-c121c0945f2e.png"> |


