### PR TITLE
Make SecondaryPreferredTeachingSubjectId optional

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
@@ -8,7 +8,6 @@ namespace GetIntoTeachingApi.Models.Validators
         public SchoolsExperienceSignUpValidator(IStore store, IDateTimeProvider dateTime)
         {
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
-            RuleFor(request => request.SecondaryPreferredTeachingSubjectId).NotNull();
             RuleFor(request => request.AcceptedPolicyId).NotNull();
 
             RuleFor(request => request.Email).NotEmpty();

--- a/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -154,9 +154,9 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasError()
+        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasNoError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.SecondaryPreferredTeachingSubjectId, null as Guid?);
+            _validator.ShouldNotHaveValidationErrorFor(request => request.SecondaryPreferredTeachingSubjectId, null as Guid?);
         }
     }
 }


### PR DESCRIPTION
The candidate does not have to provide this in the sign up form, so making it optional.