### PR TITLE
Sync Question Time events as Train to Teach

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/TeachingEvent.cs
@@ -31,6 +31,7 @@ namespace GetIntoTeachingApi.Models
             TrainToTeachEvent = 222750001,
             OnlineEvent = 222750008,
             SchoolOrUniversityEvent = 222750009,
+            QuestionTime = 222750007,
         }
 
         [EntityField("dfe_event_type", typeof(OptionSetValue))]

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -195,9 +195,20 @@ namespace GetIntoTeachingApi.Services
             var teachingEvents = _crm.GetTeachingEvents(afterDate).ToList();
             var teachingEventBuildings = _dbContext.TeachingEventBuildings.ToList();
 
-            foreach (var te in teachingEvents.Where(te => te.BuildingId != null))
+            foreach (var te in teachingEvents)
             {
-                te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);
+                // This horrible bit of misdirection is so that we can quickly lump the QT
+                // events in with TTT events on the GiT website for an immediate need. We
+                // should update the GiT website to handle QT events explicitly and remove this.
+                if (te.TypeId == (int)TeachingEvent.EventType.QuestionTime)
+                {
+                    te.TypeId = (int)TeachingEvent.EventType.TrainToTeachEvent;
+                }
+
+                if (te.BuildingId != null)
+                {
+                    te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);
+                }
             }
 
             await SyncModels(teachingEvents, _dbContext.TeachingEvents);

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -174,6 +174,7 @@ namespace GetIntoTeachingApiTests.Services
                 (int)TeachingEvent.EventType.OnlineEvent,
                 (int)TeachingEvent.EventType.ApplicationWorkshop,
                 (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
+                (int)TeachingEvent.EventType.QuestionTime,
             };
             var hasTypeCondition = conditions.Where(c => c.AttributeName == "dfe_event_type" &&
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(types)).Any();

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -77,6 +77,19 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SyncAsync_ChangesQuestionTimeEventsToBeTrainToTeachEvents()
+        {
+            await SeedMockTeachingEventBuildingsAsync();
+            var mockTeachingEvents = MockTeachingEvents().ToList();
+            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(mockTeachingEvents);
+            mockTeachingEvents.FirstOrDefault(e => e.TypeId == (int)TeachingEvent.EventType.QuestionTime).Should().NotBeNull();
+
+            await _store.SyncAsync();
+
+            DbContext.TeachingEvents.FirstOrDefault(e => e.TypeId == (int)TeachingEvent.EventType.QuestionTime).Should().BeNull();
+        }
+
+        [Fact]
         public async void SyncAsync_UpdatesExistingTeachingEvents()
         {
             var updatedTeachingEvents = (await SeedMockTeachingEventsAndBuildingsAsync()).ToList();
@@ -737,6 +750,7 @@ namespace GetIntoTeachingApiTests.Services
                 Id = Guid.NewGuid(),
                 ReadableId = "8",
                 Name = "Event 8",
+                TypeId = (int)TeachingEvent.EventType.QuestionTime,
                 StatusId = (int)TeachingEvent.Status.Pending
             };
 


### PR DESCRIPTION
We have an immediate need to display Question Time events on the GiT website, bundled in with Train to Teach events. Doing this on the front-end is a substantial change that may not be doable by the deadline of tomorrow, so for now we are going to re-type these events during the API sync so that the website will automatically pull them through and display them correctly.

Once this is in we will look to correctly handle QT events on the website directly.