### PR TITLE
Re-introduce OperationId

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -42,6 +42,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             Description = @"
                 Upsert a candidate. Returns the updated candidate information in the body of the response along 
                 with a Location header which specifies the location of the candidate",
+            OperationId = "SignUpSchoolsExperienceCandidate",
             Tags = new[] { "Schools Experience" })]
         [ProducesResponseType(typeof(SchoolsExperienceSignUp), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
This was accidently removed as part of an earlier refactoring; re-introducing as the swagger-codegen bases its method name from this.