### PR TITLE
Check if candidate can re-subcsribe based on adviser status

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -147,6 +147,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public int? GdprConsentId { get; set; }
         [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue))]
         public int? MagicLinkTokenStatusId { get; set; }
+        [EntityField("dfe_candidateadviserstatusreason", typeof(OptionSetValue))]
+        public int? AdviserStatus { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -10,6 +10,39 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
 {
     public class TeacherTrainingAdviserSignUp
     {
+        public enum ResubscribableAdviserStatus
+        {
+            AcceptedIttOffer = 222750000,
+            AcceptedRttTeachingPosition = 222750004,
+            AlreadyHasQts = 222750005,
+            AskedToBeLeftAlone = 222750006,
+            IncorrectlyAllocated = 222750007,
+            NoLongerPursuingTeaching = 222750008,
+            DoesNotWantToTrainInEngland = 222750010,
+            FeHeRoute = 222750011,
+            IncompleteContactDetailsUnableToTraceFurther = 222750012,
+            MovedAbroad = 222750013,
+            ForeignQualificationsNotEquivalent = 222750014,
+            NoLongerPursuingTeachingDueToFinancialCircumstances = 222750015,
+            NoLongerPursuingTeachingDueToNewEmployment = 222750016,
+            NoLongerPursuingTeachingDueToPersonalCircumstances = 222750017,
+            NoLongerPursuingTeachingFollowingSchoolExperience = 222750018,
+            NoQts = 222750019,
+            NoResponseToContactFromAdviser = 222750020,
+            NonEligibleDegree = 222750021,
+            NotEligibleForFunding = 222750022,
+            NotEligibleForSupportFromAdviser = 222750023,
+            ReferredToTeachingOutsideOfEngland = 222750024,
+            NoRightToStudyInUkAndReceiveFunding = 222750025,
+            WantsToApplyInFutureIttYear = 222750026,
+            OfferedIttPlaceButNotTakingItUp = 222750027,
+            Unsuccessful = 222750029,
+            PostponingOrCancellingDueToCoronaVirusConcerns = 222750030,
+            AcceptedIttTeachingPosition = 222750031,
+            GainedIttPlaceBeforeAdviserAllocation = 222750034,
+            SubjectClosedThisAcademicYear = 222750035,
+        }
+
         public Guid? CandidateId { get; set; }
         public Guid? QualificationId { get; set; }
         public Guid? SubjectTaughtId { get; set; }
@@ -46,6 +79,8 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public DateTime? PhoneCallScheduledAt { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToTeacherTrainingAdviser { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public bool CanSubscribeToTeacherTrainingAdviser { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -61,6 +96,21 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public TeacherTrainingAdviserSignUp(Candidate candidate)
         {
             PopulateWithCandidate(candidate);
+        }
+
+        private static bool CanSubscribe(Candidate candidate)
+        {
+            if (!candidate.HasTeacherTrainingAdviser())
+            {
+                return true;
+            }
+
+            if (candidate.AdviserStatus == null)
+            {
+                return false;
+            }
+
+            return Enum.IsDefined(typeof(ResubscribableAdviserStatus), candidate.AdviserStatus);
         }
 
         private void PopulateWithCandidate(Candidate candidate)
@@ -97,6 +147,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             TypeId = candidate.TypeId;
 
             AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
+            CanSubscribeToTeacherTrainingAdviser = CanSubscribe(candidate);
 
             var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();
 

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -69,6 +69,8 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
             type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("AdviserStatus").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_candidateadviserstatusreason" && a.Type == typeof(OptionSetValue));
 
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -106,6 +106,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.SubjectTaughtId.Should().Be(latestPastTeachingPosition.SubjectTaughtId);
 
             response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
+            response.CanSubscribeToTeacherTrainingAdviser.Should().BeFalse();
         }
 
         [Fact]
@@ -449,6 +450,24 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             };
 
             request.Candidate.PhoneCall.Telephone.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(true, (int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.NoLongerPursuingTeaching, true)]
+        [InlineData(false, -12345, true)]
+        [InlineData(true, null, false)]
+        [InlineData(false, null, true)]
+        [InlineData(true, -12345, false)]
+        public void CanSubscribeToTeacherTrainingAdviser_ReturnsCorrectly(bool hasAdviser, int? adviserStatus, bool expected)
+        {
+            var candidate = new Candidate() {
+                HasTeacherTrainingAdviserSubscription = hasAdviser,
+                AdviserStatus = adviserStatus
+            };
+
+            var response = new TeacherTrainingAdviserSignUp(candidate);
+
+            response.CanSubscribeToTeacherTrainingAdviser.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
[Trello-1698](https://trello.com/c/yG3hzAuh/1698-development-unblock-get-an-adviser-applicants-who-have-previously-had-an-adviser)

Up until now if a candidate has already been assigned an adviser we prevent them from re-signing up to the TTA service.

It turns out some candidates that have been assigned an adviser will have their `contact` record set to have a 'closed' adviser status. In this scenario, we want to let them re-subscribe for an adviser.

Adds a new `CanSubscribeToTeacherTrainingAdviser` attribute as `AlreadySubscribedToTeacherTrainingAdviser` would not be completely accurate for the new use case. Once the TTA service has been updated this field can be removed.