### PR TITLE
Remove relationship entity mapping from `BaseModel`

### DIFF
--- a/GetIntoTeachingApi/Models/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/BaseModel.cs
@@ -82,7 +82,6 @@ namespace GetIntoTeachingApi.Models
 
             var entity = crm.MappableEntity(LogicalName(GetType()), Id, context);
             MapFieldAttributesToEntity(entity);
-            MapRelationshipAttributesToEntity(entity, crm, context);
             FinaliseEntity(entity, crm, context);
             return entity;
         }
@@ -136,11 +135,6 @@ namespace GetIntoTeachingApi.Models
         {
             var listType = typeof(List<>).MakeGenericType(type);
             return (IList)Activator.CreateInstance(listType);
-        }
-
-        private static IEnumerable<BaseModel> EnumerableRelationshipModels(object relationship)
-        {
-            return relationship is BaseModel model ? new List<BaseModel> { model } : (IEnumerable<BaseModel>)relationship;
         }
 
         private static IEnumerable<PropertyInfo> GetProperties(object model)
@@ -264,32 +258,6 @@ namespace GetIntoTeachingApi.Models
                 else
                 {
                     entity[attribute.Name] = value;
-                }
-            }
-        }
-
-        private void MapRelationshipAttributesToEntity(Entity source, ICrmService crm, OrganizationServiceContext context)
-        {
-            foreach (var property in GetProperties(this))
-            {
-                var attribute = EntityRelationshipAttribute(property);
-                var value = property.GetValue(this);
-
-                if (attribute == null || value == null)
-                {
-                    continue;
-                }
-
-                foreach (var relatedModel in EnumerableRelationshipModels(value))
-                {
-                    var shouldMap = ShouldMapRelationship(property.Name, relatedModel, crm);
-                    if (!shouldMap)
-                    {
-                        continue;
-                    }
-
-                    var target = relatedModel.ToEntity(crm, context);
-                    crm.AddLink(source, new Relationship(attribute.Name), target, context);
                 }
             }
         }

--- a/GetIntoTeachingApiTests/Models/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/BaseModelTests.cs
@@ -274,19 +274,12 @@ namespace GetIntoTeachingApiTests.Models
                 Field1 = Guid.NewGuid(),
                 Field2 = 1,
                 Field3 = "field3",
-                RelatedMock = new MockRelatedModel() { Id = Guid.NewGuid() },
-                RelatedMocks = new List<MockRelatedModel>() { new MockRelatedModel() { Id = Guid.NewGuid() } },
             };
 
             var mockEntity = new Entity("mock");
-            var relatedMockEntity = new Entity("mock") { EntityState = EntityState.Created };
 
             _mockService.Setup(m => m.BlankExistingEntity("mock", (Guid)mock.Id, _context))
                 .Returns(mockEntity);
-            _mockService.Setup(m => m.BlankExistingEntity("relatedMock",
-                (Guid)mock.RelatedMock.Id, _context)).Returns(relatedMockEntity);
-            _mockService.Setup(m => m.BlankExistingEntity("relatedMock",
-                (Guid)mock.RelatedMocks.First().Id, _context)).Returns(relatedMockEntity);
 
             mock.ToEntity(_crm, _context);
 
@@ -294,11 +287,6 @@ namespace GetIntoTeachingApiTests.Models
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").LogicalName.Should().Be("dfe_list");
             mockEntity.GetAttributeValue<OptionSetValue>("dfe_field2").Value.Should().Be(mock.Field2);
             mockEntity.GetAttributeValue<string>("dfe_field3").Should().Be(mock.Field3);
-
-            _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mock"),
-                relatedMockEntity, _context));
-            _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mocks"),
-                relatedMockEntity, _context));
         }
 
         [Fact]
@@ -309,15 +297,11 @@ namespace GetIntoTeachingApiTests.Models
                 Field1 = Guid.NewGuid(),
                 Field2 = 1,
                 Field3 = "field3",
-                RelatedMock = new MockRelatedModel(),
-                RelatedMocks = new List<MockRelatedModel>() { new MockRelatedModel() },
             };
 
             var mockEntity = new Entity("mock");
-            var relatedMockEntity = new Entity("mock") { EntityState = EntityState.Created };
 
             _mockService.Setup(m => m.NewEntity("mock", _context)).Returns(mockEntity);
-            _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns(relatedMockEntity);
 
             mock.ToEntity(_crm, _context);
 
