### PR TITLE
Add basic auth to Hangfire dashboard (take 2)

### DIFF
--- a/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
@@ -4,11 +4,11 @@ using Hangfire.Dashboard;
 
 namespace GetIntoTeachingApi.Auth
 {
-    public class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+    public class HangfireDashboardEnvironmentAuthorizationFilter : IDashboardAuthorizationFilter
     {
         private readonly IEnv _env;
 
-        public HangfireDashboardAuthorizationFilter(IEnv env)
+        public HangfireDashboardEnvironmentAuthorizationFilter(IEnv env)
         {
             _env = env;
         }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -52,6 +52,7 @@
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.7" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
+		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -72,6 +73,7 @@
 	  <None Remove="Models\FindApply\" />
 	  <None Remove="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" />
 	  <None Remove="AspNetCoreRateLimit.Redis" />
+	  <None Remove="Hangfire.Dashboard.Basic.Authentication" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Startup.cs
+++ b/GetIntoTeachingApi/Startup.cs
@@ -233,7 +233,7 @@ The GIT API aims to provide:
 
             app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
-                Authorization = new[] { new HangfireDashboardAuthorizationFilter(env) },
+                Authorization = new[] { new HangfireDashboardEnvironmentAuthorizationFilter(env) },
             });
 
             app.UseSwagger(c =>

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -14,6 +14,8 @@ namespace GetIntoTeachingApi.Utils
         public bool ExportHangireToPrometheus => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0";
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");
+        public string HangfireUsername => Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
+        public string HangfirePassword => Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
         public string TotpSecretKey => Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");
         public string VcapServices => Environment.GetEnvironmentVariable("VCAP_SERVICES");
         public string CrmServiceUrl => Environment.GetEnvironmentVariable("CRM_SERVICE_URL");

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -10,6 +10,8 @@
         string GitCommitSha { get; }
         string DatabaseInstanceName { get; }
         string HangfireInstanceName { get; }
+        string HangfireUsername { get; }
+        string HangfirePassword { get; }
         string EnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
@@ -6,15 +6,15 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Auth
 {
-    public class HangfireDashboardAuthorizationFilterTests
+    public class HangfireDashboardEnvironmentAuthorizationFilterTests
     {
-        private readonly HangfireDashboardAuthorizationFilter _filter;
+        private readonly HangfireDashboardEnvironmentAuthorizationFilter _filter;
         private readonly Mock<IEnv> _mockEnv;
 
-        public HangfireDashboardAuthorizationFilterTests()
+        public HangfireDashboardEnvironmentAuthorizationFilterTests()
         {
             _mockEnv = new Mock<IEnv>();
-            _filter = new HangfireDashboardAuthorizationFilter(_mockEnv.Object);
+            _filter = new HangfireDashboardEnvironmentAuthorizationFilter(_mockEnv.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -106,6 +106,28 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
+        public void HangfireUsername_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("HANGFIRE_USERNAME");
+            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", "hangfire-username");
+
+            _env.HangfireUsername.Should().Be("hangfire-username");
+
+            Environment.SetEnvironmentVariable("HANGFIRE_USERNAME", previous);
+        }
+
+        [Fact]
+        public void HangfirePassword_ReturnsCorrectly()
+        {
+            var previous = Environment.GetEnvironmentVariable("HANGFIRE_PASSWORD");
+            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", "hangfire-password");
+
+            _env.HangfirePassword.Should().Be("hangfire-password");
+
+            Environment.SetEnvironmentVariable("HANGFIRE_PASSWORD", previous);
+        }
+
+        [Fact]
         public void TotpSecretKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("TOTP_SECRET_KEY");


### PR DESCRIPTION
- Rename HangfireDashboardAuthorizationFilter

It wasn't clear from the name of the class that this is responsible for making the Hangfire dashboard only available in certain environments.

- Add Hangfire credentials to Env

Add the Hangfire username/password to Env for basic auth.

- Add basic auth to Hangfire in staging

Add a basic auth prompt to the Hangfire dashboard when in the staging environment (hosted dev and test).