### PR TITLE
Apply rate limiting to event upsert endpoint

### DIFF
--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -62,6 +62,11 @@
             "Endpoint": "POST:/api/teaching_events/attendees",
             "Period": "1m",
             "Limit": 250
+          },
+          {
+            "Endpoint": "POST:/api/teaching_events",
+            "Period": "1d",
+            "Limit": 100
           }
         ]
       },

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -33,6 +33,7 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/candidates/access_tokens", "GIT", 500)]
         [InlineData("/api/mailing_list/members", "GIT", 250)]
         [InlineData("/api/teaching_events/attendees", "GIT", 250)]
+        [InlineData("/api/teaching_events", "GIT", 100)]
         [InlineData("/api/candidates/access_tokens", "TTA", 500)]
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
         [InlineData("/api/candidates/access_tokens", "SE", 500)]


### PR DESCRIPTION
The CRM team requested that rate limiting is applied to the upsert endpoint for additional security. It is unlikely that more than 100 events will be created in 1 day.