### PR TITLE
Updates to international dialing logic

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -75,13 +75,13 @@ namespace GetIntoTeachingApi.Models
             AddressCity = candidate.AddressCity;
             AddressStateOrProvince = candidate.AddressStateOrProvince;
             AddressPostcode = candidate.AddressPostcode;
-            AddressTelephone = candidate.AddressTelephone;
-            Telephone = candidate.Telephone;
+            AddressTelephone = candidate.AddressTelephone.StripExitCode();
+            Telephone = candidate.Telephone.StripExitCode();
+            MobileTelephone = candidate.MobileTelephone.StripExitCode();
 
-            var secondaryTelephoneDefaults = new List<string> { candidate.MobileTelephone, candidate.AddressTelephone, candidate.Telephone };
-            SecondaryTelephone = candidate.SecondaryTelephone ?? secondaryTelephoneDefaults.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+            var secondaryTelephoneDefaults = new List<string> { MobileTelephone, AddressTelephone, Telephone };
+            SecondaryTelephone = candidate.SecondaryTelephone.StripExitCode() ?? secondaryTelephoneDefaults.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
 
-            MobileTelephone = candidate.MobileTelephone;
             HasDbsCertificate = candidate.HasDbsCertificate;
             DbsCertificateIssuedAt = candidate.DbsCertificateIssuedAt;
         }

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Swashbuckle.AspNetCore.Annotations;
@@ -10,8 +9,6 @@ namespace GetIntoTeachingApi.Models
 {
     public class TeacherTrainingAdviserSignUp
     {
-        private string _addressTelephone;
-
         public Guid? CandidateId { get; set; }
         public Guid? QualificationId { get; set; }
         public Guid? SubjectTaughtId { get; set; }
@@ -38,17 +35,7 @@ namespace GetIntoTeachingApi.Models
         public DateTime? DateOfBirth { get; set; }
         public string TeacherId { get; set; }
         public string DegreeSubject { get; set; }
-        public string AddressTelephone
-        {
-            get
-            {
-                return SanitizeTelephone(_addressTelephone);
-            }
-            set
-            {
-                _addressTelephone = value;
-            }
-        }
+        public string AddressTelephone { get; set; }
 
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }
@@ -63,6 +50,8 @@ namespace GetIntoTeachingApi.Models
         public Candidate Candidate => CreateCandidate();
         [JsonIgnore]
         public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
+        [JsonIgnore]
+        private bool IsOverseas => CountryId != LookupItem.UnitedKingdomCountryId;
 
         public TeacherTrainingAdviserSignUp()
         {
@@ -99,7 +88,7 @@ namespace GetIntoTeachingApi.Models
             LastName = candidate.LastName;
             DateOfBirth = candidate.DateOfBirth;
             TeacherId = candidate.TeacherId;
-            AddressTelephone = candidate.AddressTelephone;
+            AddressTelephone = candidate.AddressTelephone.StripExitCode();
             AddressLine1 = candidate.AddressLine1;
             AddressLine2 = candidate.AddressLine2;
             AddressCity = candidate.AddressCity;
@@ -143,7 +132,7 @@ namespace GetIntoTeachingApi.Models
                 AddressLine2 = AddressLine2,
                 AddressCity = AddressCity,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                AddressTelephone = AddressTelephone,
+                AddressTelephone = AddressTelephone.AsFormattedTelephone(IsOverseas),
                 TeacherId = TeacherId,
                 TypeId = TypeId,
                 InitialTeacherTrainingYearId = InitialTeacherTrainingYearId,
@@ -176,25 +165,6 @@ namespace GetIntoTeachingApi.Models
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow);
 
             return candidate;
-        }
-
-        private string SanitizeTelephone(string telephone)
-        {
-            var international = CountryId != LookupItem.UnitedKingdomCountryId;
-
-            if (international && telephone != null)
-            {
-                // Remove non-digit characters.
-                telephone = Regex.Replace(telephone, "[^0-9]", string.Empty);
-
-                // Prefix the 00 exit code.
-                telephone = $"00{telephone}";
-
-                // Replace UK dial-in code with a 0.
-                telephone = Regex.Replace(telephone, "^00440?", "0");
-            }
-
-            return telephone;
         }
 
         private void ConfigureChannel(Candidate candidate)
