### PR TITLE
Make logical name explicit for all EntityReference attributes

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -14,9 +14,9 @@ namespace GetIntoTeachingApi.Models
             Event = 222750003,
         }
 
-        [EntityField("msevtmgt_contactid", typeof(EntityReference))]
+        [EntityField("msevtmgt_contactid", typeof(EntityReference), "contact")]
         public Guid CandidateId { get; set; }
-        [EntityField("msevtmgt_eventid", typeof(EntityReference))]
+        [EntityField("msevtmgt_eventid", typeof(EntityReference), "msevtmgt_event")]
         public Guid EventId { get; set; }
         [EntityField("dfe_channelcreation", typeof(OptionSetValue))]
         public int? ChannelId { get; set; }

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -20,9 +20,9 @@ namespace GetIntoTeachingApiTests.Models
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_eventregistration");
 
             type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "msevtmgt_contactid" && a.Type == typeof(EntityReference));
+                a => a.Name == "msevtmgt_contactid" && a.Type == typeof(EntityReference) && a.Reference == "contact");
             type.GetProperty("EventId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "msevtmgt_eventid" && a.Type == typeof(EntityReference));
+                a => a.Name == "msevtmgt_eventid" && a.Type == typeof(EntityReference) && a.Reference == "msevtmgt_event");
 
             type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));


### PR DESCRIPTION
The old `CdsServiceClient` was able to infer the entity logical name for relationships, however the updated `ServiceClient` doesn't appear to do this and requires the logical name to be explicitly provided. It was already provided in most cases, but a couple of inferred attributes on the `TeachingEventRegistration` was causing issues.