### PR TITLE
Add support for comma-separated query string values

### DIFF
--- a/GetIntoTeachingApi/Attributes/CommaSeparatedAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CommaSeparatedAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
+    public class CommaSeparatedAttribute : Attribute
+    {
+    }
+}

--- a/GetIntoTeachingApi/Attributes/CommaSeparatedQueryStringAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CommaSeparatedQueryStringAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public class CommaSeparatedQueryStringAttribute : Attribute, IResourceFilter
+    {
+        private readonly CommaSeparatedQueryStringValueProviderFactory _factory;
+
+        public CommaSeparatedQueryStringAttribute()
+            : this(",")
+        {
+        }
+
+        public CommaSeparatedQueryStringAttribute(string separator)
+        {
+            _factory = new CommaSeparatedQueryStringValueProviderFactory(separator);
+        }
+
+        public CommaSeparatedQueryStringAttribute(string key, string separator)
+        {
+            _factory = new CommaSeparatedQueryStringValueProviderFactory(key, separator);
+        }
+
+        public void OnResourceExecuted(ResourceExecutedContext context)
+        {
+            // Not required.
+        }
+
+        public void OnResourceExecuting(ResourceExecutingContext context)
+        {
+            context.ValueProviderFactories.Insert(0, _factory);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -99,7 +100,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             Tags = new[] { "Schools Experience" })]
         [ProducesResponseType(typeof(IEnumerable<SchoolsExperienceSignUp>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult GetMultiple([FromQuery, SwaggerParameter("A collection of `Candidate` `id`s.", Required = true)] IEnumerable<Guid> ids)
+        public IActionResult GetMultiple([FromQuery, CommaSeparated, SwaggerParameter("A collection of `Candidate` `id`s.", Required = true)] IEnumerable<Guid> ids)
         {
             var candidates = _crm.GetCandidates(ids);
             var signUps = candidates.Select(c => new SchoolsExperienceSignUp(c));

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -89,6 +89,11 @@ namespace GetIntoTeachingApi
             services.AddAuthentication("ApiClientHandler")
                 .AddScheme<ApiClientSchemaOptions, ApiClientHandler>("ApiClientHandler", op => { });
 
+            services.AddMvc(o =>
+            {
+                o.Conventions.Add(new CommaSeparatedQueryStringConvention());
+            });
+
             services.AddControllers(o =>
             {
                 o.ModelBinderProviders.Insert(0, new TrimStringModelBinderProvider());

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringConvention.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringConvention.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using GetIntoTeachingApi.Attributes;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class CommaSeparatedQueryStringConvention : IActionModelConvention
+    {
+        public void Apply(ActionModel action)
+        {
+            foreach (var parameter in action.Parameters)
+            {
+                if (parameter.Attributes.OfType<CommaSeparatedAttribute>().Any() && !parameter.Action.Filters.OfType<CommaSeparatedQueryStringAttribute>().Any())
+                {
+                    parameter.Action.Filters.Add(new CommaSeparatedQueryStringAttribute(parameter.ParameterName, ","));
+                }
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProvider.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class CommaSeparatedQueryStringValueProvider : QueryStringValueProvider
+    {
+        private readonly string _key;
+        private readonly string _separator;
+
+        public CommaSeparatedQueryStringValueProvider(IQueryCollection values, string separator)
+            : this(null, values, separator)
+        {
+            _separator = separator;
+        }
+
+        public CommaSeparatedQueryStringValueProvider(string key, IQueryCollection values, string separator)
+            : base(BindingSource.Query, values, CultureInfo.InvariantCulture)
+        {
+            _key = key;
+            _separator = separator;
+        }
+
+        public override ValueProviderResult GetValue(string key)
+        {
+            var result = base.GetValue(key);
+
+            if (_key != key)
+            {
+                return result;
+            }
+
+            if (result != ValueProviderResult.None && result.Values.Any(x => x.Contains(_separator)))
+            {
+                var splitValues = new StringValues(result.Values
+                    .SelectMany(x => x.Split(new[] { _separator }, StringSplitOptions.None)).ToArray());
+                return new ValueProviderResult(splitValues, result.Culture);
+            }
+
+            return result;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProviderFactory.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProviderFactory.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public class CommaSeparatedQueryStringValueProviderFactory : IValueProviderFactory
+    {
+        private readonly string _separator;
+        private readonly string _key;
+
+        public CommaSeparatedQueryStringValueProviderFactory(string separator)
+            : this(null, separator)
+        {
+        }
+
+        public CommaSeparatedQueryStringValueProviderFactory(string key, string separator)
+        {
+            _key = key;
+            _separator = separator;
+        }
+
+        public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+        {
+            var provider = new CommaSeparatedQueryStringValueProvider(
+                _key,
+                context.ActionContext.HttpContext.Request.Query,
+                _separator);
+
+            context.ValueProviders.Insert(0, provider);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderFactoryTests.cs
+++ b/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderFactoryTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class CommaSeparatedQueryStringValueProviderFactoryTests
+    {
+        [Fact]
+        public void CreateValueProviderAsync_InsertsCommaSepratedQueryStrinValueProvider()
+        {
+            var factory = new CommaSeparatedQueryStringValueProviderFactory("key", ",");
+            var actionContext = new ActionContext();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.QueryString = new QueryString("?key=value");
+            actionContext.HttpContext = httpContext;
+            var context = new ValueProviderFactoryContext(actionContext);
+
+            factory.CreateValueProviderAsync(context);
+
+            var expectedProvider = new CommaSeparatedQueryStringValueProvider("key",
+                context.ActionContext.HttpContext.Request.Query, ",");
+            context.ValueProviders[0].Should().BeEquivalentTo(expectedProvider);
+        }
+    }
+}


### PR DESCRIPTION
By default ASP.NET Core expects `FromQuery` parameters of a collection type to be expressed in the format:

```
GET /items?key=value1&key=value2
```

Swagger UI and SwaggerCodegen, however, create code that results in the query parameters in the format:

```
GET /items?key=value1,value2
```

As it doesn't appear possible to customise Swagger UI/SwaggerCodegen in this respect, this commit instead updates ASP.NET Core with a `CommaSeparated` attribute that can be applied to controller parameters in order to accept the
comma-separated value format.

It does this via a mixture of custom attributes, value providers and a convention - all of which are closed to mocking and difficult to test, so I've covered the bits of code that I can.