### PR TITLE
Configure DataProtection to persist in Redis

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -51,6 +51,7 @@
 		<PackageReference Include="JWT" Version="7.3.1" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -69,6 +70,7 @@
 	  <None Remove="Flurl" />
 	  <None Remove="Flurl.Http" />
 	  <None Remove="Models\FindApply\" />
+	  <None Remove="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -22,6 +22,7 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -31,6 +32,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Microsoft.Xrm.Sdk;
 using Prometheus;
+using StackExchange.Redis;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace GetIntoTeachingApi
@@ -88,6 +90,10 @@ namespace GetIntoTeachingApi
 
             services.AddAuthentication("ApiClientHandler")
                 .AddScheme<ApiClientSchemaOptions, ApiClientHandler>("ApiClientHandler", op => { });
+
+            var redisOptions = RedisConfiguration.ConfigurationOptions(env);
+            var redis = ConnectionMultiplexer.Connect(redisOptions);
+            services.AddDataProtection().PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys");
 
             services.AddMvc(o =>
             {


### PR DESCRIPTION
We don't directly use the `DataProtection` features of ASP.NET, but they are on by default and Hangfire appears to use them. We are seeing a number of anti-forgery check failures in the test environment, which appears to be due to running multiple instances and the `DataProtection` library persisting the tokens to disk by default. This means if a request goes to one  instance then the other it will fail the forgery check as the signatures wont match.

It doesn't appear to effect production as I believe its only the Hangfire dashboard that utilises the library (which is not enabled in prod).

Update to persist the keys in Redis, so that they are consistent across multiple instances.