### PR TITLE
Handle candidates re-signing up with a closed adviser status

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -100,6 +100,11 @@ namespace GetIntoTeachingApi.Models.Crm
             Exchanged = 222750004,
         }
 
+        public enum RegistrationStatus
+        {
+            ReRegistered = 222750000,
+        }
+
         public string FullName => $"{FirstName} {LastName}".NullIfEmptyOrWhitespace();
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
@@ -149,6 +154,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_candidateadviserstatusreason", typeof(OptionSetValue))]
         public int? AdviserStatusId { get; set; }
+        [EntityField("dfe_candidatereregisterstatus", typeof(OptionSetValue))]
+        public int? RegistrationStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -148,7 +148,7 @@ namespace GetIntoTeachingApi.Models.Crm
         [EntityField("dfe_websitemltokenstatus", typeof(OptionSetValue))]
         public int? MagicLinkTokenStatusId { get; set; }
         [EntityField("dfe_candidateadviserstatusreason", typeof(OptionSetValue))]
-        public int? AdviserStatus { get; set; }
+        public int? AdviserStatusId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -61,6 +61,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public int? HasGcseScienceId { get; set; }
         public int? PlanningToRetakeGcseMathsAndEnglishId { get; set; }
         public int? PlanningToRetakeGcseScienceId { get; set; }
+        public int? AdviserStatusId { get; set; }
 
         public string Email { get; set; }
         public string FirstName { get; set; }
@@ -105,12 +106,12 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
                 return true;
             }
 
-            if (candidate.AdviserStatus == null)
+            if (candidate.AdviserStatusId == null)
             {
                 return false;
             }
 
-            return Enum.IsDefined(typeof(ResubscribableAdviserStatus), candidate.AdviserStatus);
+            return Enum.IsDefined(typeof(ResubscribableAdviserStatus), candidate.AdviserStatusId);
         }
 
         private void PopulateWithCandidate(Candidate candidate)

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -146,6 +146,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
             TypeId = candidate.TypeId;
+            AdviserStatusId = candidate.AdviserStatusId;
 
             AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
             CanSubscribeToTeacherTrainingAdviser = CanSubscribe(candidate);
@@ -204,6 +205,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
                 PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
                 GdprConsentId = (int)Candidate.GdprConsent.Consent,
                 OptOutOfGdpr = false,
+                AdviserStatusId = AdviserStatusId,
             };
 
             ConfigureChannel(candidate);

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -146,7 +146,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
             TypeId = candidate.TypeId;
-            AdviserStatusId = candidate.AdviserStatusId;
 
             AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
             CanSubscribeToTeacherTrainingAdviser = CanSubscribe(candidate);
@@ -205,7 +204,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
                 PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
                 GdprConsentId = (int)Candidate.GdprConsent.Consent,
                 OptOutOfGdpr = false,
-                AdviserStatusId = AdviserStatusId,
             };
 
             ConfigureChannel(candidate);
@@ -217,9 +215,24 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             SetAdviserEligibility(candidate);
             DefaultPreferredEducationPhase(candidate);
             DefaultPreferredTeachingSubjectId(candidate);
+            UpdateClosedAdviserStatus(candidate);
+
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow);
 
             return candidate;
