### PR TITLE
Minor tweaks for Schools Experience

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -11,7 +11,6 @@ namespace GetIntoTeachingApi.Models
         public Guid? CandidateId { get; set; }
         public Guid? PreferredTeachingSubjectId { get; set; }
         public Guid? SecondaryPreferredTeachingSubjectId { get; set; }
-        public Guid? CountryId { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
 
@@ -53,7 +52,6 @@ namespace GetIntoTeachingApi.Models
             CandidateId = candidate.Id;
             PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
             SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
-            CountryId = candidate.CountryId;
 
             Email = candidate.Email;
             SecondaryEmail = candidate.SecondaryEmail;
@@ -81,7 +79,7 @@ namespace GetIntoTeachingApi.Models
                 Id = CandidateId,
                 PreferredTeachingSubjectId = PreferredTeachingSubjectId,
                 SecondaryPreferredTeachingSubjectId = SecondaryPreferredTeachingSubjectId,
-                CountryId = CountryId,
+                CountryId = LookupItem.UnitedKingdomCountryId,
                 Email = Email,
                 SecondaryEmail = SecondaryEmail,
                 FirstName = FirstName,

--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -54,7 +56,7 @@ namespace GetIntoTeachingApi.Models
             SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
 
             Email = candidate.Email;
-            SecondaryEmail = candidate.SecondaryEmail;
+            SecondaryEmail = candidate.SecondaryEmail ?? candidate.Email;
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             DateOfBirth = candidate.DateOfBirth;
@@ -66,7 +68,10 @@ namespace GetIntoTeachingApi.Models
             AddressPostcode = candidate.AddressPostcode;
             AddressTelephone = candidate.AddressTelephone;
             Telephone = candidate.Telephone;
-            SecondaryTelephone = candidate.SecondaryTelephone;
+
+            var secondaryTelephoneDefaults = new List<string> { candidate.MobileTelephone, candidate.AddressTelephone, candidate.Telephone };
+            SecondaryTelephone = candidate.SecondaryTelephone ?? secondaryTelephoneDefaults.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+
             MobileTelephone = candidate.MobileTelephone;
             HasDbsCertificate = candidate.HasDbsCertificate;
             DbsCertificateIssuedAt = candidate.DbsCertificateIssuedAt;

--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -25,7 +25,6 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
             RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
-            RuleFor(candidate => candidate.DbsCertificateIssuedAt).NotNull().When(c => c.HasDbsCertificate == true);
             RuleFor(candidate => candidate.ClassroomExperienceNotesRaw).MaximumLength(10000);
             RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
             RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);

