### PR TITLE
Split CandidateUpserter into multiple, atomic jobs

### DIFF
--- a/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
+++ b/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class ClaimCallbackBookingSlotJob : BaseJob
+    {
+        private readonly IPerformContextAdapter _contextAdapter;
+        private readonly IMetricService _metrics;
+        private readonly IAppSettings _appSettings;
+        private readonly ICrmService _crm;
+        private readonly ILogger<ClaimCallbackBookingSlotJob> _logger;
+
+        public ClaimCallbackBookingSlotJob(
+            IEnv env,
+            IPerformContextAdapter contextAdapter,
+            ICrmService crm,
+            IMetricService metrics,
+            ILogger<ClaimCallbackBookingSlotJob> logger,
+            IAppSettings appSettings)
+            : base(env)
+        {
+            _contextAdapter = contextAdapter;
+            _metrics = metrics;
+            _logger = logger;
+            _appSettings = appSettings;
+            _crm = crm;
+        }
+
+        public void Run(DateTime scheduledAt, PerformContext context)
+        {
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException("ClaimCallbackBookingSlotJob - Aborting (CRM integration paused).");
+            }
+
+            _logger.LogInformation($"ClaimCallbackBookingSlotJob - Started ({AttemptInfo(context, _contextAdapter)})");
+            _logger.LogInformation($"ClaimCallbackBookingSlotJob - Payload {scheduledAt}");
+
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                // Not critical, they'll still get a call but it may be at a different time
+                // so we can just let the job expire.
+                _logger.LogInformation($"ClaimCallbackBookingSlotJob - Deleted");
+            }
+            else
+            {
+                var quota = _crm.GetCallbackBookingQuota(scheduledAt);
+
+                if (quota != null && quota.IsAvailable)
+                {
+                    quota.NumberOfBookings += 1;
+                    _crm.Save(quota);
+                }
+
+                _logger.LogInformation($"ClaimCallbackBookingSlotJob - Succeeded - {scheduledAt}");
+            }
+
+            var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"ClaimCallbackBookingSlotJob" }).Observe(duration);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -61,15 +61,7 @@ namespace GetIntoTeachingApi.Jobs
             }
             else
             {
-                try
-                {
-                    _upserter.Upsert(candidate);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError($"UpsertCandidateJob - Exception - {e}");
-                    throw;
-                }
+                _upserter.Upsert(candidate);
 
                 _logger.LogInformation($"UpsertCandidateJob - Succeeded - {candidate.Id}");
             }

