### PR TITLE
Bug fix to support empty array in GetCandidates method

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -152,6 +152,11 @@ namespace GetIntoTeachingApi.Services
 
         public IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids)
         {
+            if (!ids.Any())
+            {
+                return Array.Empty<Candidate>();
+            }
+
             var query = new QueryExpression("contact");
             query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(Candidate)));
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -350,6 +350,16 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void GetCandidates_WithNoIds_ReturnsEmpty()
+        {
+            var ids = Array.Empty<Guid>();
+
+            var result = _crm.GetCandidates(ids);
+
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
         public void GetCandidates_WithIds_ReturnsCorrectly()
         {
             var ids = new Guid[] { JaneDoeGuid, JohnDoeGuid };


### PR DESCRIPTION
The Dynamics `QueryExpression` interpreter doesn't support an empty value for an `In` conditional, so we need to return early in this instance and not call the CRM.