### PR TITLE
Secure HTTP response headers

### DIFF
--- a/GetIntoTeachingApi/AppStart/ResponseHeaders.cs
+++ b/GetIntoTeachingApi/AppStart/ResponseHeaders.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace GetIntoTeachingApi.AppStart
+{
+    public static class ResponseHeaders
+    {
+        public static void SetupSecureHeaders(IApplicationBuilder app)
+        {
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("X-Frame-Options", "deny");
+                context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                context.Response.Headers.Add("Content-Security-Policy", "default-src 'self'");
+                await next();
+            });
+        }
+    }
+}

--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -117,6 +117,8 @@ namespace GetIntoTeachingApi.AppStart
 
             app.UseAuthorization();
 
+            ResponseHeaders.SetupSecureHeaders(app);
+
             DatabaseUtility.Migrate(serviceScope, _env);
 
             if (!_env.IsTest)

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -20,6 +20,7 @@ namespace GetIntoTeachingApi
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseSentry();
+                    webBuilder.UseKestrel(opts => opts.AddServerHeader = false);
                     webBuilder.UseStartup<Startup>();
                 });
     }


### PR DESCRIPTION
- Remove Server header from response

The server header revealed that we use Kestrel and it was deemed 'verbose' by the pen test report so we are removing it.

- Add security headers

Adds the following security headers:

```
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'self'
```

Most of these are just box-ticking given access to the API is restricted by a secret and we don't serve any HTML in production.