### PR TITLE
Sync additional data to the CRM from the Apply API

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using GetIntoTeachingApi.Models.FindApply;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -44,14 +45,54 @@ namespace GetIntoTeachingApi.Jobs
             {
                 _logger.LogInformation($"FindApplyCandidateSyncJob - Hit - {findApplyCandidate.Id}");
 
-                // We persist a new Candidate to ensure we only write the FindApplyId
-                // back to the CRM and not existing attributes on the match.
-                var candidate = new Models.Crm.Candidate() { Id = match.Id, FindApplyId = findApplyCandidate.Id };
-                _crm.Save(candidate);
+                var candidateId = (Guid)match.Id;
+                UpdateCandidate(candidateId, findApplyCandidate);
+                UpsertApplicationForms(candidateId, findApplyCandidate.Attributes.ApplicationForms);
             }
             else
             {
                 _logger.LogInformation($"FindApplyCandidateSyncJob - Miss - {findApplyCandidate.Id}");
+            }
+        }
+
+        private void UpdateCandidate(Guid candidateId, Candidate findApplyCandidate)
+        {
+            // We persist a new Candidate to ensure we only write the find/apply
+            // attributes back to the CRM and not existing attributes on the match.
+            var candidate = new Models.Crm.Candidate()
+            {
+                Id = candidateId,
+                FindApplyId = findApplyCandidate.Id,
+                FindApplyCreatedAt = findApplyCandidate.Attributes.CreatedAt,
+                FindApplyUpdatedAt = findApplyCandidate.Attributes.UpdatedAt,
+                FindApplyStatusId = (int)Enum.Parse(typeof(Models.Crm.Candidate.FindApplyApplicationStatus), findApplyCandidate.Attributes.ApplicationStatus.ToPascalCase()),
+                FindApplyPhaseId = (int)Enum.Parse(typeof(Models.Crm.Candidate.FindApplyApplicationPhase), findApplyCandidate.Attributes.ApplicationPhase.ToPascalCase()),
+            };
+
+            _crm.Save(candidate);
+        }
+
+        private void UpsertApplicationForms(Guid candidateId, IEnumerable<ApplicationForm> findApplyApplicationForms)
+        {
+            if (findApplyApplicationForms == null)
+            {
+                return;
+            }
+
+            foreach (var findApplyForm in findApplyApplicationForms)
+            {
+                var existingForm = _crm.GetApplicationForm(findApplyForm.Id.ToString());
+
+                var form = new Models.Crm.ApplicationForm()
+                {
+                    Id = existingForm?.Id,
+                    CandidateId = candidateId,
+                    FindApplyId = findApplyForm.Id.ToString(),
+                    CreatedAt = findApplyForm.CreatedAt,
+                    UpdatedAt = findApplyForm.UpdatedAt,
+                };
+
+                _crm.Save(form);
             }
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using FluentValidation;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Services;
+using Microsoft.Xrm.Sdk;
+
+namespace GetIntoTeachingApi.Models.Crm
+{
+    [SwaggerIgnore]
+    [Entity("dfe_applyapplicationform")]
+    public class ApplicationForm : BaseModel, IHasCandidateId
+    {
+        [EntityField("dfe_contact", typeof(EntityReference), "contact")]
+        public Guid CandidateId { get; set; }
+        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue))]
+        public int? PhaseId { get; set; }
+        [EntityField("dfe_applicationformid")]
+        public string FindApplyId { get; set; }
+        [EntityField("dfe_createdon")]
+        public DateTime CreatedAt { get; set; }
+        [EntityField("dfe_modifiedon")]
+        public DateTime UpdatedAt { get; set; }
+
+        public ApplicationForm()
+            : base()
+        {
+        }
+
+        public ApplicationForm(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+            : base(entity, crm, validatorFactory)
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -105,6 +105,30 @@ namespace GetIntoTeachingApi.Models.Crm
             ReRegistered = 222750000,
         }
 
