### PR TITLE
Tidy upsert teaching event action

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -184,32 +185,17 @@ namespace GetIntoTeachingApi.Controllers
             [FromBody, SwaggerRequestBody("Teaching event to upsert.", Required = true)] TeachingEvent teachingEvent,
             [FromServices] IOptions<ApiBehaviorOptions> apiBehaviorOptions)
         {
-            var operation = new TeachingEventUpsertOperation(teachingEvent);
-            var validator = new TeachingEventUpsertOperationValidator(_crm);
-            var result = validator.Validate(operation);
-
-            result.AddToModelState(ModelState, null);
+            ValidateForUpsertOperation(teachingEvent);
 
             if (!ModelState.IsValid)
             {
                 return apiBehaviorOptions.Value.InvalidModelStateResponseFactory(ControllerContext);
             }
 
-            var tempBuilding = teachingEvent.Building;
-
-            // Save independently so that the building gets an Id populated immediately.
-            // We also persist in the cache so it is immediately available.
-            if (teachingEvent.Building != null)
-            {
-                _crm.Save(teachingEvent.Building);
-                await _store.SaveAsync(new TeachingEventBuilding[] { teachingEvent.Building });
-                teachingEvent.BuildingId = teachingEvent.Building.Id;
-                teachingEvent.Building = null;
-            }
-
-            _crm.Save(teachingEvent);
-            teachingEvent.Building = tempBuilding;
-            await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
+            // Persist the building independently first so that we
+            // can populate the building id on the event prior to persisting.
+            await PersistBuildingAsync(teachingEvent);
+            await PersistEventAsync(teachingEvent);
 
             return CreatedAtAction(
                 actionName: nameof(Get),
@@ -227,6 +213,39 @@ namespace GetIntoTeachingApi.Controllers
                     TypeId = typeId,
                     TeachingEvents = events.Take(quantityPerType),
                 });
+        }
+
+        private async Task PersistBuildingAsync(TeachingEvent teachingEvent)
+        {
+            if (teachingEvent.Building == null)
+            {
+                return;
+            }
+
+            _crm.Save(teachingEvent.Building);
+            await _store.SaveAsync(teachingEvent.Building);
+            teachingEvent.BuildingId = teachingEvent.Building.Id;
+        }
+
+        private async Task PersistEventAsync(TeachingEvent teachingEvent)
+        {
+            // Remove building before persisting to prevent error.
+            var tempBuilding = teachingEvent.Building;
+            teachingEvent.Building = null;
+            _crm.Save(teachingEvent);
+
+            // Restore building before persiting to cache.
+            teachingEvent.Building = tempBuilding;
+            await _store.SaveAsync(teachingEvent);
+        }
+
+        private void ValidateForUpsertOperation(TeachingEvent teachingEvent)
+        {
+            var operation = new TeachingEventUpsertOperation(teachingEvent);
+            var validator = new TeachingEventUpsertOperationValidator(_crm);
+            var result = validator.Validate(operation);
+
+            result.AddToModelState(ModelState, null);
         }
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApi.Services
         Task SyncAsync();
         Task SaveAsync<T>(IEnumerable<T> models)
             where T : BaseModel;
+        Task SaveAsync<T>(T model)
+            where T : BaseModel;
         IQueryable<LookupItem> GetLookupItems(string entityName);
         IQueryable<PickListItem> GetPickListItems(string entityName, string attributeName);
         Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -143,6 +143,12 @@ namespace GetIntoTeachingApi.Services
             await _dbContext.SaveChangesAsync();
         }
 
+        public async Task SaveAsync<T>(T model)
+            where T : BaseModel
+        {
+            await SaveAsync(new T[] { model });
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeachingEventsControllerTests.cs
@@ -232,7 +232,7 @@ namespace GetIntoTeachingApiTests.Controllers
             const string testName = "test";
             var newTeachingEvent = new TeachingEvent() { Name = testName };
             _mockCrm.Setup(mock => mock.Save(newTeachingEvent)).Verifiable();
-            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEvent[] { newTeachingEvent })).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(newTeachingEvent)).Verifiable();
 
             var response = await _controller.Upsert(newTeachingEvent, null);
 
@@ -252,8 +252,8 @@ namespace GetIntoTeachingApiTests.Controllers
             var newTeachingEvent = new TeachingEvent() { Name = testName, Building = newBuilding };
             _mockCrm.Setup(mock => mock.Save(newBuilding)).Verifiable();
             _mockCrm.Setup(mock => mock.Save(It.Is<TeachingEvent>(e => e.BuildingId == buildingId))).Verifiable();
-            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEventBuilding[] { newBuilding })).Verifiable();
-            _mockStore.Setup(mock => mock.SaveAsync(new TeachingEvent[] { newTeachingEvent })).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(newBuilding)).Verifiable();
+            _mockStore.Setup(mock => mock.SaveAsync(newTeachingEvent)).Verifiable();
 
             var response = await _controller.Upsert(newTeachingEvent, null);
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -606,7 +606,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid(), Name = "TestEvent" };
 
-            await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
+            await _store.SaveAsync(teachingEvent);
 
             DbContext.TeachingEvents
                 .FirstOrDefault(e => e.Name == teachingEvent.Name)
@@ -618,14 +618,26 @@ namespace GetIntoTeachingApiTests.Services
         {
             var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid(), Name = "TestEvent" };
 
-            await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
+            await _store.SaveAsync(teachingEvent);
 
             teachingEvent.Name += "Updated";
 
-            await _store.SaveAsync(new TeachingEvent[] { teachingEvent });
+            await _store.SaveAsync(teachingEvent);
 
             var teachingEventNames = DbContext.TeachingEvents.Select(e => e.Name).ToList();
             teachingEventNames.ForEach(name => name.Should().Contain("Updated"));
+        }
+
+        [Fact]
+        public async Task SaveAsync_WithModels_Adds()
+        {
+            var teachingEvent1 = new TeachingEvent() { Id = Guid.NewGuid(), Name = "TestEvent1" };
+            var teachingEvent2 = new TeachingEvent() { Id = Guid.NewGuid(), Name = "TestEvent2" };
+
+            await _store.SaveAsync(new TeachingEvent[] { teachingEvent1, teachingEvent2 });
+
+            DbContext.TeachingEvents.FirstOrDefault(e => e.Id == teachingEvent1.Id).Should().NotBeNull();
+            DbContext.TeachingEvents.FirstOrDefault(e => e.Id == teachingEvent2.Id).Should().NotBeNull();
         }
 
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)


### PR DESCRIPTION
Minor refactoring to add an overload of the `SaveAsync` method to the store that accepts a single model and tidy up the logic in the `Upsert` action of the `TeachingEventsController`.