### PR TITLE
Change SchoolsExperience upsert to be synchronous

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -11,7 +11,7 @@ namespace GetIntoTeachingApi.Jobs
 {
     public class UpsertCandidateJob : BaseJob
     {
-        private readonly ICrmService _crm;
+        private readonly ICandidateUpserter _upserter;
         private readonly INotifyService _notifyService;
         private readonly IPerformContextAdapter _contextAdapter;
         private readonly IMetricService _metrics;
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApi.Jobs
 
         public UpsertCandidateJob(
             IEnv env,
-            ICrmService crm,
+            ICandidateUpserter upserter,
             INotifyService notifyService,
             IPerformContextAdapter contextAdapter,
             IMetricService metrics,
@@ -28,7 +28,7 @@ namespace GetIntoTeachingApi.Jobs
             IAppSettings appSettings)
             : base(env)
         {
-            _crm = crm;
+            _upserter = upserter;
             _notifyService = notifyService;
             _contextAdapter = contextAdapter;
             _metrics = metrics;
@@ -61,87 +61,13 @@ namespace GetIntoTeachingApi.Jobs
             }
             else
             {
-                var registrations = ClearTeachingEventRegistrations(candidate);
-                var phoneCall = ClearPhoneCall(candidate);
-                SaveCandidate(candidate);
-                SaveTeachingEventRegistrations(registrations, candidate);
-                SavePhoneCall(phoneCall, candidate);
-                IncrementCallbackBookingQuotaNumberOfBookings(phoneCall);
+                _upserter.Upsert(candidate);
 
                 _logger.LogInformation($"UpsertCandidateJob - Succeeded - {candidate.Id}");
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Observe(duration);
-        }
-
-        private void SaveCandidate(Candidate candidate)
-        {
-            _crm.Save(candidate);
-        }
-
-        private IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)
-        {
-            // Due to reasons unknown the event registrations relationship can't be deep-inserted
-            // in the same way we do for other relationships - we need to explicitly save them against
-            // the candidate instead.
-            var teachingEventRegistrations = new List<TeachingEventRegistration>(candidate.TeachingEventRegistrations);
-            candidate.TeachingEventRegistrations.Clear();
-            return teachingEventRegistrations;
-        }
-
-        private PhoneCall ClearPhoneCall(Candidate candidate)
-        {
-            if (candidate.PhoneCall == null)
-            {
-                return null;
-            }
-
-            // Due to reasons unknown the phone call relationship can't be deep-inserted
-            // in the same way we do for other relationships - we need to explicitly save them against
-            // the candidate instead.
-            var phoneCall = candidate.PhoneCall;
-            candidate.PhoneCall = null;
-            return phoneCall;
-        }
-
-        private void SaveTeachingEventRegistrations(IEnumerable<TeachingEventRegistration> registrations, Candidate candidate)
-        {
-            foreach (var registration in registrations)
-            {
-                registration.CandidateId = (Guid)candidate.Id;
-                _crm.Save(registration);
-            }
-        }
-
-        private void IncrementCallbackBookingQuotaNumberOfBookings(PhoneCall phoneCall)
-        {
-            if (phoneCall == null)
-            {
-                return;
-            }
-
-            var quota = _crm.GetCallbackBookingQuota(phoneCall.ScheduledAt);
-
-            if (quota == null || !quota.IsAvailable)
-            {
-                return;
-            }
-
-            quota.NumberOfBookings += 1;
-
-            _crm.Save(quota);
-        }
-
-        private void SavePhoneCall(PhoneCall phoneCall, Candidate candidate)
-        {
-            if (phoneCall == null)
-            {
-                return;
-            }
-
-            phoneCall.CandidateId = candidate.Id.ToString();
-            _crm.Save(phoneCall);
         }
     }
 }

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -26,7 +26,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DATABASE_INSTANCE_NAME": "gis",
         "HANGFIRE_INSTANCE_NAME": "gis",
-        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
+        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 4432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 5379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
         "VCAP_APPLICATION": "{\"application_name\": \"app-name\",\"organization_name\": \"org-name\",\"space_name\": \"space-name\"}",
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",

