### PR TITLE
Run MagicLinkTokenGenerationJob hourly

### DIFF
--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -266,7 +266,6 @@ The GIT API aims to provide:
             {
                 // Configure recurring jobs.
                 const string everyFifthMinute = "*/5 * * * *";
-                const string everyMinute = "* * * * *";
                 RecurringJob.AddOrUpdate<CrmSyncJob>(JobConfiguration.CrmSyncJobId, (x) => x.RunAsync(), everyFifthMinute);
                 RecurringJob.AddOrUpdate<LocationSyncJob>(
                     JobConfiguration.LocationSyncJobId,
@@ -275,7 +274,7 @@ The GIT API aims to provide:
                 RecurringJob.AddOrUpdate<MagicLinkTokenGenerationJob>(
                     JobConfiguration.MagicLinkTokenGenerationJobId,
                     (x) => x.Run(),
-                    everyMinute);
+                    Cron.Hourly());
             }
 
             // Don't seed test environment.


### PR DESCRIPTION
We run this minutely at present, but the feature is not in use - to avoid it polluting the logs and to make debugging other jobs easier I'm switching it to run hourly; if we need it in the future we can shorten the interval again. I don't want to turn it off completely as having it ticking over would surface any bugs/errors in the code.