### PR TITLE
Allow multiple event types in event search

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -78,13 +78,19 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);
 
+            // TODO: Fix. Prometheus can only be passed two labels currently. Don't know how we would want to handle multiple type IDs.
+            List<string> labels = new ();
+            var typeIds = request.TypeIds?.Select(id => id.ToString());
+            labels.Add(typeIds == null ? string.Empty : typeIds.First());
+            labels.Add(request.Radius.ToString());
+
             _metrics.TeachingEventSearchResults
-                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .WithLabels(labels.ToArray())
                 .Observe(teachingEvents.Count());
 
             var inPesonTeachingEvents = teachingEvents.Where(e => e.IsInPerson);
             _metrics.InPersonTeachingEventResults
-                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .WithLabels(labels.ToArray())
                 .Observe(inPesonTeachingEvents.Count());
 
             return Ok(GroupTeachingEventsByType(teachingEvents, quantityPerType));

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
@@ -11,7 +11,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         [SwaggerSchema("Set to filter results to a radius (in miles) around the postcode.")]
         public int? Radius { get; set; }
         [SwaggerSchema("Set to filter results to a type of teaching event. Must match an `typeId` of the `TeachingEvent` schema.")]
-        public int? TypeId { get; set; }
+        public int[] TypeIds { get; set; }
         [SwaggerSchema("Set to filter results to those that start after a given date.")]
         public DateTime? StartAfter { get; set; }
         [SwaggerSchema("Set to filter results to those that start before a given date.")]

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
@@ -13,9 +13,9 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
                 .MaximumLength(40)
                 .Matches(Location.OutwardOrFullPostcodeRegex)
                 .Unless(request => request.Postcode == null && request.Radius == null);
