### PR TITLE
Enable SchoolsExperience to issue verification codes

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/candidates")]
     [ApiController]
-    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser")]
+    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _accessTokenService;

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -40,7 +40,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser");
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience");
         }
 
         [Fact]


### PR DESCRIPTION
I missed this in the original PR that added the SE client to the API; we need to be able to issue verification codes from the service to perform a matchback.