@@ -265,7 +235,7 @@ namespace GetIntoTeachingApi.Models
                 candidate.EligibilityRulesPassed = "true";
                 candidate.PhoneCall = new PhoneCall()
                 {
-                    Telephone = AddressTelephone,
+                    Telephone = candidate.AddressTelephone,
                     DestinationId = TelephoneDestination(),
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.CallbackRequest,
@@ -321,9 +291,7 @@ namespace GetIntoTeachingApi.Models
                 return null;
             }
 
-            var international = CountryId != LookupItem.UnitedKingdomCountryId;
-
-            return international ? (int)PhoneCall.Destination.International : (int)PhoneCall.Destination.Uk;
+            return IsOverseas ? (int)PhoneCall.Destination.International : (int)PhoneCall.Destination.Uk;
         }
 
         private bool ContainsQualification()

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs
@@ -191,7 +191,7 @@ namespace GetIntoTeachingApi.Models
                 telephone = $"00{telephone}";
 
                 // Replace UK dial-in code with a 0.
-                telephone = Regex.Replace(telephone, "^0044", "0");
+                telephone = Regex.Replace(telephone, "^00440?", "0");
             }
 
             return telephone;

--- a/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventAddAttendee.cs
@@ -68,7 +68,7 @@ namespace GetIntoTeachingApi.Models
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
-            AddressTelephone = candidate.AddressTelephone;
+            AddressTelephone = candidate.AddressTelephone.StripExitCode();
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;

--- a/GetIntoTeachingApi/Utils/StringExtensions.cs
+++ b/GetIntoTeachingApi/Utils/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Models;
+﻿using System.Text.RegularExpressions;
+using GetIntoTeachingApi.Models;
 
 namespace GetIntoTeachingApi.Utils
 {
@@ -14,6 +15,33 @@ namespace GetIntoTeachingApi.Utils
             }
 
             return str.ToUpper().Insert(str.Length - Location.InwardPostcodeLength, " ");
+        }
+
+        public static string StripExitCode(this string str)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+
+            return Regex.Replace(str, "^00", string.Empty);
+        }
+
+        public static string AsFormattedTelephone(this string str, bool international)
+        {
+            if (international && str != null)
+            {
+                // Remove non-digit characters.
+                str = Regex.Replace(str, "[^0-9]", string.Empty);
+
+                // Prefix the 00 exit code.
+                str = $"00{str}";
+
+                // Replace UK dial-in code with a 0.
+                str = Regex.Replace(str, "^00440?", "0");
+            }
+
+            return str;
         }
 
         public static string NullIfEmptyOrWhitespace(this string str)

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -28,10 +28,10 @@ namespace GetIntoTeachingApiTests.Models
                 AddressCity = "City",
                 AddressStateOrProvince = "County",
                 AddressPostcode = "KY11 9YU",
-                AddressTelephone = "123456789",
-                Telephone = "234567890",
-                SecondaryTelephone = "345678901",
-                MobileTelephone = "456789012",
+                AddressTelephone = "00123456789",
+                Telephone = "00234567890",
+                SecondaryTelephone = "00345678901",
+                MobileTelephone = "00456789012",
                 HasDbsCertificate = true,
                 DbsCertificateIssuedAt = DateTime.UtcNow,
             };
@@ -48,17 +48,16 @@ namespace GetIntoTeachingApiTests.Models
             response.FullName.Should().Be(candidate.FullName);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
-            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
             response.AddressLine1.Should().Be(candidate.AddressLine1);
             response.AddressLine2.Should().Be(candidate.AddressLine2);
             response.AddressLine3.Should().Be(candidate.AddressLine3);
             response.AddressCity.Should().Be(candidate.AddressCity);
             response.AddressStateOrProvince.Should().Be(candidate.AddressStateOrProvince);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
-            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
-            response.Telephone.Should().Be(candidate.Telephone);
-            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
-            response.MobileTelephone.Should().Be(candidate.MobileTelephone);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
+            response.Telephone.Should().Be(candidate.Telephone[2..]);
+            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone[2..]);
+            response.MobileTelephone.Should().Be(candidate.MobileTelephone[2..]);
             response.HasDbsCertificate.Should().Be(candidate.HasDbsCertificate);
             response.DbsCertificateIssuedAt.Should().Be(candidate.DbsCertificateIssuedAt);
         }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -61,7 +61,7 @@ namespace GetIntoTeachingApiTests.Models
                 FirstName = "John",
                 LastName = "Doe",
                 DateOfBirth = DateTime.UtcNow,
