### PR TITLE
Format logging in JSON with Serilog

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net5.0</TargetFramework>
@@ -31,6 +31,8 @@
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
+		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using GetIntoTeachingApi.AppStart;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
 
 namespace GetIntoTeachingApi
 {
@@ -22,6 +24,11 @@ namespace GetIntoTeachingApi
                     webBuilder.UseSentry();
                     webBuilder.UseKestrel(opts => opts.AddServerHeader = false);
                     webBuilder.UseStartup<Startup>();
-                });
+                })
+            .UseSerilog(new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .WriteTo.Console()
+                .CreateLogger());
     }
 }

--- a/GetIntoTeachingApi/appsettings.Development.json
+++ b/GetIntoTeachingApi/appsettings.Development.json
@@ -1,9 +1,1 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
-}
+{}

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -1,12 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information",
-      "Hangfire": "Information"
-    }
-  },
   "AllowedHosts": "*",
   "ClientRateLimiting": {
     "EnableEndpointRateLimiting": true,


### PR DESCRIPTION
[Trello](https://trello.com/c/rIFDcBnt)

ASP.NET log messages aren't interpreted properly by Logit.
- Set Serilog as the logging provider, so that all ILoggers now use it and log messages in JSON.
- Remove default logger configuration.