+        // The keys for this enum need to mirror the
+        // Apply API naming so we can match them up.
+        public enum FindApplyApplicationStatus
+        {
+            NeverSignedIn = 222750000,
+            UnsubmittedNotStartedForm = 222750001,
+            UnsubmittedInProgress = 222750002,
+            AwaitingProviderDecisions = 222750003,
+            AwaitingCandidateResponse = 222750004,
+            Recruited = 222750005,
+            PendingConditions = 222750006,
+            OfferDeferred = 222750007,
+            EndedWithoutSuccess = 222750008,
+            UnknownState = 222750009,
+        }
+
+        // The keys for this enum need to mirror the
+        // Apply API naming so we can match them up.
+        public enum FindApplyApplicationPhase
+        {
+            Apply1 = 222750000,
+            Apply2 = 222750001,
+        }
+
         public string FullName => $"{FirstName} {LastName}".NullIfEmptyOrWhitespace();
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }
@@ -156,12 +180,20 @@ namespace GetIntoTeachingApi.Models.Crm
         public int? AdviserStatusId { get; set; }
         [EntityField("dfe_candidatereregisterstatus", typeof(OptionSetValue))]
         public int? RegistrationStatusId { get; set; }
+        [EntityField("dfe_candidateapplystatus", typeof(OptionSetValue), null, new string[] { "Staging", "Production" })]
+        public int? FindApplyStatusId { get; set; }
+        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue), null, new string[] { "Staging", "Production" })]
+        public int? FindApplyPhaseId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]
         public bool Merged { get; set; }
         [EntityField("dfe_applyid", null, null, new[] { "Production" })]
         public string FindApplyId { get; set; }
+        [EntityField("dfe_applylastmodifiedon", null, null, new[] { "Staging", "Production" })]
+        public DateTime? FindApplyUpdatedAt { get; set; }
+        [EntityField("dfe_applycreatedon", null, null, new[] { "Staging", "Production" })]
+        public DateTime? FindApplyCreatedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
         [EntityField("emailaddress2")]

--- a/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Validators;
+
+namespace GetIntoTeachingApi.Models.Crm.Validators
+{
+    public class ApplicationFormValidator : AbstractValidator<ApplicationForm>
+    {
+        public ApplicationFormValidator(IStore store)
+        {
+            RuleFor(form => form.FindApplyId).NotEmpty();
+            RuleFor(form => form.PhaseId)
+                .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_candidateapplyphase", store))
+                .Unless(form => form.PhaseId == null);
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -100,6 +100,12 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitismlservicesubscriptionchannel", store))
                 .Unless(candidate => candidate.MailingListSubscriptionChannelId == null);
+            RuleFor(candidate => candidate.FindApplyPhaseId)
+                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
+                .Unless(candidate => candidate.FindApplyPhaseId == null);
+            RuleFor(candidate => candidate.FindApplyStatusId)
+                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplyphase", store))
+                .Unless(candidate => candidate.FindApplyStatusId == null);
         }
     }
 }

