### PR TITLE
Run dev/test deployments in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,6 @@ jobs:
            
   qa:
     name: Quality Assurance Deployment
-    needs: [ Development ]
     runs-on: ubuntu-latest
     steps:
        - name: Check out the repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,8 @@ jobs:
            
   qa:
     name: Quality Assurance Deployment
+    needs: build
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
        - name: Check out the repo


### PR DESCRIPTION
[Trello-1685](https://trello.com/c/WXcNsFl0/1685-run-the-dev-test-deployments-in-parallel)

At the moment we deploy to the dev environment, then the test environment; it will save about 2.5 minutes off the 10 min deploy time if we deploy both in parallel.

I can't think of any downside to this? other than we get two failures on a bad deploy, but any failure is pretty rare now so probably not a big deal?