### PR TITLE
Tweak telephone validation length

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/CandidateValidator.cs
@@ -19,16 +19,16 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
-            RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(20).Matches(@"^[^a-zA-Z]+$");
+            RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(25).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);
             RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
             RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
             RuleFor(candidate => candidate.ClassroomExperienceNotesRaw).MaximumLength(10000);
-            RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
-            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
-            RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(20).Matches(TelephoneRegex);
+            RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
+            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
+            RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
             RuleFor(candidate => candidate.AddressPostcode)
                 .SetValidator(new PostcodeValidator())
                 .Unless(candidate => candidate.AddressPostcode == null);

--- a/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/CandidateValidatorTests.cs
@@ -290,10 +290,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_TelephoneTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 21));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 21));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 21));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 21));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 26));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 26));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 26));
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 26));
         }
 
         [Fact]


### PR DESCRIPTION
The API formats international numbers to prefix them with `00`, so we require the API validation to be slightly looser than the app validation for telephone numbers; increasing the max length from 20 to 25 should cover it.