### PR TITLE
Add logging for when UpsertCandidateJob throws

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -61,7 +61,15 @@ namespace GetIntoTeachingApi.Jobs
             }
             else
             {
-                _upserter.Upsert(candidate);
+                try
+                {
+                    _upserter.Upsert(candidate);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError($"UpsertCandidateJob - Exception - {e}");
+                    throw;
+                }
 
                 _logger.LogInformation($"UpsertCandidateJob - Succeeded - {candidate.Id}");
             }


### PR DESCRIPTION
If an error when processing the `UpsertCandidateJob` it will retry 24 times before failing. I would have expected the exception to raise to Sentry, however I think that Hangfire may be swallowing it and the failed jobs are resulting in duplicate records being created in the CRM.

In order to determine if this is the case, we manually catch the exception from the upserter and log it out - re-raising to keep the Hangfire behaviour consistent.

I originally expected these jobs failing to be very edge-casey and so the jobs haven't been made atomic; if it turns out that they fail more often than expected we will need to look into making the jobs atomic, which will be difficult given the number of transactions with the API being made. We will probably need to split each transaction out into a separate job and have them
daisy-chained given the inter-dependencies between the records being created.