### PR TITLE
Increase HighNotFound alert threshold

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -49,12 +49,12 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#TooManyRequests-HIGH
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1
       - alert: HighNotFound
-        expr: 'sum(increase(app_requests_total{path=~".+",status=~"404"}[10m])) > 60'
+        expr: 'sum(increase(app_requests_total{path=~".+",status=~"404"}[10m])) > 120'
         labels:
           severity: medium
         annotations:
-          summary: Alerts when the app is serving a high number of 404 responses (more than 60 in any 10 minute period).
-          description: Alerts when the app is serving a high number of 404 responses (more than 60 in any 10 minute period).
+          summary: Alerts when the app is serving a high number of 404 responses (more than 120 in any 10 minute period).
+          description: Alerts when the app is serving a high number of 404 responses (more than 120 in any 10 minute period).
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#HighNotFound-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1
       - alert: HighCpu
@@ -87,12 +87,12 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#TooManyRequests-HIGH
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1
       - alert: HighNotFound
-        expr: 'sum(increase(tta_requests_total{path=~".+",status=~"404"}[10m])) > 60'
+        expr: 'sum(increase(tta_requests_total{path=~".+",status=~"404"}[10m])) > 120'
         labels:
           severity: medium
         annotations:
-          summary: Alerts when the app is serving a high number of 404 responses (more than 60 in any 10 minute period).
-          description: Alerts when the app is serving a high number of 404 responses (more than 60 in any 10 minute period).
+          summary: Alerts when the app is serving a high number of 404 responses (more than 60 in any 120 minute period).
+          description: Alerts when the app is serving a high number of 404 responses (more than 60 in any 120 minute period).
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#HighNotFound-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1 
       - alert: HighCpu


### PR DESCRIPTION
We're seeing this more frequently from just normal traffic/bots poking. Increasing it to 120/10m to hopefully reduce the number of false positives.