### PR TITLE
Fix flakey contract tests

### DIFF
--- a/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApiTests.Helpers
 
         public IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context)
         {
-            throw new NotImplementedException();
+            return new List<Entity>().AsQueryable();
         }
 
         public IEnumerable<Entity> RetrieveMultiple(QueryBase query)


### PR DESCRIPTION
I think the contract tests are occasionally flakey depending on the order of the job runs; the `ClaimCallbackBookingSlot` job queries the API, which we weren't mocking so if it was not ran last (even though its queued last) the exception could result in the contract being incomplete.