### PR TITLE
Add merged attribute to SchoolsExperienceSignUp

### DIFF
--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -146,6 +146,8 @@ namespace GetIntoTeachingApi.Models
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
+        [EntityField("merged")]
+        public bool Merged { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
         [EntityField("emailaddress2")]

--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -19,6 +19,8 @@ namespace GetIntoTeachingApi.Models
         public Guid? MasterId { get; set; }
 
         [SwaggerSchema(ReadOnly = true)]
+        public bool Merged { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
         public string FullName { get; set; }
         public string Email { get; set; }
         public string SecondaryEmail { get; set; }
@@ -60,6 +62,7 @@ namespace GetIntoTeachingApi.Models
             SecondaryPreferredTeachingSubjectId = candidate.SecondaryPreferredTeachingSubjectId;
             MasterId = candidate.MasterId;
 
+            Merged = candidate.Merged;
             FullName = candidate.FullName;
             Email = candidate.Email;
             SecondaryEmail = candidate.SecondaryEmail ?? candidate.Email;

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -70,6 +70,7 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
 
 
+            type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApiTests.Models
                 PreferredTeachingSubjectId = Guid.NewGuid(),
                 SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
                 MasterId = Guid.NewGuid(),
+                Merged = true,
                 Email = "email@address.com",
                 SecondaryEmail = "email2@address.com",
                 FirstName = "John",
@@ -43,6 +44,7 @@ namespace GetIntoTeachingApiTests.Models
             response.MasterId.Should().Be(candidate.MasterId);
             response.Email.Should().Be(candidate.Email);
             response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
+            response.Merged.Should().Be(candidate.Merged);
             response.FullName.Should().Be(candidate.FullName);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);


### PR DESCRIPTION
Indicates if the contact record has been merged and should have a `masterId`. I didn't think we'd need this as well as `masterId` but the client app references both, so putting it in to make the migration easier.