### PR TITLE
Rate limit admin role

### DIFF
--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -14,7 +14,7 @@
     "ClientIdHeader": "Authorization",
     "HttpStatusCode": 429,
     "EndpointWhitelist": [ "*:/api/operations/*" ],
-    "ClientWhitelist": [ "ADMIN" ],
+    "ClientWhitelist": [],
     "GeneralRules": [
       {
         "Endpoint": "POST:/api/candidates/access_tokens",
@@ -44,6 +44,11 @@
       {
         "Endpoint": "POST:/api/get_into_teaching/callbacks",
         "Period": "1m",
+        "Limit": 60
+      },
+      {
+        "Endpoint": "POST:/api/teaching_events",
+        "Period": "1d",
         "Limit": 60
       }
     ]

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -23,6 +23,7 @@ namespace GetIntoTeachingApiTests.Integration
             Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
             Environment.SetEnvironmentVariable($"TTA_API_KEY", "tta-secret");
             Environment.SetEnvironmentVariable($"SE_API_KEY", "se-secret");
+            Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
 
             var factory = new GitWebApplicationFactory<Startup>();
             _httpClient = factory.CreateClient();
@@ -39,6 +40,13 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
         [InlineData("/api/candidates/access_tokens", "SE", 500)]
         [InlineData("/api/schools_experience/candidates", "SE", 250)]
+        [InlineData("/api/candidates/access_tokens", "ADMIN", 60)]
+        [InlineData("/api/mailing_list/members", "ADMIN", 60)]
+        [InlineData("/api/teaching_events/attendees", "ADMIN", 60)]
+        [InlineData("/api/teaching_events", "ADMIN", 60)]
+        [InlineData("/api/get_into_teaching/callbacks", "ADMIN", 60)]
+        [InlineData("/api/teacher_training_adviser/candidates", "ADMIN", 60)]
+        [InlineData("/api/schools_experience/candidates", "ADMIN", 60)]
         public async Task Post_Endpoint_AppliesRateLimit(string path, string client, int limit)
         {
             var apiKey = $"{client.ToLower()}-secret";


### PR DESCRIPTION
[Trello-1801](https://trello.com/c/iv8XI7tS/1801-api-pen-test-revoke-admin-role-from-rate-limiting-whitelist)

The admin role was whitelisted from any rate limiting; this was flagged by the pen test, so we're going to let the default rate limits apply to that role.

Also adds a default rate limit for the POST /api/teaching_events endpoint.