--- a/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class UpsertModelJob<T> : BaseJob
+        where T : BaseModel, IHasCandidateId
+    {
+        private readonly IPerformContextAdapter _contextAdapter;
+        private readonly IMetricService _metrics;
+        private readonly IAppSettings _appSettings;
+        private readonly INotifyService _notifyService;
+        private readonly ICrmService _crm;
+        private readonly ILogger<UpsertModelJob<T>> _logger;
+
+        public UpsertModelJob(
+            IEnv env,
+            IPerformContextAdapter contextAdapter,
+            ICrmService crm,
+            IMetricService metrics,
+            ILogger<UpsertModelJob<T>> logger,
+            IAppSettings appSettings,
+            INotifyService notifyService)
+            : base(env)
+        {
+            _contextAdapter = contextAdapter;
+            _metrics = metrics;
+            _logger = logger;
+            _appSettings = appSettings;
+            _crm = crm;
+            _notifyService = notifyService;
+        }
+
+        public void Run(string json, PerformContext context)
+        {
+            var typeName = typeof(T).Name;
+
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException($"UpsertModelJob<{typeName}> - Aborting (CRM integration paused).");
+            }
+
+            _logger.LogInformation($"UpsertModelJob<{typeName}> - Started ({AttemptInfo(context, _contextAdapter)})");
+            _logger.LogInformation($"UpsertModelJob<{typeName}> - Payload {Redactor.RedactJson(json)}");
+
+            var model = json.DeserializeChangeTracked<T>();
+
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                var candidate = _crm.GetCandidate(model.CandidateId);
+
+                if (candidate != null)
+                {
+                    var personalisation = new Dictionary<string, dynamic>();
+
+                    // We fire and forget the email, ensuring the job succeeds.
+                    _notifyService.SendEmailAsync(
+                        candidate.Email,
+                        NotifyService.SignUpPartiallyFailedTemplateId,
+                        personalisation);
+                }
+
+                _logger.LogInformation($"UpsertModelJob<{typeName}> - Deleted");
+            }
+            else
+            {
+                _crm.Save(model);
+
+                _logger.LogInformation($"UpsertModelJob<{typeName}> - Succeeded - {model.Id}");
+            }
+
+            var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"UpsertModelJob<{typeName}>" }).Observe(duration);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -7,7 +7,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("dfe_candidatepastteachingposition")]
-    public class CandidatePastTeachingPosition : BaseModel
+    public class CandidatePastTeachingPosition : BaseModel, IHasCandidateId
     {
         public enum EducationPhase
         {

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -7,7 +7,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("dfe_candidateprivacypolicy")]
-    public class CandidatePrivacyPolicy : BaseModel
+    public class CandidatePrivacyPolicy : BaseModel, IHasCandidateId
     {
         public const int Consent = 222750001;
 

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -7,7 +7,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("dfe_candidatequalification")]
-    public class CandidateQualification : BaseModel
+    public class CandidateQualification : BaseModel, IHasCandidateId
     {
         public enum DegreeStatus
         {

--- a/GetIntoTeachingApi/Models/IHasCandidateId.cs
+++ b/GetIntoTeachingApi/Models/IHasCandidateId.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Models
+{
+    public interface IHasCandidateId
+    {
+        public Guid CandidateId { get; }
+    }
+}

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
@@ -7,7 +8,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("phonecall")]
-    public class PhoneCall : BaseModel
+    public class PhoneCall : BaseModel, IHasCandidateId
     {
         public enum Channel
         {
@@ -38,6 +39,7 @@ namespace GetIntoTeachingApi.Models
         public bool AppointmentRequired { get; set; } = false;
         [EntityField("directioncode")]
         public bool IsDirectionCode { get; set; } = true;
+        Guid IHasCandidateId.CandidateId { get => new Guid(CandidateId); }
 
         public PhoneCall()
             : base()

--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -7,7 +7,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("msevtmgt_eventregistration")]
-    public class TeachingEventRegistration : BaseModel
+    public class TeachingEventRegistration : BaseModel, IHasCandidateId
     {
         public enum Channel
         {

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Services
         public const string CandidateRegistrationFailedEmailTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
         public const string TeachingEventRegistrationFailedEmailTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
         public const string MailingListAddMemberFailedEmailTemplateId = "4b3653b4-e524-42b8-bfed-201cb6bb8a25";
+        public const string SignUpPartiallyFailedTemplateId = "26402650-942d-4d6a-84dc-fe5cfdfb501c";
         private readonly ILogger<NotifyService> _logger;
         private readonly INotificationClientAdapter _client;
         private readonly IEnv _env;

--- a/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class ClaimCallbackBookingSlotJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<IAppSettings> _mockAppSettings;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly DateTime _scheduledAt;
+        private readonly IMetricService _metrics;
+        private readonly ClaimCallbackBookingSlotJob _job;
+        private readonly Mock<ILogger<ClaimCallbackBookingSlotJob>> _mockLogger;
+
+        public ClaimCallbackBookingSlotJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockLogger = new Mock<ILogger<ClaimCallbackBookingSlotJob>>();
+            _mockAppSettings = new Mock<IAppSettings>();
+            _mockCrm = new Mock<ICrmService>();
+            _metrics = new MetricService();
+            _scheduledAt = DateTime.UtcNow;
+            _job = new ClaimCallbackBookingSlotJob(
+                new Env(), _mockContext.Object, _mockCrm.Object, _metrics, _mockLogger.Object, _mockAppSettings.Object);
+
+            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "ClaimCallbackBookingSlotJob" });
+            _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
+
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        }
+
+        [Fact]
+        public void Run_OnSuccess_IncrementsNumberOfBookings()
+        {
+            var quota = new CallbackBookingQuota() { NumberOfBookings = 3, Quota = 10 };
+
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+            _mockCrm.Setup(m => m.GetCallbackBookingQuota(_scheduledAt)).Returns(quota);
+
+            _job.Run(_scheduledAt, null);
+
+            quota.NumberOfBookings.Should().Be(4);
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<CallbackBookingQuota>(q => IsMatch(quota, q))), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("ClaimCallbackBookingSlotJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled($"ClaimCallbackBookingSlotJob - Payload {_scheduledAt}");
+            _mockLogger.VerifyInformationWasCalled($"ClaimCallbackBookingSlotJob - Succeeded - {_scheduledAt}");
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "ClaimCallbackBookingSlotJob" }).Count.Should().Be(1);
+        }
+
+
+        [Fact]
+        public void Run_OnCallbackBookingNotAvailable_DoesNotIncrementNumberOfBookings()
+        {
+            var quota = new CallbackBookingQuota() { NumberOfBookings = 3, Quota = 3 };
+
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+            _mockCrm.Setup(m => m.GetCallbackBookingQuota(_scheduledAt)).Returns(quota);
+
+            _job.Run(_scheduledAt, null);
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<CallbackBookingQuota>(q => IsMatch(quota, q))), Times.Never);
+        }
+
+        [Fact]
+        public void Run_OnCallbackBookingNotFound_DoesNotIncrementNumberOfBookings()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+            _mockCrm.Setup(m => m.GetCallbackBookingQuota(_scheduledAt)).Returns<CallbackBookingQuota>(null);
+
+            _job.Run(_scheduledAt, null);
+
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<CallbackBookingQuota>()), Times.Never);
+        }
+
+        [Fact]
+        public void Run_WhenCrmIntegrationPaused_Aborts()
+        {
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+
+            Action action = () => _job.Run(_scheduledAt, null);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("ClaimCallbackBookingSlotJob - Aborting (CRM integration paused).");
+        }
+
+        private bool IsMatch(object objectA, object objectB)
+        {
+            objectA.Should().BeEquivalentTo(objectB);
+            return true;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -73,20 +73,6 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_OnError_LogsAndReRaises()
-        {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
-            var message = "boom!";
-            var exception = new Exception(message);
-            _mockUpserter.Setup(m => m.Upsert(It.IsAny<Candidate>())).Throws(exception);
-
-            _job.Invoking(j => j.Run(_candidate.SerializeChangeTracked(), null))
-                .Should().Throw<Exception>().WithMessage(message);
-
-            _mockLogger.VerifyErrorWasCalled($"UpsertCandidateJob - Exception - System.Exception: {message}");
-        }
-
-        [Fact]
         public void Run_WhenCrmIntegrationPaused_Aborts()
         {
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);

--- a/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class UpsertModelJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<IAppSettings> _mockAppSettings;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<INotifyService> _mockNotifyService;
+        private readonly CandidatePrivacyPolicy _policy;
+        private readonly IMetricService _metrics;
+        private readonly UpsertModelJob<CandidatePrivacyPolicy> _job;
+        private readonly Mock<ILogger<UpsertModelJob<CandidatePrivacyPolicy>>> _mockLogger;
+
+        public UpsertModelJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockLogger = new Mock<ILogger<UpsertModelJob<CandidatePrivacyPolicy>>>();
+            _mockAppSettings = new Mock<IAppSettings>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockNotifyService = new Mock<INotifyService>();
+            _metrics = new MetricService();
+            _policy = new CandidatePrivacyPolicy() { Id = Guid.NewGuid(), AcceptedAt = DateTime.UtcNow, CandidateId = Guid.NewGuid() };
+            _job = new UpsertModelJob<CandidatePrivacyPolicy>(
+                new Env(), _mockContext.Object, _mockCrm.Object, _metrics, _mockLogger.Object, _mockAppSettings.Object, _mockNotifyService.Object);
+
+            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" });
+            _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
+
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        }
+
+        [Fact]
+        public void Run_OnSuccess_UpsertsModel()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            var json = _policy.SerializeChangeTracked();
+            _job.Run(json, null);
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<CandidatePrivacyPolicy>(p => IsMatch(_policy, p))), Times.Once);
+            _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled($"UpsertModelJob<CandidatePrivacyPolicy> - Payload {Redactor.RedactJson(json)}");
+            _mockLogger.VerifyInformationWasCalled($"UpsertModelJob<CandidatePrivacyPolicy> - Succeeded - {_policy.Id}");
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" }).Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Run_OnFailure_EmailsCandidate()
+        {
+            var candidate = new Candidate() { Id = _policy.CandidateId, Email = "email@address.com" };
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
+            _mockCrm.Setup(m => m.GetCandidate((Guid)candidate.Id)).Returns(candidate);
+
+            _job.Run(_policy.SerializeChangeTracked(), null);
+
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<CandidatePrivacyPolicy>()), Times.Never);
+
+            _mockNotifyService.Verify(mock => mock.SendEmailAsync(candidate.Email,
+                NotifyService.SignUpPartiallyFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+            _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Started (24/24)");
+            _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Deleted");
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" }).Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Run_WhenCrmIntegrationPaused_Aborts()
+        {
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+
+            var json = _policy.SerializeChangeTracked();
+            Action action = () => _job.Run(json, null);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("UpsertModelJob<CandidatePrivacyPolicy> - Aborting (CRM integration paused).");
+        }
+
+        private bool IsMatch(object objectA, object objectB)
+        {
+            objectA.Should().BeEquivalentTo(objectB);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
[Trello-1627](https://trello.com/c/3B2nts1i/1627-split-upsertcandidatejob)

- Add job to claim a callback booking quota slot

When someone books a callback we need to ensure the callback booking slot they select has its available slots decremented. Currently we do this in the `UpsertCandidateJob`, but this commit adds a new job to perform this function.

- Add generic UpsertModelJob

As we are splitting the `UpsertCandidateJob` into multiple independent jobs we need to be able to upsert a variety of records that have a `CandidateId` (are related to a candidate). This commit adds an `UpsertModelJob` that can take any `BaseModel` implementing `IHasCandidateId` and upsert it to the CRM.

Update applicable models to implement the new interface.

- Have CandidateUpserter queue jobs for sub-tasks

The main purpose of the `CandidateUpserter` is to upsert a `Candidate` record. As a by-product it also supports upserting all the objects related to a candidate, such as accepted privacy policy, qualifications, phone calls etc.

Currently this is all done in the `CandidateUpserter`, however as this is all wrapped in a single job if any part fails and it retries it could cause a duplicate record to be created.

To get around this, the `CandidateUpserter` is updated to queue more jobs for each upsert sub-task (once the candidate is successfully upserted). This way, if anything fails its retried independently and duplicates should be avoided.

Remove catch and re-raise; it doesn't seem to be necessary, Sentry is picking up the exceptions already.