### PR TITLE
Swagger ignore TeachingEventRegistration

### DIFF
--- a/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/TeachingEventRegistration.cs
@@ -7,6 +7,7 @@ using Microsoft.Xrm.Sdk;
 namespace GetIntoTeachingApi.Models
 {
     [Entity("msevtmgt_eventregistration")]
+    [SwaggerIgnore]
     public class TeachingEventRegistration : BaseModel, IHasCandidateId
     {
         public enum Channel

--- a/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeachingEventRegistrationTests.cs
@@ -16,6 +16,7 @@ namespace GetIntoTeachingApiTests.Models
         public void EntityAttributes()
         {
             var type = typeof(TeachingEventRegistration);
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
 
             type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "msevtmgt_eventregistration");
 


### PR DESCRIPTION
Missed a model in the previous [PR](https://github.com/DFE-Digital/get-into-teaching-api/pull/717). The Ruby client looks as it should now except this model 👍 

- `TeachingEventRegistration` should not be included in the generated Swagger doc. Decorate with `SwaggerIgnore` filter.