--- a/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class ApplicationForm
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
+++ b/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace GetIntoTeachingApi.Models.FindApply
 {
@@ -6,5 +8,15 @@ namespace GetIntoTeachingApi.Models.FindApply
     {
         [JsonProperty("email_address")]
         public string Email { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+        [JsonProperty("application_status")]
+        public string ApplicationStatus { get; set; }
+        [JsonProperty("application_phase")]
+        public string ApplicationPhase { get; set; }
+        [JsonProperty("application_forms")]
+        public IEnumerable<ApplicationForm> ApplicationForms { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -73,6 +73,23 @@ namespace GetIntoTeachingApi.Services
                 .FirstOrDefault();
         }
 
+        public ApplicationForm GetApplicationForm(string findApplyId)
+        {
+            var query = new QueryExpression("dfe_applyapplicationform");
+            query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(ApplicationForm)));
+            query.Criteria.AddCondition(new ConditionExpression("dfe_applicationformid", ConditionOperator.Equal, findApplyId));
+
+            var entities = _service.RetrieveMultiple(query);
+            var entity = entities.FirstOrDefault();
+
+            if (entity == null)
+            {
+                return null;
+            }
+
+            return new ApplicationForm(entity, this, _validatorFactory);
+        }
+
         public IEnumerable<PrivacyPolicy> GetPrivacyPolicies()
         {
             return _service.CreateQuery("dfe_privacypolicy", Context())

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -23,6 +23,7 @@ namespace GetIntoTeachingApi.Services
         TeachingEvent GetTeachingEvent(string readableId);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
+        ApplicationForm GetApplicationForm(string findApplyId);
         bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -242,6 +242,8 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("contact", "dfe_isadvisorrequiredos");
             await SyncPickListItem("contact", "dfe_gitismlservicesubscriptionchannel");
             await SyncPickListItem("contact", "dfe_gitiseventsservicesubscriptionchannel");
+            await SyncPickListItem("contact", "dfe_candidateapplystatus");
+            await SyncPickListItem("contact", "dfe_candidateapplyphase");
             await SyncPickListItem("dfe_candidatequalification", "dfe_degreestatus");
             await SyncPickListItem("dfe_candidatequalification", "dfe_ukdegreegrade");
             await SyncPickListItem("dfe_candidatequalification", "dfe_type");
@@ -251,6 +253,7 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("msevtmgt_eventregistration", "dfe_channelcreation");
             await SyncPickListItem("phonecall", "dfe_channelcreation");
             await SyncPickListItem("dfe_servicesubscription", "dfe_servicesubscriptiontype");
+            await SyncPickListItem("dfe_applyapplicationform", "dfe_candidateapplyphase");
         }
 
         private async Task SyncModels<T>(IEnumerable<T> models, IQueryable<T> dbSet)

--- a/GetIntoTeachingApi/Utils/StringExtensions.cs
+++ b/GetIntoTeachingApi/Utils/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using GetIntoTeachingApi.Models;
 
 namespace GetIntoTeachingApi.Utils
@@ -47,6 +48,13 @@ namespace GetIntoTeachingApi.Utils
         public static string NullIfEmptyOrWhitespace(this string str)
         {
             return string.IsNullOrWhiteSpace(str) ? null : str;
+        }
+
+        public static string ToPascalCase(this string str)
+        {
+            str = str.ToLower().Replace("_", " ");
+            var info = CultureInfo.CurrentCulture.TextInfo;
+            return info.ToTitleCase(str).Replace(" ", string.Empty);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -51,7 +51,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var mappings = ok.Value.Should().BeOfType<List<MappingInfo>>().Subject;
-            mappings.Count().Should().Be(12);
+            mappings.Count().Should().Be(13);
             mappings.Any(m => m.LogicalName == "contact" &&
                               m.Class == "GetIntoTeachingApi.Models.Crm.Candidate"
             ).Should().BeTrue();

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models.FindApply;
@@ -17,7 +18,9 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<ILogger<FindApplyCandidateSyncJob>> _mockLogger;
         private readonly Mock<ICrmService> _mockCrm;
         private readonly FindApplyCandidateSyncJob _job;
-        private readonly GetIntoTeachingApi.Models.FindApply.Candidate _candidate;
+        private readonly Candidate _candidate;
+        private readonly CandidateAttributes _attributes;
+        private readonly IList<ApplicationForm> _forms;
 
         public FindApplyCandidateSyncJobTests()
         {
@@ -29,7 +32,25 @@ namespace GetIntoTeachingApiTests.Jobs
                 _mockLogger.Object,
                 _mockCrm.Object,
                 _mockAppSettings.Object);
-            _candidate = new GetIntoTeachingApi.Models.FindApply.Candidate() { Id = "12345", Attributes = new CandidateAttributes() { Email = "email@address.com" } };
+            _forms = new List<ApplicationForm>()
+            {
+                new ApplicationForm() { Id = 1, CreatedAt = new DateTime(2021, 1, 3), UpdatedAt = new DateTime(2021, 1, 5) },
+                new ApplicationForm() { Id = 2, CreatedAt = new DateTime(2021, 1, 4) },
+            };
+            _attributes = new CandidateAttributes()
+            {
+                Email = "email@address.com",
+                CreatedAt = new DateTime(2021, 1, 1, 10, 0, 0),
+                UpdatedAt = new DateTime(2021, 1, 2, 11, 12, 13),
+                ApplicationForms = _forms,
+                ApplicationStatus = "never_signed_in",
+                ApplicationPhase = "apply_2",
+            };
+            _candidate = new Candidate()
+            { 
+                Id = "12345",
+                Attributes = _attributes
+            };
         }
 
         [Fact]
@@ -38,7 +59,43 @@ namespace GetIntoTeachingApiTests.Jobs
             var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(c => c.Id == match.Id && c.FindApplyId == _candidate.Id)));
