### PR TITLE
Add SwaggerRequestBody annotation

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -180,7 +180,9 @@ namespace GetIntoTeachingApi.Controllers
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(TeachingEvent), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> Upsert([FromBody] TeachingEvent teachingEvent, [FromServices] IOptions<ApiBehaviorOptions> apiBehaviorOptions)
+        public async Task<IActionResult> Upsert(
+            [FromBody, SwaggerRequestBody("Teaching event to upsert.", Required = true)] TeachingEvent teachingEvent,
+            [FromServices] IOptions<ApiBehaviorOptions> apiBehaviorOptions)
         {
             var operation = new TeachingEventUpsertOperation(teachingEvent);
             var validator = new TeachingEventUpsertOperationValidator(_crm);


### PR DESCRIPTION
When SwaggerGen is generating the client library, it is expecting a teaching event to be in a hash with a body key for upsert_teaching_event.

This is an attempt to fix that. The other post actions in the API are annotated SwaggerRequestBody.