### PR TITLE
Fix return type of SE upsert method

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -45,7 +45,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                           "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
             OperationId = "SignUpSchoolsExperienceCandidate",
             Tags = new[] { "Schools Experience" })]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(SchoolsExperienceSignUp), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult SignUp(
             [FromBody, SwaggerRequestBody("Candidate to sign up for the Schools Experience service.", Required = true)] SchoolsExperienceSignUp request,
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             return CreatedAtAction(
                 actionName: nameof(Get),
                 routeValues: new { id = candidate.Id },
-                value: candidate);
+                value: new SchoolsExperienceSignUp(candidate));
         }
 
         [HttpGet]

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -101,12 +101,15 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             var mockAppSettings = new Mock<IAppSettings>();
             mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             var request = new SchoolsExperienceSignUp { FirstName = "first" };
+            var candidateId = Guid.NewGuid();
+            _mockUpserter.Setup(m => m.Upsert(It.IsAny<Candidate>())).Callback<Candidate>((c) => c.Id = candidateId);
 
             var response = _controller.SignUp(request, mockAppSettings.Object);
 
             var created = response.Should().BeOfType<CreatedAtActionResult>().Subject;
-            var candidate = created.Value.Should().BeAssignableTo<Candidate>().Subject;
-            IsMatch(candidate, request.Candidate).Should().BeTrue();
+            var signUp = created.Value.Should().BeAssignableTo<SchoolsExperienceSignUp>().Subject;
+            signUp.FirstName.Should().Be(request.FirstName);
+            signUp.CandidateId.Should().Be(candidateId);
 
             _mockUpserter.Verify(m => m.Upsert(It.IsAny<Candidate>()), Times.Once);
         }
@@ -194,12 +197,6 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
             candidateA.Should().BeEquivalentTo(candidateB);
             return true;
-        }
-
-        private static bool IsMatch(Candidate candidateA, Candidate candidateB)
-        {
-            var candidateBJson = candidateB.SerializeChangeTracked();
-            return IsMatch(candidateA, candidateBJson);
         }
     }
 }


### PR DESCRIPTION
The return type needs to be specified for the Swagger client to generate correctly. It should also have been a `SchoolsExperienceSignUp` and not a `Candidate`.