+            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(
+                c => c.Id == match.Id
+                && c.FindApplyId == _candidate.Id
+                && c.Email == _attributes.Email
+                && c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.Candidate.FindApplyApplicationStatus.NeverSignedIn
+                && c.FindApplyPhaseId == (int)GetIntoTeachingApi.Models.Crm.Candidate.FindApplyApplicationPhase.Apply2
+                && c.FindApplyCreatedAt == _attributes.CreatedAt
+                && c.FindApplyUpdatedAt == _attributes.UpdatedAt)));
+            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.ApplicationForm>()));
+
+            _job.Run(_candidate);
+
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Hit - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
+        }
+
+        [Fact]
+        public void Run_OnSuccess_SavesApplicationForms()
+        {
+            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
+            var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
+            _mockCrm.Setup(m => m.GetApplicationForm("1")).Returns<GetIntoTeachingApi.Models.Crm.ApplicationForm>(null);
+            _mockCrm.Setup(m => m.GetApplicationForm("2")).Returns(existingApplicationForm);
+            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.Candidate>()));
+            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.ApplicationForm>(
+                f => f.Id == null
+                && f.FindApplyId == _forms[0].Id.ToString()
+                && f.CreatedAt == _forms[0].CreatedAt
+                && f.UpdatedAt == _forms[0].UpdatedAt)));
+            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.ApplicationForm>(
+                f => f.Id == existingApplicationForm.Id
+                && f.FindApplyId == _forms[1].Id.ToString()
+                && f.CreatedAt == _forms[1].CreatedAt
+                && f.UpdatedAt == _forms[1].UpdatedAt)));
 
             _job.Run(_candidate);
 
