### PR TITLE
Reduce magic link batch size

### DIFF
--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApi.Jobs
 {
     public class MagicLinkTokenGenerationJob : BaseJob
     {
-        private const int BatchSize = 5000;
+        private const int BatchSize = 500;
         private readonly ICrmService _crm;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ICandidateMagicLinkTokenService _magicLinkTokenService;

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -55,7 +55,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             var candidate = new Candidate() { Id = Guid.NewGuid(), MagicLinkTokenStatusId = (int)Candidate.MagicLinkTokenStatus.Pending };
             string json = candidate.SerializeChangeTracked();
-            _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(5000)).Returns(new Candidate[] { candidate });
+            _mockCrm.Setup(m => m.GetCandidatesPendingMagicLinkTokenGeneration(500)).Returns(new Candidate[] { candidate });
 
             _job.Run();
 


### PR DESCRIPTION
We have 20k records getting magic links in the CRM and the request for the first 5k is timing out; reducing to 500 to see if that works.