### PR TITLE
On match back failure log error to Sentry

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Sentry;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -69,6 +70,7 @@ namespace GetIntoTeachingApi.Controllers
             }
             catch (Exception e)
             {
+                SentrySdk.CaptureException(e);
                 _logger.LogInformation($"CandidatesController - potential duplicate (CRM exception) - {e.Message}");
             }
 


### PR DESCRIPTION
If the CRM is down/throws any kind of exception we currently swallow it and return 404, so the user can continue as a new candidate. Instead, we want to raise the error to Sentry so we don't loose sight of it (if there is a bug in the matchback query, for example).