@@ -325,33 +309,6 @@ namespace GetIntoTeachingApiTests.Models
             mockEntity.GetAttributeValue<EntityReference>("dfe_field1").LogicalName.Should().Be("dfe_list");
             mockEntity.GetAttributeValue<OptionSetValue>("dfe_field2").Value.Should().Be(mock.Field2);
             mockEntity.GetAttributeValue<string>("dfe_field3").Should().Be(mock.Field3);
-
-            _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mock"),
-                relatedMockEntity, _context));
-            _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mocks"),
-                relatedMockEntity, _context));
-        }
-
-        [Fact]
-        public void ToEntity_WithNewThatHasExistingRelationships()
-        {
-            var mock = new MockModel()
-            {
-                RelatedMock = new MockRelatedModel(),
-            };
-
-            var mockEntity = new Entity("mock");
-            var relatedMockEntity = new Entity("mock");
-
-            _mockService.Setup(m => m.NewEntity("mock", _context)).Returns(mockEntity);
-            _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns(relatedMockEntity);
-
-            mock.ToEntity(_crm, _context);
-
-            // Ensure a pre-existing related entity is linked (if it is already linked to the entity this
-            // will have no effect, which is desirable).
-            _mockService.Verify(m => m.AddLink(mockEntity, new Relationship("dfe_mock_dfe_relatedmock_mock"),
-                relatedMockEntity, _context), Times.Once);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -186,45 +186,6 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void ToEntity_WhenRelationshipIsNull_DoesNotCreateEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var candidate = new Candidate()
-            {
-                Qualifications = new List<CandidateQualification>() { null }
-            };
-
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(new Entity("contact"));
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockService.Verify(m => m.NewEntity("dfe_candidatequalification", context), Times.Never);
-        }
-
-        [Fact]
-        public void ToEntity_WithPropertyUsingDefaultMappingLogic_CreatesEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var candidate = new Candidate()
-            {
-                Qualifications = new List<CandidateQualification>() { new CandidateQualification() }
-            };
-
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(new Entity("contact"));
-            mockCrm.Setup(m => m.MappableEntity("dfe_candidatequalification", null, context)).Returns(new Entity("dfe_candidatequalification"));
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockCrm.Verify(m => m.MappableEntity("dfe_candidatequalification", null, context), Times.Once);
-        }
-
-        [Fact]
         public void ToEntity_WhenPrivacyPolicyAlreadyAccepted_DoesNotCreatePrivacyPolicyEntity()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();
@@ -244,26 +205,6 @@ namespace GetIntoTeachingApiTests.Models
             candidate.ToEntity(mockCrm.Object, context);
 
             mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", context), Times.Never);
-        }
-
-        [Fact]
-        public void ToEntity_WithNewCandidateAndPrivacyPolicy_CreatesPrivacyPolicyEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var candidate = new Candidate()
-            {
-                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
-            };
-
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(new Entity("contact"));
-            mockCrm.Setup(m => m.MappableEntity("dfe_candidateprivacypolicy", null, context)).Returns(new Entity("dfe_candidateprivacypolicy"));
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockCrm.Verify(m => m.MappableEntity("dfe_candidateprivacypolicy", null, context), Times.Once);
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Get into Teaching API 
+# Get into Teaching API 
 [![Build and Deploy](https://github.com/DFE-Digital/get-into-teaching-api/actions/workflows/devops.yml/badge.svg)](https://github.com/DFE-Digital/get-into-teaching-api/actions/workflows/devops.yml)
 
 > Provides a RESTful API for integrating with the Get into Teaching CRM.
@@ -324,6 +324,8 @@ Supporting to-many relationships is as simple as making sure the property is a `
 [EntityRelationship("dfe_contact_dfe_candidatequalification_ContactId", typeof(CandidateQualification))]
 public List<CandidateQualification> Qualifications { get; set; }
 ```
+
+> **Currently, the `BaseModel` does not create links between related entities when mapping to an `Entity` type. Instead, the relationship must be defined by assigning a value to the foreign key property, and saving each model independently. See `CandidateUpserter`**
 
 ### Customising the Mapping Behaviour
 


### PR DESCRIPTION
- Remove relationship entity mapping from `BaseModel`

We no longer use the MapRelationshipAttributesToEntity method of the BaseModel. This broke after the recent update to the CdsServiceClient, where we now are unable to deep insert entities (create related entities in a single request). We now persist entities independently instead.