### PR TITLE
Integrate with the Find & Apply candidates API

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -50,6 +50,7 @@
 		<PackageReference Include="GovukNotify" Version="4.0.0" />
 		<PackageReference Include="JWT" Version="7.3.1" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
+		<PackageReference Include="Flurl.Http" Version="3.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -65,6 +66,8 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <None Remove="Controllers\GetIntoTeaching\" />
+	  <None Remove="Flurl" />
+	  <None Remove="Flurl.Http" />
 	  <None Remove="Models\FindApply\" />
 	</ItemGroup>
 	<ItemGroup>

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -61,9 +61,11 @@
 	  <Folder Include="Middleware\" />
 	  <Folder Include="Controllers\SchoolsExperience\" />
 	  <Folder Include="Controllers\GetIntoTeaching\" />
+	  <Folder Include="Models\FindApply\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Remove="Controllers\GetIntoTeaching\" />
+	  <None Remove="Models\FindApply\" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using GetIntoTeachingApi.Models.FindApply;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class FindApplyCandidateSyncJob : BaseJob
+    {
+        private readonly ILogger<FindApplyCandidateSyncJob> _logger;
+        private readonly ICrmService _crm;
+        private readonly Models.IAppSettings _appSettings;
+
+        public FindApplyCandidateSyncJob(
+            IEnv env,
+            ILogger<FindApplyCandidateSyncJob> logger,
+            ICrmService crm,
+            Models.IAppSettings appSettings)
+            : base(env)
+        {
+            _logger = logger;
+            _crm = crm;
+            _appSettings = appSettings;
+        }
+
+        public void Run(Candidate candidate)
+        {
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException("FindApplyCandidateSyncJob - Aborting (CRM integration paused).");
+            }
+
+            _logger.LogInformation($"FindApplyCandidateSyncJob - Started - {candidate.Id}");
+            SyncCandidate(candidate);
+            _logger.LogInformation($"FindApplyCandidateSyncJob - Succeeded - {candidate.Id}");
+        }
+
+        public void SyncCandidate(Candidate candidate)
+        {
+            var match = _crm.MatchCandidate(candidate.Attributes.Email);
+
+            if (match != null)
+            {
+                _logger.LogInformation($"FindApplyCandidateSyncJob - Hit - {candidate.Id}");
+                match.FindApplyId = candidate.Id;
+                _crm.Save(match);
+            }
+            else
+            {
+                _logger.LogInformation($"FindApplyCandidateSyncJob - Miss - {candidate.Id}");
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Flurl;
+using Flurl.Http;
+using GetIntoTeachingApi.Models.FindApply;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using MoreLinq;
+using Prometheus;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class FindApplySyncJob : BaseJob
+    {
+        private readonly ILogger<FindApplySyncJob> _logger;
+        private readonly IMetricService _metrics;
+        private readonly Models.IAppSettings _appSettings;
+        private readonly IBackgroundJobClient _jobClient;
+        private readonly IDateTimeProvider _dateTime;
+
+        public FindApplySyncJob(
+            IEnv env,
+            ILogger<FindApplySyncJob> logger,
+            IBackgroundJobClient jobClient,
+            Models.IAppSettings appSettings,
+            IMetricService metrics,
+            IDateTimeProvider dateTime)
+            : base(env)
+        {
+            _logger = logger;
+            _metrics = metrics;
+            _appSettings = appSettings;
+            _jobClient = jobClient;
+            _dateTime = dateTime;
+        }
+
+        [DisableConcurrentExecution(timeoutInSeconds: 5)]
+        public async Task RunAsync()
+        {
+            using (_metrics.FindApplySyncDuration.NewTimer())
+            {
+                _logger.LogInformation("FindApplySyncJob - Started");
+                await QueueCandidateSyncJobs();
+                _appSettings.FindApplyLastSyncAt = _dateTime.UtcNow;
+                _logger.LogInformation("FindApplySyncJob - Succeeded");
+            }
+        }
+
+        private async Task QueueCandidateSyncJobs()
+        {
+            var response = await Env.FindApplyApiUrl
+                .AppendPathSegment("candidates")
+                .SetQueryParam("updated_since", UpdatedSince())
+                .WithOAuthBearerToken(Env.FindApplyApiKey)
+                .GetJsonAsync<Response<IEnumerable<Candidate>>>();
+
+            _logger.LogInformation($"FindApplySyncJob - Syncing {response.Data.Count()} Candidates");
+            response.Data.ForEach(c => _jobClient.Enqueue<FindApplyCandidateSyncJob>(x => x.Run(c)));
+        }
+
+        private DateTime UpdatedSince()
+        {
+            // On the initial run we won't get any records back as
+            // we ask for those updated since the current time. A separate
+            // job/process will back-fill the records updated in the past.
+            return _appSettings.FindApplyLastSyncAt ?? _dateTime.UtcNow;
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/JobConfiguration.cs
+++ b/GetIntoTeachingApi/Jobs/JobConfiguration.cs
@@ -11,5 +11,6 @@ namespace GetIntoTeachingApi.Jobs
         public static string CrmSyncJobId => "crm-sync";
         public static string LocationSyncJobId => "location-sync";
         public static string MagicLinkTokenGenerationJobId => "magic-link-token-generation";
+        public static string FindApplySyncJobId => "find-apply-sync";
     }
 }

--- a/GetIntoTeachingApi/Models/AppSettings.cs
+++ b/GetIntoTeachingApi/Models/AppSettings.cs
@@ -8,6 +8,7 @@ namespace GetIntoTeachingApi.Models
     {
         private const string DateFormat = "O";
         private const string CrmOfflineUntilKey = "app_settings.crm_offline_until";
+        private const string FindApplyLastSyncAtKey = "app_settings.find_apply_last_sync_at";
         private readonly IRedisService _redis;
 
         public DateTime? CrmIntegrationPausedUntil
@@ -33,6 +34,32 @@ namespace GetIntoTeachingApi.Models
                 var dateStr = value?.ToString(DateFormat);
 
                 _redis.Database.StringSet(CrmOfflineUntilKey, dateStr);
+            }
+        }
+
+        public DateTime? FindApplyLastSyncAt
+        {
+            get
+            {
+                var dateStr = _redis.Database.StringGet(FindApplyLastSyncAtKey);
+
+                if (dateStr.IsNullOrEmpty)
+                {
+                    return null;
+                }
+
+                return DateTime.ParseExact(
+                    dateStr,
+                    DateFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind);
+            }
+
+            set
+            {
+                var dateStr = value?.ToString(DateFormat);
+
+                _redis.Database.StringSet(FindApplyLastSyncAtKey, dateStr);
             }
         }
 

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -149,6 +149,8 @@ namespace GetIntoTeachingApi.Models
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]
         public bool Merged { get; set; }
