### PR TITLE
Validate against array of strings instead of regex

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
@@ -1,15 +1,23 @@
-﻿using FluentValidation;
+﻿using System.Linq;
+using FluentValidation;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class ClassroomExperienceNoteValidator : AbstractValidator<ClassroomExperienceNote>
     {
-        private static readonly string ActionRegex =
-            "\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z";
+        private static readonly string[] _validActions = new string[]
+        {
+            "REQUEST",
+            "ACCEPTED",
+            "ATTENDED",
+            "DID NOT ATTEND",
+            "CANCELLED BY SCHOOL",
+            "CANCELLED BY CANDIDATE",
+        };
 
         public ClassroomExperienceNoteValidator()
         {
-            RuleFor(request => request.Action).NotEmpty().Matches(ActionRegex);
+            RuleFor(request => request.Action).NotEmpty().Must(a => _validActions.Contains(a));
             RuleFor(request => request.SchoolUrn).NotEmpty().MaximumLength(6);
             RuleFor(request => request.SchoolName).NotEmpty();
             RuleFor(request => request.RecordedAt).NotNull();


### PR DESCRIPTION
The swagger-codegen is creating an invalid Regex in the client, so swapping this validator out to check an array of explicit strings instead.