@@ -51,7 +108,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_WhenCandidateNotFound_LogsMiss()
         {
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<GetIntoTeachingApi.Models.FindApply.Candidate>(null);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
 
             _job.Run(_candidate);
 

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Attributes;
+using GetIntoTeachingApi.Models.Crm;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Crm
+{
+    public class ApplicationFormTests
+    {
+        [Fact]
+        public void EntityAttributes()
+        {
+            var type = typeof(ApplicationForm);
+
+            type.Should().BeDecoratedWith<EntityAttribute>(a => a.LogicalName == "dfe_applyapplicationform");
+            type.Should().BeDecoratedWith<SwaggerIgnoreAttribute>();
+
+            type.GetProperty("CandidateId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_contact"
+                && a.Type == typeof(EntityReference) && a.Reference == "contact");
+
+            type.GetProperty("PhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue));
+
+            type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationformid");
+            type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_createdon");
+            type.GetProperty("UpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_modifiedon");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -73,8 +73,14 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 a => a.Name == "dfe_candidateadviserstatusreason" && a.Type == typeof(OptionSetValue));
             type.GetProperty("RegistrationStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidatereregisterstatus" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("FindApplyStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_candidateapplystatus" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("FindApplyPhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");
+            type.GetProperty("FindApplyUpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applylastmodifiedon");
+            type.GetProperty("FindApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon");
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Models.Crm.Validators;
+using GetIntoTeachingApi.Services;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.Crm.Validators
+{
+    public class ApplicationFormValidatorTests
+    {
+        private readonly ApplicationFormValidator _validator;
+        private readonly Mock<IStore> _mockStore;
+
+        public ApplicationFormValidatorTests()
+        {
+            _mockStore = new Mock<IStore>();
+            _validator = new ApplicationFormValidator(_mockStore.Object);
+        }
+
+        [Fact]
+        public void Validate_WhenValid_HasNoErrors()
+        {
+            var mockPickListItem = new PickListItem { Id = 123 };
+
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_candidateapplyphase"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+
+            var form = new ApplicationForm()
+            {
+                CandidateId = Guid.NewGuid(),
+                FindApplyId = "67890",
+                PhaseId = mockPickListItem.Id,
+            };
+
+            var result = _validator.TestValidate(form);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_FindApplyIdIsEmpty_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(form => form.FindApplyId, "");
+        }
+
+        [Fact]
+        public void Validate_PhaseIdIsNull_HasNoError()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(form => form.PhaseId, null as int?);
+        }
+
+        [Fact]
+        public void Validate_PhaseIdIsNotValid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(form => form.PhaseId, 456);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -73,6 +73,12 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_isadvisorrequiredos"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
             _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_candidateapplystatus"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_candidateapplyphase"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
                 .Setup(mock => mock.GetPrivacyPolicies())
                 .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
 
@@ -111,6 +117,8 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 ChannelId = mockPickListItem.Id,
                 MailingListSubscriptionChannelId = mockPickListItem.Id,
                 EventsSubscriptionChannelId = mockPickListItem.Id,
+                FindApplyPhaseId = mockPickListItem.Id,
+                FindApplyStatusId = mockPickListItem.Id,
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
             };
 
@@ -659,6 +667,18 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         public void Validate_ClassroomExperienceNotesRawIsTooLong_HasError()
         {
             _validator.ShouldHaveValidationErrorFor(candidate => candidate.ClassroomExperienceNotesRaw, new string('a', 10001));
+        }
+
+        [Fact]
+        public void Validate_FindApplyPhaseIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FindApplyPhaseId, 123);
+        }
+
+        [Fact]
+        public void Validate_FindApplyStatusIdIsInvalid_HasError()
+        {
+            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FindApplyStatusId, 123);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ApplicationFormTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(ApplicationForm);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
+            type.GetProperty("CreatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
+            type.GetProperty("UpdatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
@@ -14,6 +14,16 @@ namespace GetIntoTeachingApiTests.Models.FindApply
 
             type.GetProperty("Email").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "email_address");
+            type.GetProperty("CreatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
+            type.GetProperty("UpdatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+            type.GetProperty("ApplicationStatus").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_status");
+            type.GetProperty("ApplicationPhase").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_phase");
+            type.GetProperty("ApplicationForms").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_forms");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -52,5 +52,14 @@ namespace GetIntoTeachingApiTests.Utils
         {
             input.AsFormattedTelephone(international).Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData("one_two_three", "OneTwoThree")]
+        [InlineData("ONE_TWO_THREE", "OneTwoThree")]
+        [InlineData("One Two Three", "OneTwoThree")]
+        public void ToPascalCase_IsConvertedCorrectly(string input, string expected)
+        {
+            input.ToPascalCase().Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
- Map additional attributes on Find/Apply models

New attributes are exposed on the Apply API; we are mapping these to the Find/Apply models so that we can later persist them to the CRM.

- Map Find/Apply modelling to CRM entities

The new data coming back from the Apply API will map to some new fields on the existing `Candidate` model and a new `ApplicationForm` model.

- Add extension to convert to PascalCase

We need this to be able to transform the incoming application status keys, such as `never_signed_in` to the respective C# enum key (i.e. `NeverSignedIn`).

- Sync additional Find/Apply data to CRM

We now have additional attributes on the apply `Candidate` model and a new `ApplicationForm` model that we can sync with the corresponding CRM models.

It is assumed for now that `ApplicationForm` entries will only need to be instead/updated and won't be deleted in the future. This is currently still under discussion in the Apply team - if that changes we can remove orphaned application forms from the CRM during the sync process.