--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class CandidateUpserter : ICandidateUpserter
+    {
+        private readonly ICrmService _crm;
+
+        public CandidateUpserter(ICrmService crm)
+        {
+            _crm = crm;
+        }
+
+        public void Upsert(Candidate candidate)
+        {
+            var registrations = ClearTeachingEventRegistrations(candidate);
+            var phoneCall = ClearPhoneCall(candidate);
+            SaveCandidate(candidate);
+            SaveTeachingEventRegistrations(registrations, candidate);
+            SavePhoneCall(phoneCall, candidate);
+            IncrementCallbackBookingQuotaNumberOfBookings(phoneCall);
+        }
+
+        private void SaveCandidate(Candidate candidate)
+        {
+            _crm.Save(candidate);
+        }
+
+        private IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)
+        {
+            // Due to reasons unknown the event registrations relationship can't be deep-inserted
+            // in the same way we do for other relationships - we need to explicitly save them against
+            // the candidate instead.
+            var teachingEventRegistrations = new List<TeachingEventRegistration>(candidate.TeachingEventRegistrations);
+            candidate.TeachingEventRegistrations.Clear();
+            return teachingEventRegistrations;
+        }
+
+        private PhoneCall ClearPhoneCall(Candidate candidate)
+        {
+            if (candidate.PhoneCall == null)
+            {
+                return null;
+            }
+
+            // Due to reasons unknown the phone call relationship can't be deep-inserted
+            // in the same way we do for other relationships - we need to explicitly save them against
+            // the candidate instead.
+            var phoneCall = candidate.PhoneCall;
+            candidate.PhoneCall = null;
+            return phoneCall;
+        }
+
+        private void SaveTeachingEventRegistrations(IEnumerable<TeachingEventRegistration> registrations, Candidate candidate)
+        {
+            foreach (var registration in registrations)
+            {
+                registration.CandidateId = (Guid)candidate.Id;
+                _crm.Save(registration);
+            }
+        }
+
+        private void IncrementCallbackBookingQuotaNumberOfBookings(PhoneCall phoneCall)
+        {
+            if (phoneCall == null)
+            {
+                return;
+            }
+
+            var quota = _crm.GetCallbackBookingQuota(phoneCall.ScheduledAt);
+
+            if (quota == null || !quota.IsAvailable)
+            {
+                return;
+            }
+
+            quota.NumberOfBookings += 1;
+
+            _crm.Save(quota);
+        }
+
+        private void SavePhoneCall(PhoneCall phoneCall, Candidate candidate)
+        {
+            if (phoneCall == null)
+            {
+                return;
+            }
+
+            phoneCall.CandidateId = candidate.Id.ToString();
+            _crm.Save(phoneCall);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/ICandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/ICandidateUpserter.cs
@@ -1,0 +1,9 @@
+﻿using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface ICandidateUpserter
+    {
+        public void Upsert(Candidate candidate);
+    }
+}

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -76,6 +76,7 @@ namespace GetIntoTeachingApi
             services.AddSingleton<IClientManager, ClientManager>();
             services.AddSingleton<IHangfireService, HangfireService>();
             services.AddSingleton<IRedisService, RedisService>();
+            services.AddSingleton<ICandidateUpserter, CandidateUpserter>();
             services.AddSingleton<IPerformContextAdapter, PerformContextAdapter>();
             services.AddSingleton<ICallbackBookingService, CallbackBookingService>();
             services.AddSingleton<IDateTimeProvider, DateTimeProvider>();

