### PR TITLE
Add total callbacks booked Grafana panel

### DIFF
--- a/monitoring/grafana/dashboards/get_into_teaching_api.json
+++ b/monitoring/grafana/dashboards/get_into_teaching_api.json
@@ -27,8 +27,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1623747049000,
+  "id": 6,
+  "iteration": 1628066205294,
   "links": [],
   "panels": [
     {
@@ -181,99 +181,6 @@
         "x": 6,
         "y": 1
       },
-      "id": 30,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "bucketAggs": [
-            {
-              "field": "@timestamp",
-              "id": "2",
-              "settings": {
-                "interval": "auto",
-                "min_doc_count": 0,
-                "trimEdges": 0
-              },
-              "type": "date_histogram"
-            }
-          ],
-          "metrics": [
-            {
-              "field": "select field",
-              "id": "1",
-              "type": "count"
-            }
-          ],
-          "query": "access.url:\"api/teaching_events/attendees\" AND access.method: POST AND access.response_code: 204 AND cf.app:\"$App\"",
-          "refId": "A",
-          "timeField": "@timestamp"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Teaching Event Sign Ups",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "Elasticseach",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [
-            {
-              "id": 0,
-              "op": "=",
-              "text": "N/A",
-              "type": 1,
-              "value": "null"
-            }
-          ],
-          "nullValueMode": "connected",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#FF9830",
-                "value": null
-              },
-              {
-                "color": "#FF9830",
-                "value": 0
-              },
-              {
-                "color": "#299c46",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 12,
-        "y": 1
-      },
       "id": 31,
       "interval": null,
       "links": [],
@@ -364,8 +271,194 @@
       "gridPos": {
         "h": 9,
         "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 30,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "access.url:\"api/teaching_events/attendees\" AND access.method: POST AND access.response_code: 204 AND cf.app:\"$App\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Teaching Event Sign Ups",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FF9830",
+                "value": null
+              },
+              {
+                "color": "#FF9830",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
         "x": 18,
         "y": 1
+      },
+      "id": 68,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "access.url:\"api/get_into_teaching/callbacks\" AND access.method: POST AND access.response_code: 204 AND cf.app:\"$App\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Callback Bookings",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FF9830",
+                "value": null
+              },
+              {
+                "color": "#FF9830",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 10
       },
       "id": 67,
       "interval": null,
@@ -439,7 +532,7 @@
       "gridPos": {
         "h": 10,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 10
       },
       "id": 32,
@@ -558,102 +651,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Matchback Requests",
-      "type": "grafana-piechart-panel",
-      "valueName": "total"
-    },
-    {
-      "aliasColors": {
-        "Failed Attempt": "#F2495C",
-        "Mailing List (failure)": "#F2495C",
-        "Miss": "#5794F2"
-      },
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "Elasticseach",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 10
-      },
-      "id": 65,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "values": true
-      },
-      "legendType": "Under graph",
-      "links": [],
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "alias": "Mailing List",
-          "bucketAggs": [
-            {
-              "field": "@timestamp",
-              "id": "2",
-              "settings": {
-                "interval": "auto",
-                "min_doc_count": 0,
-                "trimEdges": 0
-              },
-              "type": "date_histogram"
-            }
-          ],
-          "metrics": [
-            {
-              "field": "select field",
-              "id": "1",
-              "type": "count"
-            }
-          ],
-          "query": "\"/api/mailing_list/members/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 200 AND cf.app:\"$App\"",
-          "refId": "A",
-          "timeField": "@timestamp"
-        },
-        {
-          "alias": "Failed Attempt",
-          "bucketAggs": [
-            {
-              "field": "@timestamp",
-              "id": "2",
-              "settings": {
-                "interval": "auto",
-                "min_doc_count": 0,
-                "trimEdges": 0
-              },
-              "type": "date_histogram"
-            }
-          ],
-          "metrics": [
-            {
-              "field": "select field",
-              "id": "1",
-              "type": "count"
-            }
-          ],
-          "query": "\"/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 401 AND cf.app:\"$App\"",
-          "refId": "B",
-          "timeField": "@timestamp"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Magic Link Requests",
       "type": "grafana-piechart-panel",
       "valueName": "total"
     },
