### PR TITLE
Only write FindApplyId attribute on sync job

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -24,31 +24,34 @@ namespace GetIntoTeachingApi.Jobs
             _appSettings = appSettings;
         }
 
-        public void Run(Candidate candidate)
+        public void Run(Candidate findApplyCandidate)
         {
             if (_appSettings.IsCrmIntegrationPaused)
             {
                 throw new InvalidOperationException("FindApplyCandidateSyncJob - Aborting (CRM integration paused).");
             }
 
-            _logger.LogInformation($"FindApplyCandidateSyncJob - Started - {candidate.Id}");
-            SyncCandidate(candidate);
-            _logger.LogInformation($"FindApplyCandidateSyncJob - Succeeded - {candidate.Id}");
+            _logger.LogInformation($"FindApplyCandidateSyncJob - Started - {findApplyCandidate.Id}");
+            SyncCandidate(findApplyCandidate);
+            _logger.LogInformation($"FindApplyCandidateSyncJob - Succeeded - {findApplyCandidate.Id}");
         }
 
-        public void SyncCandidate(Candidate candidate)
+        public void SyncCandidate(Candidate findApplyCandidate)
         {
-            var match = _crm.MatchCandidate(candidate.Attributes.Email);
+            var match = _crm.MatchCandidate(findApplyCandidate.Attributes.Email);
 
             if (match != null)
             {
-                _logger.LogInformation($"FindApplyCandidateSyncJob - Hit - {candidate.Id}");
-                match.FindApplyId = candidate.Id;
-                _crm.Save(match);
+                _logger.LogInformation($"FindApplyCandidateSyncJob - Hit - {findApplyCandidate.Id}");
+
+                // We persist a new Candidate to ensure we only write the FindApplyId
+                // back to the CRM and not existing attributes on the match.
+                var candidate = new Models.Candidate() { Id = match.Id, FindApplyId = findApplyCandidate.Id };
+                _crm.Save(candidate);
             }
             else
             {
-                _logger.LogInformation($"FindApplyCandidateSyncJob - Miss - {candidate.Id}");
+                _logger.LogInformation($"FindApplyCandidateSyncJob - Miss - {findApplyCandidate.Id}");
             }
         }
     }


### PR DESCRIPTION
Previously we were retrieving a matching `Candidate`, populating the `FindApplyId` and writing that back to the CRM. The issue with this is that the `Candidate` returned from the match query will be fully populated, so we end up writing back attributes needlessly.

Instead, we instantiate a new `Candidate` with the relevant `id` and populate the `FindApplyId`, ensuring that is the only attribute that will be written back to the CRM.