### PR TITLE
Link event to building by ID only when saving in the CRM

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -195,6 +195,8 @@ namespace GetIntoTeachingApi.Controllers
                 return apiBehaviorOptions.Value.InvalidModelStateResponseFactory(ControllerContext);
             }
 
+            var tempBuilding = teachingEvent.Building;
+
             // Save independently so that the building gets an Id populated immediately.
             // We also persist in the cache so it is immediately available.
             if (teachingEvent.Building != null)
@@ -202,9 +204,11 @@ namespace GetIntoTeachingApi.Controllers
                 _crm.Save(teachingEvent.Building);
                 await _store.SaveAsync(new TeachingEventBuilding[] { teachingEvent.Building });
                 teachingEvent.BuildingId = teachingEvent.Building.Id;
+                teachingEvent.Building = null;
             }
 
             _crm.Save(teachingEvent);
+            teachingEvent.Building = tempBuilding;
             await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
 
             return CreatedAtAction(


### PR DESCRIPTION
We were getting the following error when upserting events and buildings due to the recent update of the Dataverse client: 

`The resource reference navigation property 'msevtmgt_building' has both the 'odata.bind' property annotation as well as a value`

As a quick fix, set the building to null before saving the event in the CRM.