### PR TITLE
Remove redundant AlreadySubscribedToTeacherTrainingAdviser attribute

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -79,8 +79,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         [SwaggerSchema(WriteOnly = true)]
         public DateTime? PhoneCallScheduledAt { get; set; }
         [SwaggerSchema(ReadOnly = true)]
-        public bool AlreadySubscribedToTeacherTrainingAdviser { get; set; }
-        [SwaggerSchema(ReadOnly = true)]
         public bool CanSubscribeToTeacherTrainingAdviser { get; set; }
 
         [JsonIgnore]
@@ -148,7 +146,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             TypeId = candidate.TypeId;
             AdviserStatusId = candidate.AdviserStatusId;
 
-            AlreadySubscribedToTeacherTrainingAdviser = candidate.HasTeacherTrainingAdviser();
             CanSubscribeToTeacherTrainingAdviser = CanSubscribe(candidate);
 
             var latestQualification = candidate.Qualifications.OrderByDescending(q => q.CreatedAt).FirstOrDefault();

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -107,7 +107,6 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.PastTeachingPositionId.Should().Be(latestPastTeachingPosition.Id);
             response.SubjectTaughtId.Should().Be(latestPastTeachingPosition.SubjectTaughtId);
 
-            response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
             response.CanSubscribeToTeacherTrainingAdviser.Should().BeTrue();
         }
 


### PR DESCRIPTION
This has been replaced with the `CanSubscribeToTeacherTrainingAdviser` attribute.