### PR TITLE
Don't set null option set values on SE sign up

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperienceSignUp.cs
@@ -91,8 +91,6 @@ namespace GetIntoTeachingApi.Models
             var candidate = new Candidate()
             {
                 Id = CandidateId,
-                PreferredTeachingSubjectId = PreferredTeachingSubjectId,
-                SecondaryPreferredTeachingSubjectId = SecondaryPreferredTeachingSubjectId,
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 Email = Email,
                 SecondaryEmail = SecondaryEmail,
@@ -112,6 +110,16 @@ namespace GetIntoTeachingApi.Models
                 HasDbsCertificate = HasDbsCertificate,
                 DbsCertificateIssuedAt = DbsCertificateIssuedAt,
             };
+
+            if (PreferredTeachingSubjectId != null)
+            {
+                candidate.PreferredTeachingSubjectId = PreferredTeachingSubjectId;
+            }
+
+            if (SecondaryPreferredTeachingSubjectId != null)
+            {
+                candidate.SecondaryPreferredTeachingSubjectId = SecondaryPreferredTeachingSubjectId;
+            }
 
             ConfigureChannel(candidate);
             AcceptPrivacyPolicy(candidate);

--- a/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperienceSignUpTests.cs
@@ -186,5 +186,21 @@ namespace GetIntoTeachingApiTests.Models
 
             request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
         }
+
+        [Fact]
+        public void Candidate_WhenPreferredTeachingSubjectIdIsNull_DoesNotChange()
+        {
+            var request = new SchoolsExperienceSignUp() { PreferredTeachingSubjectId = null };
+
+            request.Candidate.ChangedPropertyNames.Should().NotContain("PreferredTeachingSubjectId");
+        }
+
+        [Fact]
+        public void Candidate_WhenSecondaryPreferredTeachingSubjectIdIsNull_DoesNotChange()
+        {
+            var request = new SchoolsExperienceSignUp() { SecondaryPreferredTeachingSubjectId = null };
+
+            request.Candidate.ChangedPropertyNames.Should().NotContain("SecondaryPreferredTeachingSubjectId");
+        }
     }
 }


### PR DESCRIPTION
There is a bug in the updated `CdsServiceClient` that results in an error if you try and set a `null` `OptionSet` attribute against an existing record; instead, we can just not set the value and it will remain unchanged in the CRM, which is a more desirable outcome anyway.