### PR TITLE
Update CdsServiceClient

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using GetIntoTeachingApi.Utils;
-using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public class CdsServiceClientWrapper
     {
-        public readonly CdsServiceClient CdsServiceClient;
+        public readonly ServiceClient CdsServiceClient;
 
         public CdsServiceClientWrapper(IEnv env)
         {
             // We don't want to try and connect to Dynamics when integration testing.
             if (!env.IsTest)
             {
-                CdsServiceClient = new CdsServiceClient(ConnectionString(env));
-                CdsServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+                CdsServiceClient = new ServiceClient(ConnectionString(env));
+                CdsServiceClient.MaxRetryCount = 3;
             }
         }
 

--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Adapters
         IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
         IEnumerable<Entity> RetrieveMultiple(QueryBase query);
         void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
-        IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
+        IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
         IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
         OrganizationServiceContext Context();
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Models;
-using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -11,18 +11,18 @@ namespace GetIntoTeachingApi.Adapters
 {
     public class OrganizationServiceAdapter : IOrganizationServiceAdapter
     {
-        private readonly CdsServiceClient _client;
+        private readonly ServiceClient _client;
 
         public OrganizationServiceAdapter(IOrganizationService client)
         {
-            _client = (CdsServiceClient)client;
+            _client = (ServiceClient)client;
         }
 
         public string CheckStatus()
         {
             try
             {
-                _client.GetMyCdsUserId();
+                _client.GetMyUserId();
             }
             catch (Exception e)
             {
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApi.Adapters
             return result;
         }
 
-        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(
+        public IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(
             string entityName,
             string attributeName)
         {

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -23,7 +23,6 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.2.1-Alpha" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
@@ -50,6 +49,7 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
 		<PackageReference Include="GovukNotify" Version="4.0.0" />
 		<PackageReference Include="JWT" Version="7.3.1" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Models/PickListItem.cs
+++ b/GetIntoTeachingApi/Models/PickListItem.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
-using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public PickListItem(CdsServiceClient.PickListItem pickListItem, string entityName, string attributeName)
+        public PickListItem(ServiceClient.PickListItem pickListItem, string entityName, string attributeName)
         {
             Id = pickListItem.PickListItemId;
             Value = pickListItem.DisplayLabel;

--- a/GetIntoTeachingApiTests/Models/PickListItemTests.cs
+++ b/GetIntoTeachingApiTests/Models/PickListItemTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using FluentAssertions;
 using GetIntoTeachingApi.Models;
-using Microsoft.PowerPlatform.Cds.Client;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithPickListItem()
         {
-            var pickListItem = new CdsServiceClient.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
+            var pickListItem = new ServiceClient.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
 
             var typeEntity = new PickListItem(pickListItem, "entityName", "attributeName");
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Xrm.Sdk.Query;
 using Xunit;
 using System.Linq.Dynamic.Core;
 using FluentValidation;
+using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -775,13 +776,13 @@ namespace GetIntoTeachingApiTests.Services
             return new[] { country1, country2, country3 }.AsQueryable();
         }
 
-        private static IEnumerable<Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem> MockInitialTeacherTrainingYears()
+        private static IEnumerable<ServiceClient.PickListItem> MockInitialTeacherTrainingYears()
         {
-            var year1 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
-            var year2 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
-            var year3 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
+            var year1 = new ServiceClient.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
+            var year2 = new ServiceClient.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
+            var year3 = new ServiceClient.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
 
-            return new List<Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem> { year1, year2, year3 };
+            return new List<ServiceClient.PickListItem> { year1, year2, year3 };
         }
     }
 }


### PR DESCRIPTION
The CdsServiceClient has had a major version bump (we were a major version behind anyway) and the core classes have been renamed to fall inline with the Microsoft PowerPlatform "Dataverse" branding.

Functionality-wise the interfaces remain largely consistent, just a couple of minor updates to the configuration of the client and the method to retrieve the current user (performed in the health check).

I plan on pushing this to dev and doing some full end-to-end testing with each of the clients to ensure everything still works correctly.