### PR TITLE
Enable the GiT app to book callbacks

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
+{
+    [Route("api/get_into_teaching/callbacks")]
+    [ApiController]
+    [Authorize(Roles = "Admin,GetIntoTeaching")]
+    public class CallbacksController : ControllerBase
+    {
+        private readonly ICandidateAccessTokenService _tokenService;
+        private readonly ICrmService _crm;
+        private readonly IDateTimeProvider _dateTime;
+        private readonly IBackgroundJobClient _jobClient;
+
+        public CallbacksController(
+                    ICandidateAccessTokenService tokenService,
+                    ICrmService crm,
+                    IDateTimeProvider dateTime,
+                    IBackgroundJobClient jobClient)
+        {
+            _crm = crm;
+            _dateTime = dateTime;
+            _tokenService = tokenService;
+            _jobClient = jobClient;
+        }
+
+        [HttpPost]
+        [SwaggerOperation(
+            Summary = "Schedule a callback for the candidate.",
+            Description = "Validation errors may be present on the `GetIntoTeachingCallback` object as " +
+                          "well as the hidden `Candidate` model that is mapped to; property names are " +
+                          "consistent, so you should check for inclusion of the field in the key " +
+                          "when linking an error message back to a property on the request model. For " +
+                          "example, an error on `AddressTelephone` can return under the keys " +
+                          "`Candidate.AddressTelephone` and `AddressTelephone`.",
+            OperationId = "BookGetIntoTeachingCallback",
+            Tags = new[] { "Get into Teaching" })]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
+        public IActionResult Book(
+            [FromBody, SwaggerRequestBody("Candidate to book a callback for.", Required = true)] GetIntoTeachingCallback request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // This is the only way we can mock/freeze the current date/time
+            // in contract tests (there's no other way to inject it into this class).
+            request.DateTimeProvider = _dateTime;
+            string json = request.Candidate.SerializeChangeTracked();
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("exchange_access_token/{accessToken}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a pre-populated GetIntoTeachingCallback for the candidate.",
+            Description = @"
+                        Retrieves a pre-populated GetIntoTeachingCallback for the candidate. The `accessToken` is obtained from a 
+                        `POST /candidates/access_tokens` request (you must also ensure the `ExistingCandidateRequest` payload you 
+                        exchanged for your token matches the request payload here).",
+            OperationId = "ExchangeAccessTokenForGetIntoTeachingCallback",
+            Tags = new[] { "Get into Teaching" })]
+        [ProducesResponseType(typeof(GetIntoTeachingCallback), StatusCodes.Status200OK)]
+        public IActionResult ExchangeAccessToken(
+            [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
+            [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
+        {
+            var candidate = _crm.MatchCandidate(request);
+
+            if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new GetIntoTeachingCallback(candidate));
+        }
+    }
+}

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -60,6 +60,10 @@
 	  <Folder Include="Mocks\" />
 	  <Folder Include="Middleware\" />
 	  <Folder Include="Controllers\SchoolsExperience\" />
+	  <Folder Include="Controllers\GetIntoTeaching\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Remove="Controllers\GetIntoTeaching\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -82,6 +82,7 @@ namespace GetIntoTeachingApi.Models
             Event = 222750029,
             TeacherTrainingAdviser = 222750027,
             SchoolsExperience = 222750021,
+            GetIntoTeachingCallback = 222750043,
         }
 
         public enum GcseStatus

--- a/GetIntoTeachingApi/Models/GetIntoTeachingCallback.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeachingCallback.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class GetIntoTeachingCallback
+    {
+        public Guid? CandidateId { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
+        public Guid? AcceptedPolicyId { get; set; }
+
+        public string Email { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string AddressTelephone { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
+        public DateTime? PhoneCallScheduledAt { get; set; }
+
+        [JsonIgnore]
+        public Candidate Candidate => CreateCandidate();
+        [JsonIgnore]
+        public IDateTimeProvider DateTimeProvider { get; set; } = new DateTimeProvider();
+
+        public GetIntoTeachingCallback()
+        {
+        }
+
+        public GetIntoTeachingCallback(Candidate candidate)
+        {
+            PopulateWithCandidate(candidate);
+        }
+
+        private void PopulateWithCandidate(Candidate candidate)
+        {
+            CandidateId = candidate.Id;
+
+            Email = candidate.Email;
+            FirstName = candidate.FirstName;
+            LastName = candidate.LastName;
+            AddressTelephone = candidate.AddressTelephone.StripExitCode();
+        }
+
+        private Candidate CreateCandidate()
+        {
+            var candidate = new Candidate()
+            {
+                Id = CandidateId,
+                Email = Email,
+                FirstName = FirstName,
+                LastName = LastName,
+                AddressTelephone = AddressTelephone,
+            };
+
+            ConfigureChannel(candidate);
+            SchedulePhoneCall(candidate);
+            AcceptPrivacyPolicy(candidate);
+
+            return candidate;
+        }
+
+        private void SchedulePhoneCall(Candidate candidate)
+        {
+            if (PhoneCallScheduledAt != null)
+            {
+                candidate.PhoneCall = new PhoneCall()
+                {
+                    Telephone = candidate.AddressTelephone,
+                    DestinationId = (int)PhoneCall.Destination.Uk,
+                    ScheduledAt = (DateTime)PhoneCallScheduledAt,
+                    ChannelId = (int)PhoneCall.Channel.CallbackRequest,
+                    Subject = $"Scheduled phone call requested by {candidate.FullName}",
+                };
+            }
+        }
+
+        private void ConfigureChannel(Candidate candidate)
+        {
+            if (CandidateId == null)
+            {
+                candidate.ChannelId = (int?)Candidate.Channel.GetIntoTeachingCallback;
+            }
+        }
+
+        private void AcceptPrivacyPolicy(Candidate candidate)
+        {
+            if (AcceptedPolicyId != null)
+            {
+                candidate.PrivacyPolicy = new CandidatePrivacyPolicy()
+                {
+                    AcceptedPolicyId = (Guid)AcceptedPolicyId,
+                    AcceptedAt = DateTimeProvider.UtcNow,
+                };
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Validators/GetIntoTeachingCallbackValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/GetIntoTeachingCallbackValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Models.Validators
+{
+    public class GetIntoTeachingCallbackValidator : AbstractValidator<GetIntoTeachingCallback>
+    {
+        public GetIntoTeachingCallbackValidator(IStore store, IDateTimeProvider dateTime)
+        {
+            RuleFor(request => request.AcceptedPolicyId).NotNull();
+
+            RuleFor(request => request.Email).NotEmpty();
+            RuleFor(request => request.FirstName).NotEmpty();
+            RuleFor(request => request.LastName).NotEmpty();
+            RuleFor(request => request.AddressTelephone).NotNull();
+            RuleFor(request => request.PhoneCallScheduledAt)
+                .NotNull()
+                .GreaterThan(candidate => dateTime.UtcNow)
+                    .WithMessage("Can only be scheduled for future dates.");
+
+            RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+    }
+}

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -40,6 +40,11 @@
         "Endpoint": "POST:/api/schools_experience/candidates",
         "Period": "1m",
         "Limit": 60
+      },
+      {
+        "Endpoint": "POST:/api/get_into_teaching/callbacks",
+        "Period": "1m",
+        "Limit": 60
       }
     ]
   },
@@ -67,6 +72,11 @@
             "Endpoint": "POST:/api/teaching_events",
             "Period": "1d",
             "Limit": 100
+          },
+          {
+            "Endpoint": "POST:/api/get_into_teaching/callbacks",
+            "Period": "1m",
+            "Limit": 250
           }
         ]
       },

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Xunit;
+using Moq;
+using GetIntoTeachingApi.Services;
+using FluentAssertions;
+using GetIntoTeachingApi.Jobs;
+using Microsoft.AspNetCore.Mvc;
+using GetIntoTeachingApi.Models;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.AspNetCore.Authorization;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApi.Controllers.GetIntoTeaching;
+
+namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
+{
+    public class CallbacksControllerTests
+    {
+        private readonly Mock<ICandidateAccessTokenService> _mockTokenService;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        private readonly Mock<IDateTimeProvider> _mockDateTime;
+        private readonly CallbacksController _controller;
+        private readonly ExistingCandidateRequest _request;
+
+        public CallbacksControllerTests()
+        {
+            _mockTokenService = new Mock<ICandidateAccessTokenService>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
+            _mockDateTime = new Mock<IDateTimeProvider>();
+            _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _controller = new CallbacksController(_mockTokenService.Object, _mockCrm.Object, _mockDateTime.Object, _mockJobClient.Object);
+
+            // Freeze time.
+            _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void Authorize_IsPresent()
+        {
+            typeof(CallbacksController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching");
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+            _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_ValidToken_RespondsWithGetIntoTeachingCallback()
+        {
+            var candidate = new Candidate { Id = Guid.NewGuid() };
+            _mockTokenService.Setup(tokenService => tokenService.IsValid("000000", _request, (Guid)candidate.Id)).Returns(true);
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var responseModel = ok.Value as GetIntoTeachingCallback;
+            responseModel.CandidateId.Should().Be(candidate.Id);
+        }
+
+        [Fact]
+        public void ExchangeAccessToken_MissingCandidate_RespondsWithUnauthorized()
+        {
+            _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
+
+            var response = _controller.ExchangeAccessToken("000000", _request);
+
+            response.Should().BeOfType<UnauthorizedResult>();
+        }
+
+        [Fact]
+        public void Book_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var request = new GetIntoTeachingCallback { Email = "invalid-email@" };
+            _controller.ModelState.AddModelError("Email", "Email is invalid.");
+
+            var response = _controller.Book(request);
+
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
+
+        [Fact]
+        public void Book_ValidRequest_EnqueuesJobAndRespondsWithSuccess()
+        {
+            var request = new GetIntoTeachingCallback { FirstName = "first", PhoneCallScheduledAt = DateTime.UtcNow };
+
+            var response = _controller.Book(request);
+
+            response.Should().BeOfType<NoContentResult>();
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                IsMatch(request.Candidate, (string)job.Args[0])),
+                It.IsAny<EnqueuedState>()));
+        }
+
+        private static bool IsMatch(Candidate candidateA, string candidateBJson)
+        {
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
+            candidateA.Should().BeEquivalentTo(candidateB);
+            return true;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Controllers\GetIntoTeaching\" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
@@ -47,6 +50,7 @@
     <Folder Include="Validators\" />
     <Folder Include="JsonConverters\" />
     <Folder Include="Middleware\" />
+    <Folder Include="Controllers\GetIntoTeaching\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -34,6 +34,7 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/mailing_list/members", "GIT", 250)]
         [InlineData("/api/teaching_events/attendees", "GIT", 250)]
         [InlineData("/api/teaching_events", "GIT", 100)]
+        [InlineData("/api/get_into_teaching/callbacks", "GIT", 250)]
         [InlineData("/api/candidates/access_tokens", "TTA", 500)]
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
         [InlineData("/api/candidates/access_tokens", "SE", 500)]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeachingCallbackTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class GetIntoTeachingCallbackTests
+    {
+        [Fact]
+        public void Constructor_WithCandidate_MapsCorrectly()
+        {
+            var candidate = new Candidate()
+            {
+                Id = Guid.NewGuid(),
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                AddressTelephone = "00123456789",
+            };
+
+            var response = new GetIntoTeachingCallback(candidate);
+
+            response.CandidateId.Should().Be(candidate.Id);
+            response.Email.Should().Be(candidate.Email);
+            response.FirstName.Should().Be(candidate.FirstName);
+            response.LastName.Should().Be(candidate.LastName);
+            response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
+        }
+
+        [Fact]
+        public void Candidate_MapsCorrectly()
+        {
+            var request = new GetIntoTeachingCallback()
+            {
+                CandidateId = Guid.NewGuid(),
+                AcceptedPolicyId = Guid.NewGuid(),
+                Email = "email@address.com",
+                FirstName = "John",
+                LastName = "Doe",
+                AddressTelephone = "123456789",
+                PhoneCallScheduledAt = DateTime.UtcNow,
+            };
+
+            var candidate = request.Candidate;
+
+            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Email.Should().Be(request.Email);
+            candidate.FirstName.Should().Be(request.FirstName);
+            candidate.LastName.Should().Be(request.LastName);
+            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
+
+            candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
+            candidate.PhoneCall.Telephone.Should().Be(request.AddressTelephone);
+            candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
+            candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
+            candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
+
+            candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void Candidate_ChannelIdWhenCandidateIdIsNull_IsGetIntoTeachingCallback()
+        {
+            var request = new GetIntoTeachingCallback() { CandidateId = null };
+
+            request.Candidate.ChannelId.Should().Be((int)Candidate.Channel.GetIntoTeachingCallback);
+        }
+
+        [Fact]
+        public void Candidate_ChannelIdWhenCandidateIdIsNotNull_IsNotChanged()
+        {
+            var request = new GetIntoTeachingCallback() { CandidateId = Guid.NewGuid() };
+
+            request.Candidate.ChannelId.Should().BeNull();
+            request.Candidate.ChangedPropertyNames.Should().NotContain("ChannelId");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Validators/GetIntoTeachingCallbackValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/GetIntoTeachingCallbackValidatorTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Validators
+{
+    public class GetIntoTeachingCallbackValidatorTests
+    {
+        private readonly GetIntoTeachingCallbackValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+        private readonly GetIntoTeachingCallback _callback;
+
+        public GetIntoTeachingCallbackValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new GetIntoTeachingCallbackValidator(_mockStore.Object, new DateTimeProvider());
+            _callback = new GetIntoTeachingCallback();
+        }
+
+        [Fact]
+        public void Validate_WhenRequiredAttributesAreNull_HasErrors()
+        {
+            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
+            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
+            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
+            _validator.ShouldHaveValidationErrorFor(request => request.AddressTelephone, null as string);
+            _validator.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt, null as DateTime?);
+            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+        }
+
+        [Fact]
+        public void Validate_CandidateIsInvalid_HasError()
+        {
+            var request = new GetIntoTeachingCallback
+            {
+                AddressTelephone = "123",
+            };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("Candidate.AddressTelephone");
+        }
+
+        [Fact]
+        public void Validate_WhenPhoneCallScheduledAtIsInPast_HasError()
+        {
+            _callback.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(-1);
+
+            var result = _validator.TestValidate(_callback);
+
+            result.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt)
+                .WithErrorMessage("Can only be scheduled for future dates.");
+
+            _callback.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(1);
+
+            result = _validator.TestValidate(_callback);
+
+            result.ShouldNotHaveValidationErrorFor(request => request.PhoneCallScheduledAt);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-1567](https://trello.com/c/lk6tXkkt/1567-product-book-a-call-functionality-on-ml-completion-page)

- Add model for GetIntoTeachingCallback

We want to add a new transaction in the Get into Teaching website that allows users to book a callback; this adds the request model with appropriate fields we want to collect.

- Add validator for request model

Add a validator for the new GetIntoTeachingCallback request model. Every field is required and callbacks can only be scheduled for future dates.

- Add controller for scheduling callbacks

Add a controller to enable the `GetIntoTeaching` role to schedule callbacks for candidates and exchange an access token for a pre-filled callback request model.

- Rate limit callback bookings

Add rate limiting for callback booking requests; intentionally high, it will be rate limited per IP address on the Rails app-side.