--- a/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
@@ -9,7 +9,6 @@ namespace GetIntoTeachingApi.Models.Validators
         {
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
             RuleFor(request => request.SecondaryPreferredTeachingSubjectId).NotNull();
-            RuleFor(request => request.CountryId).NotNull();
             RuleFor(request => request.AcceptedPolicyId).NotNull();
 
             RuleFor(request => request.Email).NotEmpty();

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -59,6 +59,50 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Constructor_CandidateSecondaryEmail_SetsCorrectly()
+        {
+            var candidate = new Candidate() { Email = "email@address.com" };
+
+            var response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryEmail.Should().Be(candidate.Email);
+
+            candidate.SecondaryEmail = "email2@address.com";
+
+            response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
+        }
+
+        [Fact]
+        public void Constructor_SecondaryTelephone_SetsCorrectly()
+        {
+            var candidate = new Candidate() { Telephone = "111111" };
+
+            var response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryTelephone.Should().Be(candidate.Telephone);
+
+            candidate.AddressTelephone = "222222";
+
+            response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryTelephone.Should().Be(candidate.AddressTelephone);
+
+            candidate.MobileTelephone = "333333";
+
+            response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryTelephone.Should().Be(candidate.MobileTelephone);
+
+            candidate.SecondaryTelephone = "444444";
+
+            response = new SchoolsExperienceSignUp(candidate);
+
+            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
+        }
+
+        [Fact]
         public void Candidate_MapsCorrectly()
         {
             var request = new SchoolsExperienceSignUp()

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -15,7 +15,6 @@ namespace GetIntoTeachingApiTests.Models
                 Id = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
-                CountryId = Guid.NewGuid(),
                 Email = "email@address.com",
                 SecondaryEmail = "email2@address.com",
                 FirstName = "John",
@@ -40,7 +39,6 @@ namespace GetIntoTeachingApiTests.Models
             response.CandidateId.Should().Be(candidate.Id);
             response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
             response.SecondaryPreferredTeachingSubjectId.Should().Be(candidate.SecondaryPreferredTeachingSubjectId);
-            response.CountryId.Should().Be(candidate.CountryId);
             response.Email.Should().Be(candidate.Email);
             response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
             response.FirstName.Should().Be(candidate.FirstName);
@@ -68,7 +66,6 @@ namespace GetIntoTeachingApiTests.Models
                 CandidateId = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
-                CountryId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
                 Email = "email@address.com",
                 SecondaryEmail = "email2@address.com",
@@ -94,7 +91,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.Id.Should().Equals(request.CandidateId);
             candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
             candidate.SecondaryPreferredTeachingSubjectId.Should().Equals(request.SecondaryPreferredTeachingSubjectId);
-            candidate.CountryId.Should().Equals(request.CountryId);
+            candidate.CountryId.Should().Equals(LookupItem.UnitedKingdomCountryId);
             candidate.Email.Should().Be(request.Email);
             candidate.SecondaryEmail.Should().Be(request.SecondaryEmail);
             candidate.FirstName.Should().Be(request.FirstName);

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -93,7 +93,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 MobileTelephone = "07584 734 576",
                 ClassroomExperienceNotesRaw = "notes",
                 HasDbsCertificate = true,
-                DbsCertificateIssuedAt = DateTime.UtcNow.AddYears(-1),
                 HasGcseMathsId = mockPickListItem.Id,
                 HasGcseEnglishId = mockPickListItem.Id,
                 AdviserEligibilityId = mockPickListItem.Id,
@@ -653,15 +652,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_ConsiderationJourneyStageIdIsNull_HasNoError()
         {
             _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.ConsiderationJourneyStageId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_HasDbsCertificateAndDbsCertificateIssuedAtIsNull_HasError()
-        {
-            var candidate = new Candidate() { HasDbsCertificate = true, DbsCertificateIssuedAt = null };
-            var result = _validator.TestValidate(candidate);
-
-            result.ShouldHaveValidationErrorFor("DbsCertificateIssuedAt");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -61,13 +61,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         {
             var request = new SchoolsExperienceSignUp
             {
-                HasDbsCertificate = true,
-                DbsCertificateIssuedAt = null,
+                Telephone = "123",
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("Candidate.DbsCertificateIssuedAt");
+            result.ShouldHaveValidationErrorFor("Candidate.Telephone");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -33,7 +33,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
                 CandidateId = null,
                 PreferredTeachingSubjectId = mockLookupItem.Id,
                 SecondaryPreferredTeachingSubjectId = mockLookupItem.Id,
-                CountryId = (Guid)mockLookupItem.Id,
                 AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id,
                 Email = "email@address.com",
                 FirstName = "John",
@@ -159,12 +158,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.SecondaryPreferredTeachingSubjectId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_CountryIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.CountryId, null as Guid?);
         }
     }
 }


### PR DESCRIPTION
- Default country to UK for SE sign up

We only appear to accept sign ups to the Schools Experience service from UK candidates. Currently the country is set as an environment variable in the Rails app, but its easier to default this in the API.

- Default secondary email/telephone on SE sign up

The Rails app has logic in it to default the secondary telephone/email when pre-filling for form; this replicates the logic in the API so we can remove it from the app.

- Remove validation on DBS certificate date

In the SE app the DBS certificate issued at date is cleared when the `HasDbsCertificate` field is changed; this means it could be `true` and not have a date of issue, so we should remove this validation check.