### PR TITLE
Conditionally set teaching event sign up attributes

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -80,8 +80,6 @@ namespace GetIntoTeachingApi.Models
             var candidate = new Candidate()
             {
                 Id = CandidateId,
-                ConsiderationJourneyStageId = ConsiderationJourneyStageId,
-                PreferredTeachingSubjectId = PreferredTeachingSubjectId,
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
@@ -92,6 +90,16 @@ namespace GetIntoTeachingApi.Models
                 GdprConsentId = (int)Candidate.GdprConsent.Consent,
                 OptOutOfGdpr = false,
             };
+
+            if (ConsiderationJourneyStageId != null)
+            {
+                candidate.ConsiderationJourneyStageId = ConsiderationJourneyStageId;
+            }
+
+            if (PreferredTeachingSubjectId != null)
+            {
+                candidate.PreferredTeachingSubjectId = PreferredTeachingSubjectId;
+            }
 
             ConfigureChannel(candidate);
             AddTeachingEventRegistration(candidate);

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -120,6 +120,22 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
+        public void Candidate_ConsiderationJourneyStageIdIsNull_DoesNotSet()
+        {
+            var request = new TeachingEventAddAttendee() { ConsiderationJourneyStageId = null };
+
+            request.Candidate.ChangedPropertyNames.Should().NotContain("ConsiderationJourneyStageId");
+        }
+
+        [Fact]
+        public void Candidate_PreferredTeachingSubjectIdIsNull_DoesNotSet()
+        {
+            var request = new TeachingEventAddAttendee() { ConsiderationJourneyStageId = null };
+
+            request.Candidate.ChangedPropertyNames.Should().NotContain("PreferredTeachingSubjectId");
+        }
+
+        [Fact]
         public void Candidate_SubscribeToMailingListIsFalse_ConsentIsCorrect()
         {
             var request = new TeachingEventAddAttendee() { SubscribeToMailingList = false, AddressPostcode = null };


### PR DESCRIPTION
I've not got to the root cause of this bug, but if you sign up for a teaching event then perform a matchback and sign up for another teaching event without opting into the mailing list the API fails to send the sign up through to the CRM. The underlying exception is obscured by another exception raised by the ServiceClient library, so its not clear whats gone wrong.

The cause appears to be sending a `null` option set value for two of the optional properties; as these are optional we can instead not set them at all if they are passed to the API as null, which gets around the error for now. I'll look into raising an issue for the bug in the ServiceClient repo.