### PR TITLE
Add basic auth to Hangfire dashboard

### DIFF
--- a/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
@@ -4,11 +4,11 @@ using Hangfire.Dashboard;
 
 namespace GetIntoTeachingApi.Auth
 {
-    public class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+    public class HangfireDashboardEnvironmentAuthorizationFilter : IDashboardAuthorizationFilter
     {
         private readonly IEnv _env;
 
-        public HangfireDashboardAuthorizationFilter(IEnv env)
+        public HangfireDashboardEnvironmentAuthorizationFilter(IEnv env)
         {
             _env = env;
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
@@ -52,6 +52,7 @@
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.7" />
+		<PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -71,6 +72,7 @@
 	  <None Remove="Flurl.Http" />
 	  <None Remove="Models\FindApply\" />
 	  <None Remove="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" />
+	  <None Remove="Hangfire.Dashboard.BasicAuthorization" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -231,7 +231,7 @@ The GIT API aims to provide:
 
             app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
-                Authorization = new[] { new HangfireDashboardAuthorizationFilter(env) },
+                Authorization = new[] { new HangfireDashboardEnvironmentAuthorizationFilter(env) },
             });
 
             app.UseSwagger(c =>

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -19,6 +19,8 @@ using GetIntoTeachingApi.Redis;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using Hangfire.Dashboard;
+using Hangfire.Dashboard.BasicAuthorization;
 using Hangfire.MemoryStorage;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Builder;
@@ -221,18 +223,7 @@ The GIT API aims to provide:
 
             app.UseRequestResponseLogging();
 
-            var hangfireOptions = new BackgroundJobServerOptions();
-            if (!env.IsDevelopment)
-            {
-                hangfireOptions.WorkerCount = 20;
-            }
-
-            app.UseHangfireServer(hangfireOptions);
-
-            app.UseHangfireDashboard("/hangfire", new DashboardOptions
-            {
-                Authorization = new[] { new HangfireDashboardEnvironmentAuthorizationFilter(env) },
-            });
+            ConfigureHangfire(app, env);
 
             app.UseSwagger(c =>
             {
@@ -344,6 +335,42 @@ The GIT API aims to provide:
 
             // Configuration (resolvers, counter key builders).
             services.AddSingleton<IRateLimitConfiguration, ApiClientRateLimitConfiguration>();
+        }
+
+        private void ConfigureHangfire(IApplicationBuilder app, IEnv env)
+        {
+            var hangfireOptions = new BackgroundJobServerOptions();
+            if (!env.IsDevelopment)
+            {
+                hangfireOptions.WorkerCount = 20;
+            }
+
+            app.UseHangfireServer(hangfireOptions);
+
+            var filters = new List<IDashboardAuthorizationFilter> { new HangfireDashboardEnvironmentAuthorizationFilter(env) };
+
+            if (env.IsStaging)
+            {
+                filters.Add(new BasicAuthAuthorizationFilter(
+                new BasicAuthAuthorizationFilterOptions
+                {
+                    RequireSsl = true,
+                    LoginCaseSensitive = true,
+                    Users = new[]
+                    {
+                        new BasicAuthAuthorizationUser
+                        {
+                            Login = env.HangfireUsername,
+                            PasswordClear = env.HangfirePassword,
+                        },
+                    },
+                }));
+            }
+
+            app.UseHangfireDashboard("/hangfire", new DashboardOptions
+            {
+                Authorization = filters,
+            });
         }
     }
 }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -14,6 +14,8 @@ namespace GetIntoTeachingApi.Utils
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
+        public string HangfireUsername => Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
+        public string HangfirePassword => Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");
         public string CrmServiceUrl => Environment.GetEnvironmentVariable("CRM_SERVICE_URL");

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -10,6 +10,8 @@
         string GitCommitSha { get; }
         string DatabaseInstanceName { get; }
         string HangfireInstanceName { get; }
+        string HangfireUsername { get; }
+        string HangfirePassword { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
@@ -6,15 +6,15 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Auth
 {
-    public class HangfireDashboardAuthorizationFilterTests
+    public class HangfireDashboardEnvironmentAuthorizationFilterTests
     {
-        private readonly HangfireDashboardAuthorizationFilter _filter;
+        private readonly HangfireDashboardEnvironmentAuthorizationFilter _filter;
         private readonly Mock<IEnv> _mockEnv;
 
-        public HangfireDashboardAuthorizationFilterTests()
+        public HangfireDashboardEnvironmentAuthorizationFilterTests()
         {
             _mockEnv = new Mock<IEnv>();
-            _filter = new HangfireDashboardAuthorizationFilter(_mockEnv.Object);
+            _filter = new HangfireDashboardEnvironmentAuthorizationFilter(_mockEnv.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -106,6 +106,28 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
+        public void HangfireUsername_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
+            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", "hangfire-username");
+
+            _env.HangfireUsername.Should().Be("hangfire-username");
+
+            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", previous);
+        }
+
+        [Fact]
+        public void HangfirePassword_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
+            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", "hangfire-password");
+
+            _env.HangfirePassword.Should().Be("hangfire-password");
+
+            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", previous);
+        }
+
+        [Fact]
         public void TotpSecretKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");


### PR DESCRIPTION
- Rename HangfireDashboardAuthorizationFilter

It wasn't clear from the name of the class that this is responsible for making the Hangfire dashboard only available in certain environments.

- Add basic auth to Hangfire dashboard

The Hangfire dashboard is only available in the dev/test environment, however there is no authentication in front of it at the moment. Whilst its not particularly exploitable, someone could re-queue a bunch of jobs and potentially clog up our workers.

Add basic authentication in front of the Hangfire dashboard.