### PR TITLE
Updates to GetIntoTeachingCallbackBooking modelling

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
@@ -41,6 +41,8 @@ namespace GetIntoTeachingApi.Models.Crm
         [EntityField("directioncode")]
         public bool IsDirectionCode { get; set; } = true;
         Guid IHasCandidateId.CandidateId { get => new Guid(CandidateId); }
+        [EntityField("dfe_talkingpoints")]
+        public string TalkingPoints { get; set; }
 
         public PhoneCall()
             : base()

--- a/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Models.Crm
         public enum Channel
         {
             CallbackRequest = 222750003,
+            WebsiteCallbackRequest = 222750004,
         }
 
         public enum Destination

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/GetIntoTeachingCallback.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/GetIntoTeachingCallback.cs
@@ -19,6 +19,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         public string AddressTelephone { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public DateTime? PhoneCallScheduledAt { get; set; }
+        public string TalkingPoints { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -73,6 +74,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
                     ChannelId = (int)PhoneCall.Channel.WebsiteCallbackRequest,
                     Subject = $"Scheduled phone call requested by {candidate.FullName}",
+                    TalkingPoints = TalkingPoints,
                 };
             }
         }

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/GetIntoTeachingCallback.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/GetIntoTeachingCallback.cs
@@ -71,7 +71,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
                     Telephone = candidate.AddressTelephone,
                     DestinationId = (int)PhoneCall.Destination.Uk,
                     ScheduledAt = (DateTime)PhoneCallScheduledAt,
-                    ChannelId = (int)PhoneCall.Channel.CallbackRequest,
+                    ChannelId = (int)PhoneCall.Channel.WebsiteCallbackRequest,
                     Subject = $"Scheduled phone call requested by {candidate.FullName}",
                 };
             }

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidator.cs
@@ -22,6 +22,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
                 .NotNull()
                 .GreaterThan(_ => dateTime.UtcNow)
                     .WithMessage("Can only be scheduled for future dates.");
+            RuleFor(request => request.TalkingPoints).NotEmpty();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }

--- a/GetIntoTeachingApiTests/Models/Crm/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/PhoneCallTests.cs
@@ -28,6 +28,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("IsAppointment").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_appointmentflag");
             type.GetProperty("AppointmentRequired").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_appointmentrequired");
             type.GetProperty("IsDirectionCode").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "directioncode");
+            type.GetProperty("TalkingPoints").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_talkingpoints");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
@@ -53,7 +53,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
             candidate.PhoneCall.Telephone.Should().Be(request.AddressTelephone);
-            candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.CallbackRequest);
+            candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.WebsiteCallbackRequest);
             candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
             candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
 

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
@@ -41,6 +41,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
                 LastName = "Doe",
                 AddressTelephone = "123456789",
                 PhoneCallScheduledAt = DateTime.UtcNow,
+                TalkingPoints = "Talking points",
             };
 
             var candidate = request.Candidate;
@@ -56,6 +57,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.PhoneCall.ChannelId.Should().Be((int)PhoneCall.Channel.WebsiteCallbackRequest);
             candidate.PhoneCall.DestinationId.Should().Be((int)PhoneCall.Destination.Uk);
             candidate.PhoneCall.Subject.Should().Be("Scheduled phone call requested by John Doe");
+            candidate.PhoneCall.TalkingPoints.Should().Be(request.TalkingPoints);
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidatorTests.cs
@@ -30,6 +30,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
             _validator.ShouldHaveValidationErrorFor(request => request.AddressTelephone, null as string);
             _validator.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt, null as DateTime?);
             _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
+            _validator.ShouldHaveValidationErrorFor(request => request.TalkingPoints, null as string);
         }
 
         [Fact]


### PR DESCRIPTION
- Update PhoneCall Channel for GiT callback

We need to differentiate between the TTA callback and the GiT callback, which means providing different channels on the PhoneCall entity.

- Add talking points to callback request

When we create a callback from the GiT website we want to collect the talking points/reason for the phone call from the candidate to give the an adviser an indication of what the call will be about.