### PR TITLE
Make date optional in ClassroomExperienceNote

### DIFF
--- a/GetIntoTeachingApi/Models/ClassroomExperienceNote.cs
+++ b/GetIntoTeachingApi/Models/ClassroomExperienceNote.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Models
         public string Action { get; set; }
         [SwaggerSchema(Format = "date")]
         public DateTime? Date { get; set; }
-        public int SchoolUrn { get; set; }
+        public int? SchoolUrn { get; set; }
         public string SchoolName { get; set; }
 
         public ClassroomExperienceNote()

--- a/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ClassroomExperienceNoteValidator.cs
@@ -19,10 +19,9 @@ namespace GetIntoTeachingApi.Models.Validators
         public ClassroomExperienceNoteValidator()
         {
             RuleFor(request => request.Action).NotEmpty().Must(a => _validActions.Contains(a));
-            RuleFor(request => request.SchoolUrn).Must(urn => urn.ToString().Length == _urnLength);
+            RuleFor(request => request.SchoolUrn).NotEmpty().Must(urn => urn.ToString().Length == _urnLength);
             RuleFor(request => request.SchoolName).NotEmpty();
             RuleFor(request => request.RecordedAt).NotNull();
-            RuleFor(request => request.Date).NotNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/ClassroomExperienceNoteTests.cs
+++ b/GetIntoTeachingApiTests/Models/ClassroomExperienceNoteTests.cs
@@ -26,6 +26,10 @@ namespace GetIntoTeachingApiTests.Models
             note.SchoolName = "Test";
 
             note.ToString().Should().Be("01/01/2020 CANCELLED BY SCHOOL    02/03/2020 123    Test\r\n");
+
+            note.Date = null;
+
+            note.ToString().Should().Be("01/01/2020 CANCELLED BY SCHOOL               123    Test\r\n");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/ClassroomExperienceNoteValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ClassroomExperienceNoteValidatorTests.cs
@@ -40,12 +40,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
         }
 
         [Fact]
-        public void Validate_DateIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Date, null as DateTime?);
-        }
-
-        [Fact]
         public void Validate_RecordedAtIsNull_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.RecordedAt, null as DateTime?);
@@ -90,6 +84,12 @@ namespace GetIntoTeachingApiTests.Models.Validators
         public void Validate_SchoolUrnIsWrongLength_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, 11);
+        }
+
+        [Fact]
+        public void Validate_SchoolUrnIsNull_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, null as int?);
         }
     }
 }


### PR DESCRIPTION
The `Date` attribute is not alwasy specified by the client.

Also updates the `SchoolUrn` to be nullable but required, which should prevent swagger-codegen from marking it as `[Optional]`.