### PR TITLE
Disable HTTP -> HTTPS redirection

### DIFF
--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -32,6 +32,7 @@
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
+        "ASPNETCORE_URLS": "https://localhost:5001",
         "TOTP_SECRET_KEY": "def456"
       }
     }


### PR DESCRIPTION
A HTTP to HTTPS redirection is potentially insecure; on a browser-facing website its often the lesser of two evils and forces users to connect via HTTPS if they input the HTTP address. On an API this isn't necessary and we can be more secure by disabling HTTP access completely, only accepting direct HTTPS connections (preventing a potential man in the middle attack).

To do this we ensure the application only accepts requests that are over HTTPS, as recommended by:

https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-5.0&tabs=visual-studio

I've updated dev/test with the appropriate `ASPNETCORE_URLS` env var and, assuming they work as expected, I'll update prod before shipping this.