### PR TITLE
Remove teaching event relationships

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -21,5 +21,6 @@ namespace GetIntoTeachingApi.Adapters
         Entity NewEntity(string entityName, OrganizationServiceContext context);
         void SaveChanges(OrganizationServiceContext context);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -102,5 +102,10 @@ namespace GetIntoTeachingApi.Adapters
         {
             context.AddLink(source, relationship, target);
         }
+
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            context.DeleteLink(source, relationship, target);
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -75,7 +75,7 @@ namespace GetIntoTeachingApi.Models
 
         public virtual Entity ToEntity(ICrmService crm, OrganizationServiceContext context)
         {
-            if (!ShouldMap(crm))
+            if (!ShouldMap(crm, context))
             {
                 return null;
             }
@@ -102,7 +102,7 @@ namespace GetIntoTeachingApi.Models
             return true;
         }
 
-        protected virtual bool ShouldMap(ICrmService crm)
+        protected virtual bool ShouldMap(ICrmService crm, OrganizationServiceContext context)
         {
             // Hook.
             return true;

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -6,6 +6,7 @@ using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -319,7 +320,7 @@ namespace GetIntoTeachingApi.Models
         public bool MagicLinkTokenExpired() => MagicLinkTokenExpiresAt == null || MagicLinkTokenExpiresAt < DateTime.UtcNow;
         public bool MagicLinkTokenAlreadyExchanged() => MagicLinkTokenStatusId == (int)MagicLinkTokenStatus.Exchanged;
 
-        protected override bool ShouldMap(ICrmService crm)
+        protected override bool ShouldMap(ICrmService crm, OrganizationServiceContext context)
         {
             IsNewRegistrant = Id == null;
 
@@ -332,7 +333,7 @@ namespace GetIntoTeachingApi.Models
                 EventsSubscriptionTypeId = (int)SubscriptionType.LocalEvent;
             }
 
-            return base.ShouldMap(crm);
+            return base.ShouldMap(crm, context);
         }
 
         protected override bool ShouldMapRelationship(string propertyName, dynamic value, ICrmService crm)

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -35,7 +36,7 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        protected override bool ShouldMap(ICrmService crm)
+        protected override bool ShouldMap(ICrmService crm, OrganizationServiceContext context)
         {
             var alreadyRegistered = !crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
 
@@ -44,7 +45,7 @@ namespace GetIntoTeachingApi.Models
                 return false;
             }
 
-            return base.ShouldMap(crm);
+            return base.ShouldMap(crm, context);
         }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -170,6 +170,11 @@ namespace GetIntoTeachingApi.Services
             _service.AddLink(source, relationship, target, context);
         }
 
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            _service.DeleteLink(source, relationship, target, context);
+        }
+
         public IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName)
         {
             var relatedEntityKeys = entity.Attributes.Keys.Where(k => k.StartsWith($"{relationshipName}.")).ToList();

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -175,6 +175,11 @@ namespace GetIntoTeachingApi.Services
             _service.DeleteLink(source, relationship, target, context);
         }
 
+        public void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context)
+        {
+            _service.LoadProperty(entity, relationship, context);
+        }
+
         public IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName)
         {
             var relatedEntityKeys = entity.Attributes.Keys.Where(k => k.StartsWith($"{relationshipName}.")).ToList();

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -29,5 +29,6 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();
+        void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApi.Services
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -430,6 +430,18 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void DeleteLink_ProxiesToService()
+        {
+            var source = new Entity("parent");
+            var target = new Entity("child");
+            var relationship = new Relationship("child");
+
+            _crm.DeleteLink(source, relationship, target, _context);
+
+            _mockService.Verify(mock => mock.DeleteLink(source, relationship, target, _context));
+        }
+
+        [Fact]
         public void RelatedEntities_ProxiesToService()
         {
             var entity = new Entity("parent");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -442,6 +442,17 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void LoadProperty_ProxiesToService()
+        {
+            var entity = new Entity("parent");
+            var relationship = new Relationship("child");
+
+            _crm.LoadProperty(entity, relationship, _context);
+
+            _mockService.Verify(mock => mock.LoadProperty(entity, relationship, _context));
+        }
+
+        [Fact]
         public void RelatedEntities_ProxiesToService()
         {
             var entity = new Entity("parent");


### PR DESCRIPTION
Existing relationships between `TeachingEvent` and `TeachingEventBuilding` do not get removed when the related Building is deleted. Currently, the Event is persisted in the cache with a null Building, which will then be re-added when the CRM sync runs.

Call `DeleteLink` in this scenario to remove the relationship in the CRM as well.