### PR TITLE
Add API client for external pen testers

### DIFF
--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -30,3 +30,8 @@
   description: "A service that allows candidates to book school experience"
   api_key_prefix: SE
   role: SchoolsExperience
+-
+  name: Penetration Test
+  description: "A cient for external pen testers (access to dev/test only)"
+  api_key_prefix: PT
+  role: Admin

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -32,6 +32,7 @@
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
+        "PT_API_KEY": "secret-pt",
         "TOTP_SECRET_KEY": "def456"
       }
     }


### PR DESCRIPTION
We are using external pen testers to test the API for vulnerabilities. To give access to all the endpoints they will be granted the `Admin` role, however we will only be providing keys for the dev and test environments (not prod).