### PR TITLE
Add FullName property to SE sign up

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -16,6 +16,8 @@ namespace GetIntoTeachingApi.Models
         [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
 
+        [SwaggerSchema(ReadOnly = true)]
+        public string FullName { get; set; }
         public string Email { get; set; }
         public string SecondaryEmail { get; set; }
         public string FirstName { get; set; }
@@ -55,6 +57,7 @@ namespace GetIntoTeachingApi.Models
             PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
             SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
 
+            FullName = candidate.FullName;
             Email = candidate.Email;
             SecondaryEmail = candidate.SecondaryEmail ?? candidate.Email;
             FirstName = candidate.FirstName;

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -41,6 +41,7 @@ namespace GetIntoTeachingApiTests.Models
             response.SecondaryPreferredTeachingSubjectId.Should().Be(candidate.SecondaryPreferredTeachingSubjectId);
             response.Email.Should().Be(candidate.Email);
             response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
+            response.FullName.Should().Be(candidate.FullName);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.AddressTelephone.Should().Be(candidate.AddressTelephone);


### PR DESCRIPTION
The SE codebase references `contact.full_name` frequently; instead of adding a helper and replacing a bunch of occurrences its going to be a lighter-touch to expose the full name in the API model and that way the existing references will just work.