### PR TITLE
Attempt to speed up `UpsertTeachingEvent`

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -259,16 +259,20 @@ namespace GetIntoTeachingApi.Services
 
         public TeachingEvent GetTeachingEvent(string readableId)
         {
-            var context = Context();
-            var entity = _service.CreateQuery("msevtmgt_event", context)
-                             .Where(entity => entity.GetAttributeValue<string>("dfe_websiteeventpartialurl") == readableId)
-                             .FirstOrDefault();
+            var query = new QueryExpression("msevtmgt_event");
+            query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(TeachingEvent)));
+            var readableIdCondition = new ConditionExpression("dfe_websiteeventpartialurl", ConditionOperator.Equal, readableId);
+            query.Criteria.AddCondition(readableIdCondition);
+
+            var entity = _service.RetrieveMultiple(query).FirstOrDefault();
 
             if (entity == null)
             {
                 return null;
             }
 
+            var context = Context();
+            context.Attach(entity);
             _service.LoadProperty(entity, new Relationship("msevtmgt_event_building"), context);
 
             return new TeachingEvent(entity, this, _validatorFactory);


### PR DESCRIPTION
Currently, the `UpsertTeachingEvent` endpoint is a bit slow.

`UpsertTeachingEvent` calls `CrmService.GetTeachingEvent` two times, once for validation and once to determine whether the attached building needs to be removed. 

Update `GetTeachingEvent` to use `QueryExpression` as it is quicker than LINQ.