+        [EntityField("dfe_applyid")]
+        public string FindApplyId { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
         [EntityField("emailaddress2")]

--- a/GetIntoTeachingApi/Models/FindApply/Candidate.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Candidate.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class Candidate
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        [JsonProperty("attributes")]
+        public CandidateAttributes Attributes { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
+++ b/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class CandidateAttributes
+    {
+        [JsonProperty("email_address")]
+        public string Email { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/FindApply/Response.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Response.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class Response<T>
+    {
+        [JsonProperty("data")]
+        public T Data { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/IAppSettings.cs
+++ b/GetIntoTeachingApi/Models/IAppSettings.cs
@@ -4,6 +4,7 @@ namespace GetIntoTeachingApi.Models
 {
     public interface IAppSettings
     {
+        DateTime? FindApplyLastSyncAt { get; set; }
         DateTime? CrmIntegrationPausedUntil { get; set; }
         bool IsCrmIntegrationPaused { get; }
     }

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PickListItem> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
+        Candidate MatchCandidate(string email);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
         IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);

--- a/GetIntoTeachingApi/Services/IMetricService.cs
+++ b/GetIntoTeachingApi/Services/IMetricService.cs
@@ -5,6 +5,7 @@ namespace GetIntoTeachingApi.Services
     public interface IMetricService
     {
         Histogram CrmSyncDuration { get; }
+        Histogram FindApplySyncDuration { get; }
         Histogram LocationSyncDuration { get; }
         Histogram MagicLinkTokenGenerationDuration { get; }
         Histogram HangfireJobQueueDuration { get; }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -6,6 +6,8 @@ namespace GetIntoTeachingApi.Services
     {
         private static readonly Histogram _crmSyncDuration = Metrics
             .CreateHistogram("api_crm_sync_duration_seconds", "Histogram of CRM sync durations.");
+        private static readonly Histogram _findApplySyncDuration = Metrics
+            .CreateHistogram("api_find_apply_sync_duration_seconds", "Histogram of Find & Apply sync durations.");
         private static readonly Histogram _locationSyncDuration = Metrics
             .CreateHistogram("api_location_sync_duration_seconds", "Histogram of location sync durations.");
         private static readonly Histogram _magicLinkTokenGenerationDuration = Metrics
@@ -45,6 +47,7 @@ namespace GetIntoTeachingApi.Services
                 LabelNames = new[] { "valid" },
             });
 
+        public Histogram FindApplySyncDuration => _findApplySyncDuration;
         public Histogram CrmSyncDuration => _crmSyncDuration;
         public Histogram LocationSyncDuration => _locationSyncDuration;
         public Histogram MagicLinkTokenGenerationDuration => _magicLinkTokenGenerationDuration;

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -275,6 +275,15 @@ The GIT API aims to provide:
                     JobConfiguration.MagicLinkTokenGenerationJobId,
                     (x) => x.Run(),
                     Cron.Hourly());
+
+                // Only run FindApplySyncJob in dev/staging environments for now.
+                if (!env.IsProduction)
+                {
+                    RecurringJob.AddOrUpdate<FindApplySyncJob>(
+                        JobConfiguration.FindApplySyncJobId,
+                        (x) => x.RunAsync(),
+                        Cron.Hourly());
+                }
             }
 
             // Don't seed test environment.

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -21,6 +21,8 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+        public string FindApplyApiUrl => Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
+        public string FindApplyApiKey => Environment.GetEnvironmentVariable("FIND_APPLY_API_KEY");
         public string AppName => AppServices.ApplicationName;
         public string Organization => AppServices.OrganizationName;
         public string Space => AppServices.SpaceName;

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -19,6 +19,8 @@
         string CrmServiceUrl { get; }
         string CrmClientId { get; }
         string CrmClientSecret { get; }
+        string FindApplyApiUrl { get; }
+        string FindApplyApiKey { get; }
         string NotifyApiKey { get; }
         string GoogleApiKey { get; }
         bool IsMasterInstance { get; }

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <None Remove="Controllers\GetIntoTeaching\" />
+    <None Remove="Models\FindApply\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
@@ -51,6 +52,7 @@
     <Folder Include="JsonConverters\" />
     <Folder Include="Middleware\" />
     <Folder Include="Controllers\GetIntoTeaching\" />
+    <Folder Include="Models\FindApply\" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models.FindApply;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class FindApplyCandidateSyncJobTests
+    {
+        private readonly Mock<GetIntoTeachingApi.Models.IAppSettings> _mockAppSettings;
+        private readonly Mock<ILogger<FindApplyCandidateSyncJob>> _mockLogger;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly FindApplyCandidateSyncJob _job;
+        private readonly Candidate _candidate;
+
+        public FindApplyCandidateSyncJobTests()
+        {
+            _mockLogger = new Mock<ILogger<FindApplyCandidateSyncJob>>();
+            _mockAppSettings = new Mock<GetIntoTeachingApi.Models.IAppSettings>();
+            _mockCrm = new Mock<ICrmService>();
+            _job = new FindApplyCandidateSyncJob(
+                new Env(),
+                _mockLogger.Object,
+                _mockCrm.Object,
+                _mockAppSettings.Object);
+            _candidate = new Candidate() { Id = "12345", Attributes = new CandidateAttributes() { Email = "email@address.com" } };
+        }
+
+        [Fact]
+        public void Run_OnSuccess_SavesCandidate()
+        {
+            var match = new GetIntoTeachingApi.Models.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
+            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Candidate>(c => c.Id == match.Id && c.FindApplyId == _candidate.Id)));
+
+            _job.Run(_candidate);
+
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Hit - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
+        }
+
+        [Fact]
+        public void Run_WhenCandidateNotFound_LogsMiss()
+        {
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
+
+            _job.Run(_candidate);
+
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Miss - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
+        }
+
+        [Fact]
+        public void Run_WhenCrmIntegrationPaused_Aborts()
+        {
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+
+            Action action = () => _job.Run(_candidate);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("FindApplyCandidateSyncJob - Aborting (CRM integration paused).");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Flurl.Http.Testing;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models.FindApply;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class FindApplySyncJobTests
+    {
+        private readonly Mock<GetIntoTeachingApi.Models.IAppSettings> _mockAppSettings;
+        private readonly MetricService _metrics;
+        private readonly Mock<ILogger<FindApplySyncJob>> _mockLogger;
+        private readonly Mock<IDateTimeProvider> _mockDateTime;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        private readonly Mock<IEnv> _mockEnv;
+        private readonly FindApplySyncJob _job;
+
+        public FindApplySyncJobTests()
+        {
+            _mockLogger = new Mock<ILogger<FindApplySyncJob>>();
+            _metrics = new MetricService();
+            _mockAppSettings = new Mock<GetIntoTeachingApi.Models.IAppSettings>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
+            _mockDateTime = new Mock<IDateTimeProvider>();
+            _mockEnv = new Mock<IEnv>();
+
+            _mockEnv.Setup(m => m.FindApplyApiUrl).Returns("https://test.apply.api/candidates-api");
+            _mockEnv.Setup(m => m.FindApplyApiKey).Returns("1234567");
+
+            _job = new FindApplySyncJob(
+                _mockEnv.Object,
+                _mockLogger.Object,
+                _mockJobClient.Object,
+                _mockAppSettings.Object,
+                _metrics,
+                _mockDateTime.Object);
+        }
+
+        [Fact]
+        public void DisableConcurrentExecutionAttribute()
+        {
+            var type = typeof(FindApplySyncJob);
+
+            type.GetMethod("RunAsync").Should().BeDecoratedWith<DisableConcurrentExecutionAttribute>();
+        }
+
+        [Fact]
+        public async void RunAsync_WithUpdatedCandidates_QueuesCandidateJobs()
+        {
+            var metricCount = _metrics.FindApplySyncDuration.Count;
+            var lastSyncAt = new DateTime(2020, 1, 1);
+            _mockAppSettings.Setup(m => m.FindApplyLastSyncAt).Returns(lastSyncAt);
+            var candidates = new Candidate[]
+            {
+                new Candidate() { Id = "11111", Attributes = new CandidateAttributes() { Email = "email1@address.com" } },
+                new Candidate() { Id = "22222", Attributes = new CandidateAttributes() { Email = "email2@address.com" } },
+            };
+
+            using (var httpTest = new HttpTest())
+            {
+                var response = new Response<IEnumerable<Candidate>>() { Data = candidates };
+                MockResponse(httpTest, lastSyncAt, response);
+                await _job.RunAsync();
+            }
+
+            _mockJobClient.Verify(x => x.Create(
+               It.Is<Job>(job => job.Type == typeof(FindApplyCandidateSyncJob) && job.Method.Name == "Run"),
+               It.IsAny<EnqueuedState>()), Times.Exactly(candidates.Count()));
+
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Started");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Syncing 2 Candidates");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Succeeded");
+            _metrics.FindApplySyncDuration.Count.Should().Be(metricCount + 1);
+        }
+
+        [Fact]
+        public async void RunAsync_WithNoUpdatedCandidates_DoesNotQueueJobs()
+        {
+            var metricCount = _metrics.FindApplySyncDuration.Count;
+            var lastSyncAt = new DateTime(2020, 1, 1);
+            _mockAppSettings.Setup(m => m.FindApplyLastSyncAt).Returns(lastSyncAt);
+
+            using (var httpTest = new HttpTest())
+            {
+                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                MockResponse(httpTest, lastSyncAt, response);
+                await _job.RunAsync();
+            }
+
+            _mockJobClient.Verify(x => x.Create(
+               It.Is<Job>(job => job.Type == typeof(FindApplyCandidateSyncJob)),
+               It.IsAny<EnqueuedState>()), Times.Never);
+
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Started");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Syncing 0 Candidates");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Succeeded");
+            _metrics.FindApplySyncDuration.Count.Should().Be(metricCount + 1);
+        }
+
+        [Fact]
+        public async void RunAsync_OnFirstRun_GetsUpdatedSinceNow()
+        {
+            var now = DateTime.UtcNow;
+            _mockDateTime.Setup(m => m.UtcNow).Returns(now);
+            _mockAppSettings.Setup(m => m.FindApplyLastSyncAt).Returns<DateTime>(null);
+
+            using (var httpTest = new HttpTest())
+            {
+                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                MockResponse(httpTest, now, response);
+                await _job.RunAsync();
+            }
+
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Started");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Syncing 0 Candidates");
+            _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Succeeded");
+        }
+
+        [Fact]
+        public async void RunAsync_OnSuccess_UpdatesLastSyncAt()
+        {
+            var lastSyncAt = DateTime.UtcNow.AddMonths(-1);
+            _mockAppSettings.Setup(m => m.FindApplyLastSyncAt).Returns(lastSyncAt);
+            var now = DateTime.UtcNow;
+            _mockDateTime.Setup(m => m.UtcNow).Returns(now);
+
+            using (var httpTest = new HttpTest())
+            {
+                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                MockResponse(httpTest, lastSyncAt, response);
+                await _job.RunAsync();
+            }
+
+            _mockAppSettings.VerifySet(m => m.FindApplyLastSyncAt = now, Times.Once);
+        }
+
+        private void MockResponse(HttpTest httpTest, DateTime updatedSince, Response<IEnumerable<Candidate>> response)
+        {
+            var json = JsonConvert.SerializeObject(response);
+
+            httpTest
+                    .ForCallsTo($"{_mockEnv.Object.FindApplyApiUrl}/candidates")
+                    .WithVerb("GET")
+                    .WithQueryParam("updated_since", updatedSince)
+                    .WithHeader("Authorization", $"Bearer {_mockEnv.Object.FindApplyApiKey}")
+                    .RespondWith(json, 200);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/AppSettingsTests.cs
+++ b/GetIntoTeachingApiTests/Models/AppSettingsTests.cs
@@ -69,5 +69,27 @@ namespace GetIntoTeachingApiTests.Models
 
             _settings.IsCrmIntegrationPaused.Should().BeFalse();
         }
+
+        [Fact]
+        public void FindApplyLastSyncAt_SetAndGetWithDate_WorkCorrectly()
+        {
+            var date = DateTime.UtcNow;
+            var dateStr = date.ToString("O");
+            _database.Setup(m => m.StringSet("app_settings.find_apply_last_sync_at", dateStr, null, When.Always, CommandFlags.None));
+            _database.Setup(m => m.StringGet("app_settings.find_apply_last_sync_at", CommandFlags.None)).Returns(dateStr);
+
+            _settings.FindApplyLastSyncAt = date;
+            _settings.FindApplyLastSyncAt.Should().Be(date);
+        }
+
+        [Fact]
+        public void FindApplyLastSyncAt_SetAndGetWithNull_WorkCorrectly()
+        {
+            _database.Setup(m => m.StringSet("app_settings.find_apply_last_sync_at", null as string, null, When.Always, CommandFlags.None));
+            _database.Setup(m => m.StringGet("app_settings.find_apply_last_sync_at", CommandFlags.None)).Returns(null as string);
+
+            _settings.FindApplyLastSyncAt = null;
+            _settings.FindApplyLastSyncAt.Should().BeNull();
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -70,6 +70,7 @@ namespace GetIntoTeachingApiTests.Models
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
 
 
+            type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");

--- a/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class CandidateAttributesTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(CandidateAttributes);
+
+            type.GetProperty("Email").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "email_address");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CandidateTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class CandidateTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Candidate);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
+            type.GetProperty("Attributes").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "attributes");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/ResponseTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ResponseTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ResponseTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Response<object>);
+
+            type.GetProperty("Data").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "data");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -20,6 +20,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void FindApplySyncDuration_ReturnsMetric()
+        {
+            _metrics.FindApplySyncDuration.Name.Should().Be("api_find_apply_sync_duration_seconds");
+        }
+
+        [Fact]
         public void LocationSyncDuration_ReturnsMetric()
         {
             _metrics.LocationSyncDuration.Name.Should().Be("api_location_sync_duration_seconds");

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -153,6 +153,28 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
+        public void FindApplyApiUrl_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", "find-apply-api-url");
+
+            _env.FindApplyApiUrl.Should().Be("find-apply-api-url");
+
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", previous);
+        }
+
+        [Fact]
+        public void FindApplyApiKey_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("FIND_APPLY_API_KEY");
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_KEY", "find-apply-api-key");
+
+            _env.FindApplyApiKey.Should().Be("find-apply-api-key");
+
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_KEY", previous);
+        }
+
+        [Fact]
         public void CrmServiceUrl_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("CRM_SERVICE_URL");


