### PR TITLE
Revert "Add basic auth to Hangfire dashboard"

### DIFF
--- a/GetIntoTeachingApi/Auth/HangfireDashboardAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardAuthorizationFilter.cs
@@ -4,11 +4,11 @@ using Hangfire.Dashboard;
 
 namespace GetIntoTeachingApi.Auth
 {
-    public class HangfireDashboardEnvironmentAuthorizationFilter : IDashboardAuthorizationFilter
+    public class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
     {
         private readonly IEnv _env;
 
-        public HangfireDashboardEnvironmentAuthorizationFilter(IEnv env)
+        public HangfireDashboardAuthorizationFilter(IEnv env)
         {
             _env = env;
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
@@ -52,7 +52,6 @@
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.7" />
-		<PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -72,7 +71,6 @@
 	  <None Remove="Flurl.Http" />
 	  <None Remove="Models\FindApply\" />
 	  <None Remove="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" />
-	  <None Remove="Hangfire.Dashboard.BasicAuthorization" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -14,8 +14,6 @@ namespace GetIntoTeachingApi.Utils
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
-        public string HangfireUsername => Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
-        public string HangfirePassword => Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");
         public string CrmServiceUrl => Environment.GetEnvironmentVariable("CRM_SERVICE_URL");

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -10,8 +10,6 @@
         string GitCommitSha { get; }
         string DatabaseInstanceName { get; }
         string HangfireInstanceName { get; }
-        string HangfireUsername { get; }
-        string HangfirePassword { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardAuthorizationFilterTests.cs
@@ -6,15 +6,15 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Auth
 {
-    public class HangfireDashboardEnvironmentAuthorizationFilterTests
+    public class HangfireDashboardAuthorizationFilterTests
     {
-        private readonly HangfireDashboardEnvironmentAuthorizationFilter _filter;
+        private readonly HangfireDashboardAuthorizationFilter _filter;
         private readonly Mock<IEnv> _mockEnv;
 
-        public HangfireDashboardEnvironmentAuthorizationFilterTests()
+        public HangfireDashboardAuthorizationFilterTests()
         {
             _mockEnv = new Mock<IEnv>();
-            _filter = new HangfireDashboardEnvironmentAuthorizationFilter(_mockEnv.Object);
+            _filter = new HangfireDashboardAuthorizationFilter(_mockEnv.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -106,28 +106,6 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void HangfireUsername_ReturnsCorrectly()
-        {
-            var previous = Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
-            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", "hangfire-username");
-
-            _env.HangfireUsername.Should().Be("hangfire-username");
-
-            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", previous);
-        }
-
-        [Fact]
-        public void HangfirePassword_ReturnsCorrectly()
-        {
-            var previous = Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
-            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", "hangfire-password");
-
-            _env.HangfirePassword.Should().Be("hangfire-password");
-
-            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", previous);
-        }
-
-        [Fact]
         public void TotpSecretKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#685

For some reason this works locally but not in the hosted environment. There is another basic auth library I can try but it requires .NET Core 5 (we are on 3) so I will revert this until we can update .NET Core.