### PR TITLE
Add IsWalkIn attribute to TeachingEventAddAttendee

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
@@ -27,6 +27,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string AddressTelephone { get; set; }
+        public bool IsWalkIn { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
         [SwaggerSchema(ReadOnly = true)]


### PR DESCRIPTION
[Trello-1767](https://trello.com/c/0pE9y92j/1767-create-a-ml-sign-up-form-for-events-walk-ins)

We are going to start accepting 'walk in' sign ups to events that are otherwise closed to new registrations.

Add `IsWalkIn` attribute to the `TeachingEventAddAttendee` model so we can capture this and submit it with the rest of the event sign up form in the GiT app.

When the new channel creation has been added to the CRM we will be able to mark the candidate as a 'walk in' sign up.