### PR TITLE
Automapper - map same properties

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
+		<PackageReference Include="AutoMapper" Version="10.1.1" />
 		<PackageReference Include="CsvHelper" Version="27.1.1" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="10.2.3" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
@@ -57,18 +57,12 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
             }
 
             CandidateId = candidate.Id;
-            PreferredTeachingSubjectId = candidate.PreferredTeachingSubjectId;
-
-            ConsiderationJourneyStageId = candidate.ConsiderationJourneyStageId;
-
-            Email = candidate.Email;
-            FirstName = candidate.FirstName;
-            LastName = candidate.LastName;
-            AddressPostcode = candidate.AddressPostcode;
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
             AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
+
+            AutoMapperUtil.MapMatchingProperties(candidate, this);
         }
 
         private Candidate CreateCandidate()

--- a/GetIntoTeachingApi/Utils/AutoMapperUtil.cs
+++ b/GetIntoTeachingApi/Utils/AutoMapperUtil.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+
+namespace GetIntoTeachingApi.Utils
+{
+    public static class AutoMapperUtil
+    {
+        public static void MapMatchingProperties<TSource, TDestination>(TSource source, TDestination destination)
+        {
+            var config = new MapperConfiguration(config => config.CreateMap<TSource, TDestination>());
+
+            var mapper = config.CreateMapper();
+            mapper.Map(source, destination);
+        }
+    }
+}


### PR DESCRIPTION
Explore using Automapper to map same properties.

Otherwise, Automapper would suggest that we move all of our mapping out of the request models, create a mapper for each one, then inject it into the controllers and call it there