### PR TITLE
Expose MasterId for SchoolsExperienceSignUp

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -106,6 +106,8 @@ namespace GetIntoTeachingApi.Models
         public Guid? CountryId { get; set; }
         [EntityField("owningbusinessunit", typeof(EntityReference), "businessunit")]
         public Guid? OwningBusinessUnitId { get; set; }
+        [EntityField("masterid", typeof(EntityReference), "contact")]
+        public Guid? MasterId { get; set; }
         [EntityField("dfe_preferrededucationphase01", typeof(OptionSetValue))]
         public int? PreferredEducationPhaseId { get; set; }
         [EntityField("dfe_ittyear", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -15,6 +15,8 @@ namespace GetIntoTeachingApi.Models
         public Guid? SecondaryPreferredTeachingSubjectId { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public Guid? MasterId { get; set; }
 
         [SwaggerSchema(ReadOnly = true)]
         public string FullName { get; set; }
@@ -56,6 +58,7 @@ namespace GetIntoTeachingApi.Models
             CandidateId = candidate.Id;
             PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
             SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
+            MasterId = candidate.MasterId;
 
             FullName = candidate.FullName;
             Email = candidate.Email;

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -32,6 +32,9 @@ namespace GetIntoTeachingApiTests.Models
             type.GetProperty("OwningBusinessUnitId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "owningbusinessunit" && a.Type == typeof(EntityReference) &&
                      a.Reference == "businessunit");
+            type.GetProperty("MasterId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "masterid" && a.Type == typeof(EntityReference) &&
+                     a.Reference == "contact");
 
             type.GetProperty("PreferredEducationPhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_preferrededucationphase01" && a.Type == typeof(OptionSetValue));

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApiTests.Models
                 Id = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
+                MasterId = Guid.NewGuid(),
                 Email = "email@address.com",
                 SecondaryEmail = "email2@address.com",
                 FirstName = "John",
@@ -39,6 +40,7 @@ namespace GetIntoTeachingApiTests.Models
             response.CandidateId.Should().Be(candidate.Id);
             response.PreferredTeachingSubjectId.Should().Be(candidate.PreferredTeachingSubjectId);
             response.SecondaryPreferredTeachingSubjectId.Should().Be(candidate.SecondaryPreferredTeachingSubjectId);
+            response.MasterId.Should().Be(candidate.MasterId);
             response.Email.Should().Be(candidate.Email);
             response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
             response.FullName.Should().Be(candidate.FullName);


### PR DESCRIPTION
The SE app uses the master id to traverse contacts until it finds the 'master' record. Ideally this logic would be deferred to the API, but to make the migration easier I'm exposing it so we can continue to do it in the Rails app for now.