### PR TITLE
Sync teaching events up to 9 months old

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class Store : IStore
     {
-        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 4);
+        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 9);
         public static readonly HashSet<string> FailedPostcodeLookupCache = new HashSet<string>();
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;


### PR DESCRIPTION
We were finding that the app was serving 404s for some past teaching events; users likely bookmark the page and revisit it once the 4 month TTL of the events cache has expired. As the event sync was optimised a while back we should be fine to increase this to retrieve events further into the past.

Sync events going back 9 months instead of 4.