+        }
+
+        private void UpdateClosedAdviserStatus(Candidate candidate)
+        {
+            // Ignore if not a closed reason.
+            if (AdviserStatusId == null || !Enum.IsDefined(typeof(ResubscribableAdviserStatus), AdviserStatusId))
+            {
+                return;
+            }
+
+            candidate.AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned;
+            candidate.RegistrationStatusId = (int)Candidate.RegistrationStatus.ReRegistered;
+            candidate.StatusIsWaitingToBeAssignedAt = DateTimeProvider.UtcNow;
         }
 
         private void ConfigureChannel(Candidate candidate)

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -69,7 +69,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 a => a.Name == "msgdpr_gdprconsent" && a.Type == typeof(OptionSetValue));
             type.GetProperty("MagicLinkTokenStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
-            type.GetProperty("AdviserStatus").Should().BeDecoratedWith<EntityFieldAttribute>(
+            type.GetProperty("AdviserStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidateadviserstatusreason" && a.Type == typeof(OptionSetValue));
 
 

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -71,7 +71,8 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 a => a.Name == "dfe_websitemltokenstatus" && a.Type == typeof(OptionSetValue));
             type.GetProperty("AdviserStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidateadviserstatusreason" && a.Type == typeof(OptionSetValue));
-
+            type.GetProperty("RegistrationStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_candidatereregisterstatus" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -458,11 +458,11 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
         [InlineData(true, null, false)]
         [InlineData(false, null, true)]
         [InlineData(true, -12345, false)]
-        public void CanSubscribeToTeacherTrainingAdviser_ReturnsCorrectly(bool hasAdviser, int? adviserStatus, bool expected)
+        public void CanSubscribeToTeacherTrainingAdviser_ReturnsCorrectly(bool hasAdviser, int? adviserStatusId, bool expected)
         {
             var candidate = new Candidate() {
                 HasTeacherTrainingAdviserSubscription = hasAdviser,
-                AdviserStatus = adviserStatus
+                AdviserStatusId = adviserStatusId
             };
 
             var response = new TeacherTrainingAdviserSignUp(candidate);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -59,7 +59,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 PlanningToRetakeGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
-                AdviserStatusId = (int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttTeachingPosition,
+                AdviserStatusId = null,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -87,7 +87,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.PlanningToRetakeGcseScienceId.Should().Be(candidate.PlanningToRetakeGcseScienceId);
             response.PlanningToRetakeGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
             response.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
-            response.AdviserStatusId.Should().Be((int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttTeachingPosition);
+            response.AdviserStatusId.Should().BeNull();
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
@@ -133,7 +133,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 HasGcseScienceId = 7,
                 PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = 9,
-                AdviserStatusId = 10,
+                AdviserStatusId = null,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -161,7 +161,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeGcseScienceId.Should().Equals(request.PlanningToRetakeGcseScienceId);
-            candidate.AdviserStatusId.Should().Equals(request.AdviserStatusId);
+            candidate.AdviserStatusId.Should().BeNull();
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
@@ -189,6 +189,8 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
             candidate.GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
             candidate.OptOutOfGdpr.Should().BeFalse();
+
+            candidate.RegistrationStatusId.Should().BeNull();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
@@ -436,6 +438,16 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             var request = new TeacherTrainingAdviserSignUp() { AddressPostcode = "ky119yu" };
 
             request.Candidate.AddressPostcode.Should().Be("KY11 9YU");
+        }
+
+        [Fact]
+        public void Candidate_WithClosedAdviserStatusId_UpdatesAssignmentAndRegistrationStatus()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { AdviserStatusId = (int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AlreadyHasQts };
+
+            request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
+            request.Candidate.RegistrationStatusId.Should().Be((int)Candidate.RegistrationStatus.ReRegistered);
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow);
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -59,6 +59,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 PlanningToRetakeGcseEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
+                AdviserStatusId = (int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttTeachingPosition,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -86,6 +87,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.PlanningToRetakeGcseScienceId.Should().Be(candidate.PlanningToRetakeGcseScienceId);
             response.PlanningToRetakeGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
             response.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
+            response.AdviserStatusId.Should().Be((int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttTeachingPosition);
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
@@ -131,6 +133,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 HasGcseScienceId = 7,
                 PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = 9,
+                AdviserStatusId = 10,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -158,6 +161,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeGcseScienceId.Should().Equals(request.PlanningToRetakeGcseScienceId);
+            candidate.AdviserStatusId.Should().Equals(request.AdviserStatusId);
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);


### PR DESCRIPTION
[Trello-1698](https://trello.com/c/yG3hzAuh/1698-development-unblock-get-an-adviser-applicants-who-have-previously-had-an-adviser)

- Rename AdviserStatus to AdviserStatusId

To match the other option set fields.

- Expose AdviserStatusId on TeacherTrainingAdviserSignUp

We need to expose this so that the client can post it back to us for matchback scenarios (otherwise we would have to query the CRM to retrieve it, which would complicate the logic for when the CRM is offline etc).

- Handle candidates with closed adviser status

When a candidate re-subscribes and has a closed adviser status we want to:

```
- Set the `AssignmentStatusId` to `WaitingToBeAssigned`
- Set the `RegistrationStatusId` to `ReRegistered`
- Update the `StatusIsWaitingToBeAssignedAt` to the current date/time
```

- Post adviser_status_id back to the API

If an candidate has an `adviser_status_id` returned as part of the matchback process we want to post this back to the API as part of the submission. This avoids the API having to re-retrieve the candidate in order to determine the status.