--- a/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseFixture.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApiTests.Helpers
         public DatabaseFixture()
         {
             TemplateDatabaseName = $"gis_test";
-            ConnectionString = $"Host=localhost;Database={TemplateDatabaseName};Username=docker;Password=docker";
+            ConnectionString = $"Host=localhost;Database={TemplateDatabaseName};Username=docker;Password=docker;Port=4432";
 
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
             DbConfiguration.ConfigPostgres(ConnectionString, builder);

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -2,7 +2,6 @@
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using Prometheus;
 
 namespace GetIntoTeachingApiTests.Helpers
 {
@@ -34,7 +33,7 @@ namespace GetIntoTeachingApiTests.Helpers
 
         private void SetupDbContext(string databaseName)
         {
-            var connectionString = $"Host=localhost;Database={databaseName};Username=docker;Password=docker";
+            var connectionString = $"Host=localhost;Database={databaseName};Username=docker;Password=docker;Port=4432";
             var builder = new DbContextOptionsBuilder<GetIntoTeachingDbContext>();
 
             DbConfiguration.ConfigPostgres(connectionString, builder);
@@ -57,8 +56,8 @@ namespace GetIntoTeachingApiTests.Helpers
             Environment.SetEnvironmentVariable("DATABASE_INSTANCE_NAME", databaseName);
             Environment.SetEnvironmentVariable("VCAP_SERVICES",
                 $"{{\"postgres\": [{{\"instance_name\": \"{databaseName}\",\"credentials\": {{\"host\": \"localhost\"," +
-                $"\"name\": \"{databaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 5432}}}}]," +
-                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": 6379,\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
+                $"\"name\": \"{databaseName}\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 4432}}}}]," +
+                $"\"redis\": [{{\"credentials\": {{\"host\": \"0.0.0.0\",\"port\": 5379,\"password\": \"docker\",\"tls_enabled\": false}}}}]}}");
             Environment.SetEnvironmentVariable("VCAP_APPLICATION",
                 "{\"application_name\":\"app-name\",\"space_name\":\"space-name\",\"organization_name\":\"org-name\"}");
         }

--- a/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class CandidateUpserterTests
+    {
+        private readonly ICandidateUpserter _upserter;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Candidate _candidate;
+
+        public CandidateUpserterTests()
+        {
+            _mockCrm = new Mock<ICrmService>();
+            _upserter = new CandidateUpserter(_mockCrm.Object);
+            _candidate = new Candidate() { Id = Guid.NewGuid(), Email = "test@test.com" };
+        }
+
+        [Fact]
+        public void Upsert_WithCandidate_SavesCandidate()
+        {
+            _upserter.Upsert(_candidate);
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<Candidate>(c => IsMatch(_candidate, c))), Times.Once);
+        }
+
+        [Fact]
+        public void Upsert_WithTeachingEventRegistrations_SavesTeachingEventRegistrations()
+        {
+            var candidateId = Guid.NewGuid();
+            var registration = new TeachingEventRegistration() { EventId = Guid.NewGuid() };
+            _candidate.TeachingEventRegistrations.Add(registration);
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
+
+            _upserter.Upsert(_candidate);
+
+            registration.CandidateId = candidateId;
+            _mockCrm.Verify(mock => mock.Save(It.Is<TeachingEventRegistration>(r => IsMatch(registration, r))), Times.Once);
+        }
+
+        [Fact]
+        public void Upsert_WithPhoneCall_SavesPhoneCallAndIncrementsCallbackBookingQuotaNumberOfBookings()
+        {
+            var candidateId = Guid.NewGuid();
+            var scheduledAt = DateTime.UtcNow.AddDays(3);
+            var phoneCall = new PhoneCall() { ScheduledAt = scheduledAt };
+            _candidate.PhoneCall = phoneCall;
+            var quota = new CallbackBookingQuota() { StartAt = scheduledAt, NumberOfBookings = 5, Quota = 10 };
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
+            _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
+
+            _upserter.Upsert(_candidate);
+
+            phoneCall.CandidateId = candidateId.ToString();
+            _mockCrm.Verify(mock => mock.Save(It.Is<PhoneCall>(p => IsMatch(phoneCall, p))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<CallbackBookingQuota>(q => IsMatch(quota, q))), Times.Once);
+            quota.NumberOfBookings.Should().Be(6);
+        }
+
+        [Fact]
+        public void Upsert_WithPhoneCallButMatchingQuotaIsAlreadyFull_DoesNotIncrementsCallbackBookingQuotaNumberOfBookings()
+        {
+            var candidateId = Guid.NewGuid();
+            var scheduledAt = DateTime.UtcNow.AddDays(3);
+            var phoneCall = new PhoneCall() { ScheduledAt = scheduledAt };
+            var quota = new CallbackBookingQuota() { StartAt = scheduledAt, NumberOfBookings = 5, Quota = 5 };
+            _candidate.PhoneCall = phoneCall;
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
+            _mockCrm.Setup(mock => mock.GetCallbackBookingQuota(scheduledAt)).Returns(quota);
+
+            _upserter.Upsert(_candidate);
+
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<CallbackBookingQuota>()), Times.Never);
+            quota.NumberOfBookings.Should().Be(5);
+        }
+
+        private bool IsMatch(object objectA, object objectB)
+        {
+            objectA.Should().BeEquivalentTo(objectB);
+            return true;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,14 @@ services:
     healthcheck:
         test: "exit 0"
     ports:
-      - '5432:5432'
+      - '4432:5432'
 
   redis:
     image: redis:6.0.9-alpine
     volumes:
       - redis:/data
     ports:
-      - '6379:6379'
+      - '5379:6379'
     command: >
       --requirepass docker
 


### PR DESCRIPTION
- Update docker-compose ports

I often run the API along side another Rails app locally and the ports clash; changing this so I can keep both apps running locally at the same time.

- Extract upsert logic into CandidateUpserter service

We need to be able to call the upsert operation from outside a job for the Schools Experience service (as it requires an immediate response from the CRM with the candidate GUID in).

Extract the upsert logic into a new service that can be called independently.

- Update SE upsert operation to be synchronous

Instead of queueing the job to upsert a candidate we need to be able to return the newly created candidate (with an ID) to the Schools Experience service.

This means the service will be unavailable when the CRM is offline, but that is the case currently anyway.

Once the migration to the API has been completed we may be able to update the service to remove this requirement.