### PR TITLE
Revert "Update CdsServiceClient"

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using GetIntoTeachingApi.Utils;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Cds.Client;
 
 namespace GetIntoTeachingApi.Adapters
 {
     public class CdsServiceClientWrapper
     {
-        public readonly ServiceClient CdsServiceClient;
+        public readonly CdsServiceClient CdsServiceClient;
 
         public CdsServiceClientWrapper(IEnv env)
         {
             // We don't want to try and connect to Dynamics when integration testing.
             if (!env.IsTest)
             {
-                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
-                CdsServiceClient = new ServiceClient(ConnectionString(env));
-                CdsServiceClient.MaxRetryCount = 3;
+                CdsServiceClient = new CdsServiceClient(ConnectionString(env));
+                CdsServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
             }
         }
 

--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Adapters
         IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
         IEnumerable<Entity> RetrieveMultiple(QueryBase query);
         void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
-        IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
+        IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
         IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
         OrganizationServiceContext Context();
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Models;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Cds.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -11,18 +11,18 @@ namespace GetIntoTeachingApi.Adapters
 {
     public class OrganizationServiceAdapter : IOrganizationServiceAdapter
     {
-        private readonly ServiceClient _client;
+        private readonly CdsServiceClient _client;
 
         public OrganizationServiceAdapter(IOrganizationService client)
         {
-            _client = (ServiceClient)client;
+            _client = (CdsServiceClient)client;
         }
 
         public string CheckStatus()
         {
             try
             {
-                _client.GetMyUserId();
+                _client.GetMyCdsUserId();
             }
             catch (Exception e)
             {
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApi.Adapters
             return result;
         }
 
-        public IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(
+        public IEnumerable<CdsServiceClient.PickListItem> GetPickListItemsForAttribute(
             string entityName,
             string attributeName)
         {

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -23,6 +23,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.2.1-Alpha" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
@@ -49,7 +50,6 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.1" />
 		<PackageReference Include="GovukNotify" Version="4.0.0" />
 		<PackageReference Include="JWT" Version="7.3.1" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Models/PickListItem.cs
+++ b/GetIntoTeachingApi/Models/PickListItem.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Cds.Client;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public PickListItem(ServiceClient.PickListItem pickListItem, string entityName, string attributeName)
+        public PickListItem(CdsServiceClient.PickListItem pickListItem, string entityName, string attributeName)
         {
             Id = pickListItem.PickListItemId;
             Value = pickListItem.DisplayLabel;

--- a/GetIntoTeachingApiTests/Models/PickListItemTests.cs
+++ b/GetIntoTeachingApiTests/Models/PickListItemTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using FluentAssertions;
 using GetIntoTeachingApi.Models;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Cds.Client;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithPickListItem()
         {
-            var pickListItem = new ServiceClient.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
+            var pickListItem = new CdsServiceClient.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
 
             var typeEntity = new PickListItem(pickListItem, "entityName", "attributeName");
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Xrm.Sdk.Query;
 using Xunit;
 using System.Linq.Dynamic.Core;
 using FluentValidation;
-using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace GetIntoTeachingApiTests.Services
 {
@@ -790,13 +789,13 @@ namespace GetIntoTeachingApiTests.Services
             return new[] { country1, country2, country3 }.AsQueryable();
         }
 
-        private static IEnumerable<ServiceClient.PickListItem> MockInitialTeacherTrainingYears()
+        private static IEnumerable<Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem> MockInitialTeacherTrainingYears()
         {
-            var year1 = new ServiceClient.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
-            var year2 = new ServiceClient.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
-            var year3 = new ServiceClient.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
+            var year1 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
+            var year2 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
+            var year3 = new Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
 
-            return new List<ServiceClient.PickListItem> { year1, year2, year3 };
+            return new List<Microsoft.PowerPlatform.Cds.Client.CdsServiceClient.PickListItem> { year1, year2, year3 };
         }
     }
 }


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#649

On testing the TTA sign up in dev we found this error:

```
Microsoft.Xrm.Sdk.SaveChangesException: An error occured while processing this request.
 ---> Microsoft.PowerPlatform.Dataverse.Client.Utils.DataverseOperationException: Deep update of navigation properties is not allowed.
```

We need to address this before it can be rolled out to production.