### PR TITLE
Support retrieving multiple SE sign ups

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -88,6 +89,22 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             }
 
             return Ok(new SchoolsExperienceSignUp(candidate));
+        }
+
+        [HttpGet]
+        [Route("")]
+        [SwaggerOperation(
+            Summary = "Retrieves existing SchoolsExperienceSignUps for the candidate `ids`.",
+            OperationId = "GetSchoolsExperienceSignUps",
+            Tags = new[] { "Schools Experience" })]
+        [ProducesResponseType(typeof(IEnumerable<SchoolsExperienceSignUp>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult GetMultiple([FromQuery, SwaggerParameter("A collection of `Candidate` `id`s.", Required = true)] IEnumerable<Guid> ids)
+        {
+            var candidates = _crm.GetCandidates(ids);
+            var signUps = candidates.Select(c => new SchoolsExperienceSignUp(c));
+
+            return Ok(signUps);
         }
 
         [HttpPost]

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -130,11 +130,19 @@ namespace GetIntoTeachingApi.Services
 
         public Candidate GetCandidate(Guid id)
         {
-            var entity = _service.CreateQuery("contact", Context())
-                .FirstOrDefault(c => c.GetAttributeValue<EntityReference>("contactid") != null &&
-                c.GetAttributeValue<EntityReference>("contactid").Id == id);
+            return GetCandidates(new Guid[] { id }).FirstOrDefault();
+        }
 
-            return entity == null ? null : new Candidate(entity, this, _validatorFactory);
+        public IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids)
+        {
+            var query = new QueryExpression("contact");
+            query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(Candidate)));
+
+            query.Criteria.AddCondition(new ConditionExpression("contactid", ConditionOperator.In, ids.ToArray()));
+
+            var entities = _service.RetrieveMultiple(query);
+
+            return entities.Select((entity) => new Candidate(entity, this, _validatorFactory));
         }
 
         public IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi.Services
         Candidate MatchCandidate(ExistingCandidateRequest request);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
+        IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);
         IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10);
         IEnumerable<TeachingEvent> GetTeachingEvents(DateTime? startAfter = null);
         TeachingEvent GetTeachingEvent(string readableId);


### PR DESCRIPTION
Part of the Schools Experience code appears to batch-update contacts, so we need to provide a method to retrieve details for multiple candidates at once.