### PR TITLE
Map related model validation errors to request model

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
@@ -37,12 +37,7 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
         [HttpPost]
         [SwaggerOperation(
             Summary = "Schedule a callback for the candidate.",
-            Description = "Validation errors may be present on the `GetIntoTeachingCallback` object as " +
-                          "well as the hidden `Candidate` model that is mapped to; property names are " +
-                          "consistent, so you should check for inclusion of the field in the key " +
-                          "when linking an error message back to a property on the request model. For " +
-                          "example, an error on `AddressTelephone` can return under the keys " +
-                          "`Candidate.AddressTelephone` and `AddressTelephone`.",
+            Description = "Queues a candidate upsert job.",
             OperationId = "BookGetIntoTeachingCallback",
             Tags = new[] { "Get into Teaching" })]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/GetIntoTeachingApi/Controllers/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/MailingListController.cs
@@ -41,15 +41,9 @@ namespace GetIntoTeachingApi.Controllers
         [Route("members")]
         [SwaggerOperation(
             Summary = "Adds a new member to the mailing list.",
-            Description = "If the `CandidateId` is specified then the existing candidate will be " +
-                          "added to the mailing list, otherwise a new candidate will be created." +
-                          "\n\n" +
-                          "Validation errors may be present on the `MailingListAddMember` object as " +
-                          "well as the hidden `Candidate` model that is mapped to; property names are " +
-                          "consistent, so you should check for inclusion of the field in the key " +
-                          "when linking an error message back to a property on the request model. For " +
-                          "example, an error on `UkDegreeGradeId` can return under the keys " +
-                          "`Candidate.Qualifications[0].UkDegreeGradeId` and `UkDegreeGradeId`.",
+            Description = @"
+                If the `CandidateId` is specified then the existing candidate will be 
+                added to the mailing list, otherwise a new candidate will be created.",
             OperationId = "AddMailingListMember",
             Tags = new[] { "Mailing List" })]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -39,13 +39,9 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         [HttpPost]
         [SwaggerOperation(
             Summary = "Sign up a candidate for the Schools Experience service.",
-            Description = "Validation errors may be present on the `SchoolsExperienceSignUp` object as " +
-                          "well as the hidden `Candidate` model that is mapped to; property names are " +
-                          "consistent, so you should check for inclusion of the field in the key " +
-                          "when linking an error message back to a property on the request model. For " +
-                          "example, an error on `DegreeSubject` can return under the keys " +
-                          "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
-            OperationId = "SignUpSchoolsExperienceCandidate",
+            Description = @"
+                Upsert a candidate. Returns the updated candidate information in the body of the response along 
+                with a Location header which specifies the location of the candidate",
             Tags = new[] { "Schools Experience" })]
         [ProducesResponseType(typeof(SchoolsExperienceSignUp), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -37,12 +37,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
         [HttpPost]
         [SwaggerOperation(
             Summary = "Sign up a candidate for the Teacher Training Adviser service.",
-            Description = "Validation errors may be present on the `TeacherTrainingAdviserSignUp` object as " +
-                          "well as the hidden `Candidate` model that is mapped to; property names are " +
-                          "consistent, so you should check for inclusion of the field in the key " +
-                          "when linking an error message back to a property on the request model. For " +
-                          "example, an error on `DegreeSubject` can return under the keys " +
-                          "`Candidate.Qualifications[0].DegreeSubject` and `DegreeSubject`.",
+            Description = "Queue a candidate upsert job.",
             OperationId = "SignUpTeacherTrainingAdviserCandidate",
             Tags = new[] { "Teacher Training Adviser" })]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/TeachingEventsController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
-using FluentValidation.Results;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -114,15 +113,9 @@ namespace GetIntoTeachingApi.Controllers
         [Route("attendees")]
         [SwaggerOperation(
             Summary = "Adds an attendee to a teaching event.",
-            Description = "If the `CandidateId` is specified then the existing candidate will be " +
-                          "registered for the event, otherwise a new candidate will be created." +
-                          "\n\n" +
-                          "Validation errors may be present on the `TeachingEventAddAttendee` object as " +
-                          "well as the hidden `Candidate` model that is mapped to; property names are " +
-                          "consistent, so you should check for inclusion of the field in the key " +
-                          "when linking an error message back to a property on the request model. For " +
-                          "example, an error on `AcceptedPolicyId` can return under the keys " +
-                          "`Candidate.PrivacyPolicy.AcceptedPolicyId` and `AcceptedPolicyId`.",
+            Description = @"
+                If the `CandidateId` is specified then the existing candidate will be 
+                registered for the event, otherwise a new candidate will be created.",
             OperationId = "AddTeachingEventAttendee",
             Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/GetIntoTeachingApi/Models/Validators/GetIntoTeachingCallbackValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/GetIntoTeachingCallbackValidator.cs
@@ -1,9 +1,13 @@
 ﻿using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class GetIntoTeachingCallbackValidator : AbstractValidator<GetIntoTeachingCallback>
+    public class GetIntoTeachingCallbackValidator : AbstractValidator<GetIntoTeachingCallback>, IValidatorInterceptor
     {
         public GetIntoTeachingCallbackValidator(IStore store, IDateTimeProvider dateTime)
         {
@@ -15,10 +19,20 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.AddressTelephone).NotNull();
             RuleFor(request => request.PhoneCallScheduledAt)
                 .NotNull()
-                .GreaterThan(candidate => dateTime.UtcNow)
+                .GreaterThan(_ => dateTime.UtcNow)
                     .WithMessage("Can only be scheduled for future dates.");
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            return result.SurfaceErrorsOnMatchingProperties(validationContext);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/MailingListAddMemberValidator.cs
@@ -1,9 +1,13 @@
 ﻿using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class MailingListAddMemberValidator : AbstractValidator<MailingListAddMember>
+    public class MailingListAddMemberValidator : AbstractValidator<MailingListAddMember>, IValidatorInterceptor
     {
         public MailingListAddMemberValidator(IStore store, IDateTimeProvider dateTime)
         {
@@ -16,6 +20,16 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            return result.SurfaceErrorsOnMatchingProperties(validationContext);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/SchoolsExperienceSignUpValidator.cs
@@ -1,9 +1,13 @@
 ﻿using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class SchoolsExperienceSignUpValidator : AbstractValidator<SchoolsExperienceSignUp>
+    public class SchoolsExperienceSignUpValidator : AbstractValidator<SchoolsExperienceSignUp>, IValidatorInterceptor
     {
         public SchoolsExperienceSignUpValidator(IStore store, IDateTimeProvider dateTime)
         {
@@ -24,6 +28,16 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.SecondaryTelephone).NotNull();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            return result.SurfaceErrorsOnMatchingProperties(validationContext);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class TeacherTrainingAdviserSignUpValidator : AbstractValidator<TeacherTrainingAdviserSignUp>
+    public class TeacherTrainingAdviserSignUpValidator : AbstractValidator<TeacherTrainingAdviserSignUp>, IValidatorInterceptor
     {
         public TeacherTrainingAdviserSignUpValidator(IStore store, IDateTimeProvider dateTime)
         {
@@ -108,6 +111,16 @@ namespace GetIntoTeachingApi.Models.Validators
             });
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            return result.SurfaceErrorsOnMatchingProperties(validationContext);
         }
 
         private static List<int?> StudyingForADegreeStatus()

--- a/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/TeachingEventAddAttendeeValidator.cs
@@ -1,9 +1,13 @@
 ﻿using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
-    public class TeachingEventAddAttendeeValidator : AbstractValidator<TeachingEventAddAttendee>
+    public class TeachingEventAddAttendeeValidator : AbstractValidator<TeachingEventAddAttendee>, IValidatorInterceptor
     {
         public TeachingEventAddAttendeeValidator(IStore store, IDateTimeProvider dateTime)
         {
@@ -17,6 +21,16 @@ namespace GetIntoTeachingApi.Models.Validators
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull().When(request => request.SubscribeToMailingList);
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            return result.SurfaceErrorsOnMatchingProperties(validationContext);
         }
     }
 }

--- a/GetIntoTeachingApi/Utils/ValidationResultExtensions.cs
+++ b/GetIntoTeachingApi/Utils/ValidationResultExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class ValidationResultExtensions
+    {
+        public static ValidationResult SurfaceErrorsOnMatchingProperties(
+            this ValidationResult result, IValidationContext validationContext)
+        {
+            var model = validationContext.InstanceToValidate;
+            result.Errors.ForEach(error => RemapError(error, model));
+            return result;
+        }
+
+        private static void RemapError(ValidationFailure error, object model)
+        {
+            var errorPropertyName = error.PropertyName.Split('.').Last();
+            var modelHasMatchingProperty = model
+                .GetType()
+                .GetProperties()
+                .Any(property => property.Name == errorPropertyName);
+
+            if (modelHasMatchingProperty)
+            {
+                error.PropertyName = errorPropertyName;
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Utils/ValidationResultExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/ValidationResultExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Utils;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Utils
+{
+    public class ValidationResultExtensionsTests
+    {
+        [Fact]
+        public void SurfaceErrorsOnMatchingProperties_WhenThereAreNoMatchingPropertiesOnTheRelatedModel_DoesNotSurfaceErrors()
+        {
+            var model = new GetIntoTeachingCallback();
+            var validationErrors = new List<ValidationFailure>
+            {
+                new ValidationFailure("Candidate.MobileTelephone", "Some error message")
+            };
+            var validationResult = new ValidationResult(failures: validationErrors);
+            var validationContext = new ValidationContext<GetIntoTeachingCallback>(instanceToValidate: model);
+
+            validationResult.SurfaceErrorsOnMatchingProperties(validationContext);
+
+            validationResult.Errors.Find(error => error.PropertyName == "Candidate.MobileTelephone").ErrorMessage
+                .Should().Be("Some error message");
+            validationResult.Errors.Find(error => error.PropertyName == "MobileTelephone").Should().BeNull();
+        }
+
+        [Fact]
+        public void SurfaceErrorsOnMatchingProperties_WhenThereAreMatchingPropertiesOnTheRelatedModel_SurfacesErrors()
+        {
+            var model = new GetIntoTeachingCallback();
+            var validationErrors = new List<ValidationFailure>
+            {
+                new ValidationFailure("Candidate.AddressTelephone", "Some error message"),
+                new ValidationFailure("Candidate.PrivacyPolicy.AcceptedPolicyId", "Some other error message")
+            };
+            var validationResult = new ValidationResult(failures: validationErrors);
+            var validationContext = new ValidationContext<GetIntoTeachingCallback>(instanceToValidate: model);
+
+            validationResult.SurfaceErrorsOnMatchingProperties(validationContext);
+
+            validationResult.Errors.Find(error => error.PropertyName == "AddressTelephone").ErrorMessage
+                .Should().Be("Some error message");
+            validationResult.Errors.Find(error => error.PropertyName == "AcceptedPolicyId").ErrorMessage
+                .Should().Be("Some other error message");
+            validationResult.Errors.Find(error => error.PropertyName == "Candidate.AddressTelephone").Should().BeNull();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The majority of the validation should be performed against the core models linke
 
 We also call registered validators for subclasses of `BaseModel` when mapping CRM entities into our API models. If the CRM returns an invalid value according to our validation logic it will be nullified. An example of where this can happen is with postcodes; if the CRM returns an invalid postcode we will nullify it (otherwise the client may re-post the invalid postcode back to the API without checking it and receive a 400 bad request response unexpectedly).
 
-Property names in request models should be consistent with any hidden `BaseModel` models they encapsulate and map to; this way the client can resolve the validation error messages back to the original request attributes. For example, the `MailingListAddMember.UkDegreeGradeId` maps to and is consistent with `MailingListAddMember.Candidate.Qualifications[0].UkDegreeGradeId`.
+Property names in request models should be consistent with any hidden `BaseModel` models they encapsulate and map to. When consistent, we can intercept validation results in order surface these back to the original request model. For example, the `MailingListAddMember.UkDegreeGradeId` is consistent with `MailingListAddMember.Candidate.Qualifications[0].UkDegreeGradeId`. Any errors that appear on the `MailingListAddMember.Candidate.Qualifications[0].UkDegreeGradeId` property will be intercepted in the `MailingListAddMemberValidator` mapped back to `MailingListAddMember.UkDegreeGradeId`.
 
 ### Testing
 


### PR DESCRIPTION
Validation errors on related models will appear in the format `RelatedModel.PropertyName`. It will be easier for clients to handle errors if they are mapped back to the request model property.

- Add an extension to `ValidationResult`. Intercept validation errors and map keys that are duplicated in any related model to the request model. Validation errors will now have the key `PropertyName`.
- Apply the interceptor to any request model validators with a hidden `Candidate` model. Update Swagger controller descriptions to remove warnings about hidden errors.
- Update validation error mapping advise in README