### PR TITLE
Remove teaching event relationships

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -21,5 +21,6 @@ namespace GetIntoTeachingApi.Adapters
         Entity NewEntity(string entityName, OrganizationServiceContext context);
         void SaveChanges(OrganizationServiceContext context);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
     }
 }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -102,5 +102,10 @@ namespace GetIntoTeachingApi.Adapters
         {
             context.AddLink(source, relationship, target);
         }
+
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            context.DeleteLink(source, relationship, target);
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -83,6 +83,7 @@ namespace GetIntoTeachingApi.Models
             var entity = crm.MappableEntity(LogicalName(GetType()), Id, context);
             MapFieldAttributesToEntity(entity);
             MapRelationshipAttributesToEntity(entity, crm, context);
+            FinaliseEntity(entity, crm, context);
             return entity;
         }
 
@@ -108,6 +109,11 @@ namespace GetIntoTeachingApi.Models
             return true;
         }
 
+        protected virtual void FinaliseEntity(Entity source, ICrmService crm, OrganizationServiceContext context)
+        {
+            // Hook.
+        }
+
         protected void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
             var excluded = _propertyNamesExcludedFromChangeTracking.Any(p => p == propertyName);
@@ -116,6 +122,14 @@ namespace GetIntoTeachingApi.Models
             {
                 ChangedPropertyNames.Add(propertyName);
             }
+        }
+
+        protected void DeleteLink(Entity source, ICrmService crm, OrganizationServiceContext context, BaseModel modelToRemove, string modelToRemovePropertyName)
+        {
+            PropertyInfo property = GetType().GetProperty(modelToRemovePropertyName);
+            var attribute = EntityRelationshipAttribute(property);
+            var target = modelToRemove.ToEntity(crm, context);
+            crm.DeleteLink(source, new Relationship(attribute.Name), target, context);
         }
 
         private static IList NewListOfType(Type type)

--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Models
@@ -109,6 +110,18 @@ namespace GetIntoTeachingApi.Models
         public TeachingEvent(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
             : base(entity, crm, validatorFactory)
         {
+        }
+
+        protected override void FinaliseEntity(Entity source, ICrmService crm, OrganizationServiceContext context)
+        {
+            var existingEvent = crm.GetTeachingEvent(ReadableId);
+
+            bool removeBuilding = Building == null && existingEvent.Building != null;
+
+            if (removeBuilding)
+            {
+                DeleteLink(source, crm, context, existingEvent.Building, nameof(existingEvent.Building));
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -170,6 +170,11 @@ namespace GetIntoTeachingApi.Services
             _service.AddLink(source, relationship, target, context);
         }
 
+        public void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            _service.DeleteLink(source, relationship, target, context);
+        }
+
         public IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName)
         {
             var relatedEntityKeys = entity.Attributes.Keys.Where(k => k.StartsWith($"{relationshipName}.")).ToList();

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -246,10 +246,14 @@ namespace GetIntoTeachingApi.Services
 
         public TeachingEvent GetTeachingEvent(string readableId)
         {
-            return _service.CreateQuery("msevtmgt_event", Context())
-                .Where(entity => entity.GetAttributeValue<string>("dfe_websiteeventpartialurl") == readableId)
-                .Select(entity => new TeachingEvent(entity, this, _validatorFactory))
-                .SingleOrDefault();
+            var context = Context();
+            var entity = _service.CreateQuery("msevtmgt_event", context)
+                             .Where(entity => entity.GetAttributeValue<string>("dfe_websiteeventpartialurl") == readableId)
+                             .FirstOrDefault();
+
+            _service.LoadProperty(entity, new Relationship("msevtmgt_event_building"), context);
+
+            return entity != null ? new TeachingEvent(entity, this, _validatorFactory) : null;
         }
 
         public IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings()

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApi.Services
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
         void Save(BaseModel model);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
+        void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -430,6 +430,18 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void DeleteLink_ProxiesToService()
+        {
+            var source = new Entity("parent");
+            var target = new Entity("child");
+            var relationship = new Relationship("child");
+
+            _crm.DeleteLink(source, relationship, target, _context);
+
+            _mockService.Verify(mock => mock.DeleteLink(source, relationship, target, _context));
+        }
+
+        [Fact]
         public void RelatedEntities_ProxiesToService()
         {
             var entity = new Entity("parent");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -529,6 +529,19 @@ namespace GetIntoTeachingApiTests.Services
             result.Should().BeNull();
         }
 
+        [Fact]
+        public void GetTeachingEvent_CallLoadProperty()
+        {
+            _mockService.Setup(mock => mock.CreateQuery("msevtmgt_event", _context))
+                .Returns(MockTeachingEvents());
+
+            var result = _crm.GetTeachingEvent("event_one");
+
+            result.ReadableId.Should().Be("event_one");
+            _mockService.Verify(mock => mock.LoadProperty(It.IsAny<Entity>(),
+               new Relationship("msevtmgt_event_building"), _context), Times.Once);
+        }
+
         private static IQueryable<Entity> MockTeachingEventBuildings()
         {
             var building1 = new Entity("msevtmgt_building");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -516,6 +516,8 @@ namespace GetIntoTeachingApiTests.Services
             var result = _crm.GetTeachingEvent("event_one");
 
             result.ReadableId.Should().Be("event_one");
+            _mockService.Verify(mock => mock.LoadProperty(It.IsAny<Entity>(),
+               new Relationship("msevtmgt_event_building"), _context), Times.Once);
         }
 
         [Fact]
@@ -527,19 +529,6 @@ namespace GetIntoTeachingApiTests.Services
             var result = _crm.GetTeachingEvent("wrong");
 
             result.Should().BeNull();
-        }
-
-        [Fact]
-        public void GetTeachingEvent_CallLoadProperty()
-        {
-            _mockService.Setup(mock => mock.CreateQuery("msevtmgt_event", _context))
-                .Returns(MockTeachingEvents());
-
-            var result = _crm.GetTeachingEvent("event_one");
-
-            result.ReadableId.Should().Be("event_one");
-            _mockService.Verify(mock => mock.LoadProperty(It.IsAny<Entity>(),
-               new Relationship("msevtmgt_event_building"), _context), Times.Once);
         }
 
         private static IQueryable<Entity> MockTeachingEventBuildings()


### PR DESCRIPTION
Existing relationships between TeachingEvent and TeachingEventBuilding do not get removed when the related Building is deleted. Currently, the Event is persisted in the cache with a null Building, which will then be re-added when the CRM sync runs.

Call DeleteLink in this scenario to remove the relationship in the CRM as well.