-                AddressTelephone = "1234567",
+                AddressTelephone = "001234567",
                 TeacherId = "abc123",
                 AddressLine1 = "Address 1",
                 AddressLine2 = "Address 2",
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApiTests.Models
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.TeacherId.Should().Be(candidate.TeacherId);
-            response.AddressTelephone.Should().Be($"00{candidate.AddressTelephone}");
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
             response.AddressLine1.Should().Be(candidate.AddressLine1);
             response.AddressLine2.Should().Be(candidate.AddressLine2);
             response.AddressCity.Should().Be(candidate.AddressCity);
@@ -116,7 +116,7 @@ namespace GetIntoTeachingApiTests.Models
                 SubjectTaughtId = Guid.NewGuid(),
                 PastTeachingPositionId = Guid.NewGuid(),
                 PreferredTeachingSubjectId = Guid.NewGuid(),
-                CountryId = LookupItem.UnitedKingdomCountryId,
+                CountryId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 UkDegreeGradeId = 0,
@@ -164,7 +164,7 @@ namespace GetIntoTeachingApiTests.Models
             candidate.LastName.Should().Be(request.LastName);
             candidate.DateOfBirth.Should().Be(request.DateOfBirth);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
+            candidate.AddressTelephone.Should().Be("00" + request.AddressTelephone);
             candidate.TeacherId.Should().Be(request.TeacherId);
             candidate.AddressLine1.Should().Be(request.AddressLine1);
             candidate.AddressLine2.Should().Be(request.AddressLine2);
@@ -187,9 +187,9 @@ namespace GetIntoTeachingApiTests.Models
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
-            candidate.PhoneCall.Telephone.Should().Be(request.AddressTelephone);
+            candidate.PhoneCall.Telephone.Should().Be("00" + request.AddressTelephone);
             candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
-            candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
+            candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.International);
             candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
 
             candidate.PastTeachingPositions.First().Id.Should().Be(request.PastTeachingPositionId);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviserSignUpTests.cs
@@ -436,6 +436,7 @@ namespace GetIntoTeachingApiTests.Models
         [InlineData("+818495394", "00818495394")]
         [InlineData("+(81) 849 5394", "00818495394")]
         [InlineData("+44756483443", "0756483443")]
+        [InlineData("+440756483443", "0756483443")]
         public void PhoneCallScheduledAt_InternationalCallback_IsSanitized(string input, string expected)
         {
             var request = new TeacherTrainingAdviserSignUp()

--- a/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventAddAttendeeTests.cs
@@ -34,7 +34,7 @@ namespace GetIntoTeachingApiTests.Models
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
-                AddressTelephone = "1234567",
+                AddressTelephone = "001234567",
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
@@ -49,7 +49,7 @@ namespace GetIntoTeachingApiTests.Models
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
-            response.AddressTelephone.Should().Be(candidate.AddressTelephone);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
 
             response.QualificationId.Should().Be(latestQualification.Id);

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -30,5 +30,27 @@ namespace GetIntoTeachingApiTests.Utils
         {
             input.NullIfEmptyOrWhitespace().Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData("001234567", "1234567")]
+        [InlineData("0001234567", "01234567")]
+        [InlineData("1234567", "1234567")]
+        [InlineData(null, null)]
+        public void StripExitCode_ReturnsCorrectly(string input, string expected)
+        {
+            input.StripExitCode().Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("(65).234.543.435", "0065234543435", true)]
+        [InlineData("+818495394", "00818495394", true)]
+        [InlineData("+(81) 849 5394", "00818495394", true)]
+        [InlineData("+44756483443", "0756483443", true)]
+        [InlineData("+440756483443", "0756483443", true)]
+        [InlineData("07584758473", "07584758473", false)]
+        public void AsFormattedTelephone_IsSanitizedCorrectly(string input, string expected, bool international)
+        {
+            input.AsFormattedTelephone(international).Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
- Support malformed UK numbers

If a candidate enters a UK phone number with a dial-in code and leading 0 it currently fails to dial; we can instead account for this and remove the leading 0 if present with a UK dialing code.

- Strip exit code before serving existing sign ups

If a candidate already exists in the system its likely that we will have transformed their telephone number into a format that is dialable by TPUK's telephone system. This means it will be prefixed with a `00` exit code. As we don't want the user to have to put in the exit code manually we expect their country dial-in code at the start of the telephone instead. We need to
therefore strip the `00` exit code from any responses that are subsequently used to pre-fill a form.

Reworks the telephone sanitisation to pull it into a string extension so that we can more easily reuse it elsewhere.