### PR TITLE
Fix MagicLinkTokenGenerationJob

### DIFF
--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -58,8 +58,11 @@ namespace GetIntoTeachingApi.Jobs
             var candidates = _crm.GetCandidatesPendingMagicLinkTokenGeneration(BatchSize);
             _logger.LogInformation($"MagicLinkTokenGenerationJob - Processing ({candidates.Count()})");
 
-            foreach (var candidate in candidates)
+            foreach (var match in candidates)
             {
+                // We create a new Candidate and populate only the fields
+                // we want to write back to the CRM (via GenerateToken).
+                var candidate = new Candidate() { Id = match.Id };
                 _magicLinkTokenService.GenerateToken(candidate);
                 string json = candidate.SerializeChangeTracked();
                 _jobClient.Enqueue<UpsertCandidateJob>(x => x.Run(json, null));


### PR DESCRIPTION
The magic link generation job was failing due to writing back the entire `Candidate` object which contained `null` `OptionSet` values (these aren't supported by the Dynamics `ServiceClient`).

Instead, we create a new `Candidate` and only populate the fields that have changed.