### PR TITLE
Add Swagger definitions filter

### DIFF
--- a/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
+++ b/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
@@ -103,9 +103,9 @@ The GIT API aims to provide:
                 });
 
                 c.OperationFilter<AuthOperationFilter>();
+                c.DocumentFilter<SwaggerDefinitionsFilter>();
                 c.EnableAnnotations();
             });
-
             services.AddFluentValidationRulesToSwagger();
         }
 

--- a/GetIntoTeachingApi/AppStart/SwaggerDefinitionsFilter.cs
+++ b/GetIntoTeachingApi/AppStart/SwaggerDefinitionsFilter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Attributes;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GetIntoTeachingApi.AppStart
+{
+    public class SwaggerDefinitionsFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            var apiTypes = AppDomain
+                .CurrentDomain
+                .GetAssemblies()
+                .Where(assembly => assembly.FullName.StartsWith("GetIntoTeachingApi"))
+                .SelectMany(assembly => assembly.GetTypes())
+                .ToList();
+
+            IEnumerable<string> swaggerIngoredTypeNames = apiTypes
+                .Where(type => Attribute.IsDefined(type, typeof(SwaggerIgnoreAttribute)))
+                .Select(type => type.Name);
+
+            var schemas = swaggerDoc.Components.Schemas;
+
+            foreach (var definition in schemas)
+            {
+                if (swaggerIngoredTypeNames.Contains(definition.Key))
+                {
+                    schemas.Remove(definition);
+                }
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApi/Attributes/SwaggerIgnoreAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/SwaggerIgnoreAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GetIntoTeachingApi.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SwaggerIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/GetIntoTeachingApi/Models/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Candidate.cs
@@ -11,6 +11,7 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("contact")]
+    [SwaggerIgnore]
     public class Candidate : BaseModel
     {
         public static readonly Guid AdviserBusinessUnitId = new Guid("1A61F629-F502-E911-A972-000D3A23443B");

--- a/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/CandidatePastTeachingPosition.cs
@@ -6,6 +6,7 @@ using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [SwaggerIgnore]
     [Entity("dfe_candidatepastteachingposition")]
     public class CandidatePastTeachingPosition : BaseModel, IHasCandidateId
     {

--- a/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/CandidatePrivacyPolicy.cs
@@ -6,6 +6,7 @@ using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [SwaggerIgnore]
     [Entity("dfe_candidateprivacypolicy")]
     public class CandidatePrivacyPolicy : BaseModel, IHasCandidateId
     {

--- a/GetIntoTeachingApi/Models/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/CandidateQualification.cs
@@ -6,6 +6,7 @@ using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [SwaggerIgnore]
     [Entity("dfe_candidatequalification")]
     public class CandidateQualification : BaseModel, IHasCandidateId
     {

--- a/GetIntoTeachingApi/Models/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/PhoneCall.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
@@ -7,6 +6,7 @@ using Microsoft.Xrm.Sdk;
 
 namespace GetIntoTeachingApi.Models
 {
+    [SwaggerIgnore]
     [Entity("phonecall")]
     public class PhoneCall : BaseModel, IHasCandidateId
     {

--- a/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePastTeachingPositionTests.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(CandidatePastTeachingPosition);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_candidatepastteachingposition");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.GetProperty("SubjectTaughtId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_subjecttaught" && a.Type == typeof(EntityReference) && a.Reference == "dfe_teachingsubjectlist");

--- a/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidatePrivacyPolicyTests.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(CandidatePrivacyPolicy);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_candidateprivacypolicy");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_candidate" &&
                 a.Type == typeof(EntityReference) && a.Reference == "contact");

--- a/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateQualificationTests.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(CandidateQualification);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_candidatequalification");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_contactid" &&
                 a.Type == typeof(EntityReference) && a.Reference == "contact");

--- a/GetIntoTeachingApiTests/Models/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateTests.cs
@@ -19,6 +19,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(Candidate);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "contact");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.GetProperty("PreferredTeachingSubjectId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_preferredteachingsubject01" && a.Type == typeof(EntityReference) &&

--- a/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
+++ b/GetIntoTeachingApiTests/Models/PhoneCallTests.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApiTests.Models
             var type = typeof(PhoneCall);
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "phonecall");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.GetProperty("ChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_channelcreation" && a.Type == typeof(OptionSetValue));


### PR DESCRIPTION
Since the update to .NET 5.0, Swashbuckle has being including models that should be hidden in the generated Swagger doc. This has gone unnoticed because the API client hasn't been regenerated in a while.

I think this is because of the update to FluentValidation, now that validators must be generic (but I'm not 100% sure)

To prevent this: 
- add a new SwaggerIgnore attribute that can be used to decorate any types that should not be included in the Swagger docs 
- hook into the generation process to inspect the schema for matching types.