-            RuleFor(request => request.TypeId)
-                .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
-                .Unless(request => request.TypeId == null);
+            RuleFor(request => request.TypeIds)
+                .SetValidator(new PickListItemIdsValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
+                .Unless(request => request.TypeIds == null);
             RuleFor(request => request.Radius).GreaterThan(0);
             RuleFor(request => request)
                 .Must(StartAfterEarlierThanStartBefore)

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -91,9 +91,10 @@ namespace GetIntoTeachingApi.Services
                 .Include(te => te.Building)
                 .OrderBy(te => te.StartAt);
 
-            if (request.TypeId != null)
+            if (request.TypeIds != null)
             {
-                teachingEvents = teachingEvents.Where(te => te.TypeId == request.TypeId);
+                teachingEvents = teachingEvents.Where(te =>
+                    request.TypeIds.Contains(te.TypeId));
             }
 
             if (request.StartAfter != null)

--- a/GetIntoTeachingApi/Validators/PickListItemIdsValidator.cs
+++ b/GetIntoTeachingApi/Validators/PickListItemIdsValidator.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using FluentValidation;
+using FluentValidation.Validators;
+using GetIntoTeachingApi.Services;
+
+namespace GetIntoTeachingApi.Validators
+{
+    public class PickListItemIdsValidator<T> : PropertyValidator<T, int[]>
+    {
+        private readonly string _entityName;
+        private readonly string _attributeName;
+        private readonly IStore _store;
+
+        public PickListItemIdsValidator(string entityName, string attributeName, IStore store)
+        {
+            _entityName = entityName;
+            _attributeName = attributeName;
+            _store = store;
+        }
+
+        public override bool IsValid(ValidationContext<T> context, int[] values)
+        {
+            foreach (int value in values)
+            {
+                if (!_store.GetPickListItems(_entityName, _attributeName).Any(i => i.Id == value))
+                {
+                    context.MessageFormatter.AppendArgument("PropertyName", context.PropertyName);
+                    context.MessageFormatter.AppendArgument("EntityName", _entityName);
+                    context.MessageFormatter.AppendArgument("AttributeName", _attributeName);
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override string Name => "PickListItemIdsValidator";
+
+        protected override string GetDefaultMessageTemplate(string errorCode) => "{PropertyName} must be valid {EntityName}/{AttributeName} items.";
+    }
+}

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -129,8 +129,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             _mockLogger.VerifyInformationWasCalled("SearchGroupedByType: KY12 8FG");
 
-            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
-            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
+            _metrics.TeachingEventSearchResults.WithLabels(new[] { string.Empty, request.Radius.ToString() }).Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
@@ -21,11 +21,11 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
         [Fact]
         public void Clone_WithBlock_ClonesAndCallsBlock()
         {
-            var request = new TeachingEventSearchRequest() { Radius = 10, TypeId = 123 };
+            var request = new TeachingEventSearchRequest() { Radius = 10, TypeIds = new int[] { 123 } };
             var clone = request.Clone((te) => te.Radius = 100);
 
             clone.Radius.Should().Be(100);
-            clone.TypeId.Should().Be(request.TypeId);
+            clone.TypeIds.Should().BeEquivalentTo(request.TypeIds);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
             {
                 Postcode = "KY11 9HF",
                 Radius = 10,
-                TypeId = mockPickListItem.Id,
+                TypeIds = new int[] { mockPickListItem.Id },
                 StartAfter = DateTime.UtcNow.AddDays(-1),
                 StartBefore = DateTime.UtcNow.AddDays(1)
             };
@@ -102,15 +102,17 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         }
 
         [Fact]
-        public void Validate_TypeIdIsInvalid_HasError()
+        public void Validate_TypeIdsAreInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.TypeId, 123);
+            _validator
+                .ShouldHaveValidationErrorFor(request => request.TypeIds, new int[] { 123 })
+                .WithErrorMessage("Type Ids must be valid msevtmgt_event/dfe_event_type items.");
         }
 
         [Fact]
         public void Validate_TypeIdIsNull_HasNoError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.TypeId, null as int?);
+            _validator.ShouldNotHaveValidationErrorFor(request => request.TypeIds, null as int[]);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -414,7 +414,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 15,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -435,7 +435,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 13,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -456,7 +456,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 12,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -509,12 +509,31 @@ namespace GetIntoTeachingApiTests.Services
         {
             SeedMockLocations();
             await SeedMockTeachingEventsAndBuildingsAsync();
-            var request = new TeachingEventSearchRequest() { TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop };
+            var request = new TeachingEventSearchRequest() { TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop } };
 
             var result = await _store.SearchTeachingEventsAsync(request);
 
             result.Select(e => e.Name).Should().BeEquivalentTo(new string[] { "Event 2" },
                 options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public async void SearchTeachingEvents_FilteredByMultipleTypes_ReturnsMatching()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAndBuildingsAsync();
+            var request = new TeachingEventSearchRequest()
+            {
+                TypeIds = new int[]
+                {
+                    (int)TeachingEvent.EventType.TrainToTeachEvent,
+                    (int)TeachingEvent.EventType.ApplicationWorkshop
+                }
+            };
+
+            var results = await _store.SearchTeachingEventsAsync(request);
+
+            results.Select(e => e.Name).Should().Contain(new string[] { "Event 1", "Event 2" });
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Validators/PickListItemIdsValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Validators/PickListItemIdsValidatorTests.cs
@@ -1,0 +1,55 @@
+﻿using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
+using Moq;
+using Xunit;
+using FluentValidation;
+using GetIntoTeachingApi.Models;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+
+namespace GetIntoTeachingApiTests.Validators
+{
+    public class PickListItemIdsValidatorTests
+    {
+        private readonly Mock<IStore> _mockStore;
+        private readonly List<PickListItem> _items;
+        private readonly PickListItemIdsValidator<object> _validator;
+
+        public PickListItemIdsValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new PickListItemIdsValidator<object>("contact", "dfe_channel", _mockStore.Object);
+            _items = new List<PickListItem> {
+                new PickListItem { Id = 111 },
+                new PickListItem { Id = 222 }
+            };
+
+            _mockStore.Setup(m => m.GetPickListItems("contact", "dfe_channel")).Returns(_items.AsQueryable());
+        }
+
+        [Theory]
+        [InlineData(111)]
+        [InlineData(111, 222)]
+        public void IsValid_WhenValidIds_ReturnsTrue(params int[] ids)
+        {
+            var context = new ValidationContext<object>(this);
+
+            var valid = _validator.IsValid(context, ids);
+
+            valid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(333)]
+        [InlineData(111, 333)]
+        public void IsValid_WhenInvalidIds_ReturnsFalse(params int[] ids)
+        {
+            var context = new ValidationContext<object>(this);
+
+            var valid = _validator.IsValid(context, ids);
+
+            valid.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
https://trello.com/c/qbuoFw8L

We may want to search by multiple event types to prevent filtering in the client. Update the type ID parameter of the teaching event search to an array of event types.

Not sure how we would want to handle multiple event types in Prometheus. Not sure if it really matters, but do we need a "don't track" param so that we don't export certain searches (internal searches) to Prometheus.

Also, not sure what the best way to clean up the two PickListItem validators is... 