### PR TITLE
Make LINQ statements more efficient

### DIFF
--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -57,14 +57,14 @@ namespace GetIntoTeachingApi.Models
 
         public static EntityFieldAttribute EntityFieldAttribute(ICustomAttributeProvider property)
         {
-            return (EntityFieldAttribute)property.GetCustomAttributes(false)
-                .FirstOrDefault(a => a.GetType() == typeof(EntityFieldAttribute) && !((EntityFieldAttribute)a).Ignored);
+            return (EntityFieldAttribute)Array.Find(property.GetCustomAttributes(false), a =>
+              a.GetType() == typeof(EntityFieldAttribute) && !((EntityFieldAttribute)a).Ignored);
         }
 
         public static EntityRelationshipAttribute EntityRelationshipAttribute(ICustomAttributeProvider property)
         {
-            return (EntityRelationshipAttribute)property.GetCustomAttributes(false)
-                .FirstOrDefault(a => a.GetType() == typeof(EntityRelationshipAttribute));
+            return (EntityRelationshipAttribute)Array.Find(property.GetCustomAttributes(false), a =>
+              a.GetType() == typeof(EntityRelationshipAttribute));
         }
 
         public static string LogicalName(MemberInfo type)

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -191,7 +191,7 @@ namespace GetIntoTeachingApi.Services
 
             foreach (var te in teachingEvents.Where(te => te.BuildingId != null))
             {
-                te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);
+                te.Building = teachingEventBuildings.Find(b => b.Id == te.BuildingId);
             }
 
             await SyncModels(teachingEvents, _dbContext.TeachingEvents);


### PR DESCRIPTION
Visual Studio is complaining that these LINQ queries could be more efficient. 

If querying the context `FirstOrDefault` will always hit the database, whereas `Find` will first check whether the required entity is already loaded.

If querying a List or Array, `FirstOrDefault` uses a `for loop` vs `Find` which uses `foreach`, which is slower