### PR DESCRIPTION
### Trello card

[Trello-1641](https://trello.com/c/LwotLDGF/1641-dev-find-apply-integration-work-with-the-api-crm)

### Context

The Find & Apply team are providing a candidates API that exposes candidate information updated since a given date/time. We want to query this API for the GiT API and sync up the `id` of their candidates with those matched in the CRM.

Initially we will only be matching back on email address and updating existing candidates (creating new candidates in the CRM that exist in Find & Apply but don't match back will come later).

We want to run the sync operation hourly and only in non-production environments. We will only be concerned with records updated _after_ the first sync run (past records will be bulk-imported by another process/job). 

### Changes proposed in this pull request

- Store find/apply last sync date in Redis

We need to keep track of the date that the Find & Apply API was last synced successfully (as we pass this as a parameter in the subsequent API call).

Update `AppSettings` to enable storing the last sync date.

- Add find/apply API credentials

In order to access the Find & Apply API we will need the URL for the instance (sandbox or production) and a valid API key.

- Support match back on email address only

The normal match back process involves matching the email plus 2/3 of first name, last name and date of birth.

As the Find & Apply API is only going to be exposing the email address of the candidates initially we need to support matching back on just that field.

Replicates the current match back logic (taking into account status, duplicate score and date modified) and picks the first with the correct email.

- Add FindApplyId to Candidate model

When we sync with the Find & Apply API we will be storing their candidate id against the corresponding `contact` in the CRM; this adds the field mapping for the id.

- Model response from find/apply API

Add the models that map to the response from the Find & Apply candidates API.

- Add job to sync a find/apply candidate with the CRM

Add a job that takes a Find & Apply candidate model and matches it against a `contact` in the CRM. If there is a match the `FindApplyId` is set and the model is persisted back to the CRM.

- Add job to sync with find/apply API

The job requests Find & Apply candidates that have been updated since the last sync date. If no sync has been performed yet it will use the current date/time (we will pre-fill past records separately). A job is then queued for each candidate to sync it with the CRM.

Flurl is used for making the HTTP requests.

- Run find/apply sync job on a schedule

We want to sync with the Find & Apply API periodically; initially this will be hourly and only in our development and staging environments (we don't want this enabled in production yet).

### Guidance to review

Best reviewed by-commit.