### PR TITLE
Revert "Disable HTTP -> HTTPS redirection"

### DIFF
--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -32,7 +32,6 @@
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
-        "ASPNETCORE_URLS": "https://localhost:5001",
         "TOTP_SECRET_KEY": "def456"
       }
     }


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#746

This isn't deploying for some reason; even after I've reverted the env var changes in dev/test. The code change here _shouldn't_ have any bearing on dev/test, but in case it has I'm going to try and revert to see if it unblocks the deployments.

It looks like `ASPNETCORE_URLS` is also set in the Dockerfile, though when I ssh onto dev/test it doesn't appear explicitly set at all 🤷 