@@ -847,13 +844,109 @@
       "type": "stat"
     },
     {
+      "aliasColors": {
+        "Failed Attempt": "#F2495C",
+        "Mailing List (failure)": "#F2495C",
+        "Miss": "#5794F2"
+      },
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 65,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "alias": "Mailing List",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/api/mailing_list/members/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 200 AND cf.app:\"$App\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "Failed Attempt",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "\"/exchange_magic_link_token/\" AND access.method: GET AND access.response_code: 401 AND cf.app:\"$App\"",
+          "refId": "B",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Magic Link Requests",
+      "type": "grafana-piechart-panel",
+      "valueName": "total"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 30
       },
       "id": 46,
       "panels": [],
@@ -880,7 +973,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 52,
@@ -984,7 +1077,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 44,
@@ -1172,7 +1265,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 41
       },
       "id": 38,
       "panels": [],
@@ -1198,7 +1291,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 23,
@@ -1294,7 +1387,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1390,7 +1483,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 54
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1491,7 +1584,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 66
       },
       "id": 40,
       "panels": [],
@@ -1532,7 +1625,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 57
+        "y": 67
       },
       "id": 50,
       "interval": null,
@@ -1599,7 +1692,7 @@
         "h": 10,
         "w": 5,
         "x": 4,
-        "y": 57
+        "y": 67
       },
       "id": 48,
       "interval": null,
@@ -1673,7 +1766,7 @@
         "h": 10,
         "w": 5,
         "x": 9,
-        "y": 57
+        "y": 67
       },
       "id": 6,
       "interval": null,
@@ -1749,7 +1842,7 @@
         "h": 10,
         "w": 5,
         "x": 14,
-        "y": 57
+        "y": 67
       },
       "id": 66,
       "interval": null,
@@ -1825,7 +1918,7 @@
         "h": 10,
         "w": 5,
         "x": 19,
-        "y": 57
+        "y": 67
       },
       "id": 21,
       "interval": null,
@@ -1879,7 +1972,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 77
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1989,7 +2082,7 @@
         "h": 12,
         "w": 6,
         "x": 12,
-        "y": 67
+        "y": 77
       },
       "id": 25,
       "interval": null,
@@ -2049,7 +2142,7 @@
         "h": 12,
         "w": 6,
         "x": 18,
-        "y": 67
+        "y": 77
       },
       "id": 14,
       "interval": null,
@@ -2133,7 +2226,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 89
       },
       "id": 16,
       "pageSize": null,
@@ -2195,7 +2288,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 100
       },
       "hiddenSeries": false,
       "id": 18,
@@ -2296,7 +2389,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 100
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2361,7 +2454,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2479,7 +2572,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 60,
@@ -2692,7 +2785,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 122
       },
       "id": 34,
       "panels": [],
@@ -2718,7 +2811,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 113
+        "y": 123
       },
       "hiddenSeries": false,
       "id": 61,
@@ -2852,7 +2945,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 113
+        "y": 123
       },
       "hiddenSeries": false,
       "id": 2,
@@ -2939,7 +3032,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 135
       },
       "id": 42,
       "panels": [],
@@ -2988,7 +3081,7 @@
         "h": 10,
         "w": 4,
         "x": 0,
-        "y": 126
+        "y": 136
       },
       "id": 27,
       "interval": null,
@@ -3063,7 +3156,7 @@
         "h": 10,
         "w": 4,
         "x": 4,
-        "y": 126
+        "y": 136
       },
       "id": 55,
       "interval": null,
@@ -3135,7 +3228,7 @@
         "h": 10,
         "w": 16,
         "x": 8,
-        "y": 126
+        "y": 136
       },
       "hiddenSeries": false,
       "id": 58,


### PR DESCRIPTION
Add a new panel to the Grafana dashboard to track the number of callbacks booked.

Shifts some of the other panels around, hence the big diff.

<img width="1417" alt="Screenshot 2021-08-04 at 09 40 56" src="https://user-images.githubusercontent.com/29867726/128150563-75cb0ff7-d226-43e2-aa3e-7ed972a432a1.png">
