### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -14,12 +14,12 @@
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.3" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.1.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.7">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.7">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.9">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -29,16 +29,16 @@
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
-		<PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.5" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-		<PackageReference Include="dotenv.net" Version="3.0.0" />
+		<PackageReference Include="dotenv.net" Version="3.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 		<PackageReference Include="Fody" Version="6.5.2">
@@ -46,13 +46,20 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.2" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
 		<PackageReference Include="GovukNotify" Version="4.0.1" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.12" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.21" />
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.9" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Castle.Core" Version="4.4.1" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -74,6 +81,13 @@
 	  <None Remove="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" />
 	  <None Remove="AspNetCoreRateLimit.Redis" />
 	  <None Remove="Hangfire.Dashboard.Basic.Authentication" />
+	  <None Remove="Newtonsoft.Json" />
+	  <None Remove="Microsoft.Extensions.DependencyInjection" />
+	  <None Remove="Microsoft.Extensions.Logging" />
+	  <None Remove="Serilog" />
+	  <None Remove="Castle.Core" />
+	  <None Remove="Microsoft.Bcl.AsyncInterfaces" />
+	  <None Remove="Microsoft.EntityFrameworkCore.Relational" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -54,7 +54,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+            errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
@@ -91,7 +91,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+            errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/MailingListControllerTests.cs
@@ -140,7 +140,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("FirstName").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
+            errors.Should().ContainKey("FirstName").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -79,7 +79,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("FirstName").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
+            errors.Should().ContainKey("FirstName").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("First name must be specified.");
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Postcode").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Postcode must be specified.");
+            errors.Should().ContainKey("Postcode").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Postcode must be specified.");
         }
 
         [Fact]
@@ -207,7 +207,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey(expectedErrorKey).WhichValue.Should().BeOfType<string[]>().Which.Should().Contain(expectedErrorMessage);
+            errors.Should().ContainKey(expectedErrorKey).WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain(expectedErrorMessage);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("ReadableId").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Must be unique");
+            errors.Should().ContainKey("ReadableId").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Must be unique");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -141,7 +141,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
         private static bool VerifyDateIsCloseTo(DateTime date, DateTime closeToDate)
         {
-            date.Should().BeCloseTo(closeToDate);
+            date.Should().BeCloseTo(closeToDate, TimeSpan.FromSeconds(30));
 
             return true;
         }

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -96,7 +96,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+            errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("SchoolName").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("SchoolName must be set.");
+            errors.Should().ContainKey("SchoolName").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("SchoolName must be set.");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -91,7 +91,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
-            errors.Should().ContainKey("Email").WhichValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+            errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -20,17 +20,17 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="5.10.3" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+	<PackageReference Include="FluentAssertions" Version="6.0.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 	<PackageReference Include="Moq" Version="4.16.1" />
-	<PackageReference Include="WireMock.Net" Version="1.4.18" />
+	<PackageReference Include="WireMock.Net" Version="1.4.20" />
 	<PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderTests.cs
+++ b/GetIntoTeachingApiTests/ModelBinders/TrimStringModelBinderTests.cs
@@ -27,7 +27,7 @@ namespace GetIntoTeachingApiTests.ModelBinders
         [Fact]
         public void BindModelAsync_WithNullContext_ThrowsArgumentNullException()
         {
-            _binder.Awaiting(b => b.BindModelAsync(null)).Should().Throw<ArgumentNullException>();
+            _binder.Awaiting(b => b.BindModelAsync(null)).Should().ThrowAsync<ArgumentNullException>();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
@@ -60,7 +60,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.PhoneCall.TalkingPoints.Should().Be(request.TalkingPoints);
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
-            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
@@ -100,7 +100,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.OptOutOfGdpr.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
-            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
 
             candidate.HasMailingListSubscription.Should().BeTrue();
             candidate.HasEventsSubscription.Should().BeTrue();

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
@@ -106,7 +106,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.OptOutOfGdpr.Should().BeFalse();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
-            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
 
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.HasMailingListSubscription.Should().BeTrue();

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
@@ -161,7 +161,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             candidate.DbsCertificateIssuedAt.Should().Be(request.DbsCertificateIssuedAt);
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
-            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -192,7 +192,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.RegistrationStatusId.Should().BeNull();
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
-            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow);
+            candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
 
             candidate.PhoneCall.ScheduledAt.Should().Be((DateTime)request.PhoneCallScheduledAt);
             candidate.PhoneCall.Telephone.Should().Be("00" + request.AddressTelephone);
@@ -416,7 +416,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
             request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
-            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow);
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
         }
 
         [Fact]
@@ -446,7 +446,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
 
             request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
             request.Candidate.RegistrationStatusId.Should().Be((int)Candidate.RegistrationStatus.ReRegistered);
-            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow);
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApiTests.Services
 
             candidate.MagicLinkToken.Should().NotBeNull();
             candidate.MagicLinkToken.Length.Should().Be(32);
-            candidate.MagicLinkTokenExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddHours(48));
+            candidate.MagicLinkTokenExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddHours(48), TimeSpan.FromSeconds(30));
             candidate.MagicLinkTokenStatusId.Should().Be((int)Candidate.MagicLinkTokenStatus.Generated);
         }
 

--- a/GetIntoTeachingApiTests/Services/DateTimeProviderTests.cs
+++ b/GetIntoTeachingApiTests/Services/DateTimeProviderTests.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var provider = new DateTimeProvider();
 
-            provider.UtcNow.Should().BeCloseTo(DateTime.UtcNow);
+            provider.UtcNow.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -56,8 +56,7 @@ namespace GetIntoTeachingApiTests.Services
             var countBefore = DbContext.PrivacyPolicies.Count();
             _mockCrm.Setup(m => m.GetPrivacyPolicies()).Throws<Exception>();
 
-            _store.Invoking(s => s.SyncAsync())
-                .Should().Throw<Exception>();
+            await _store.Awaiting(s => s.SyncAsync()).Should().ThrowAsync<Exception>();
 
             var countAfter = DbContext.PrivacyPolicies.Count();
             countBefore.Should().BeGreaterThan(0);
@@ -659,7 +658,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);
 
-            date.Should().BeCloseTo(afterDate);
+            date.Should().BeCloseTo(afterDate, TimeSpan.FromSeconds(30));
 
             return true;
         }


### PR DESCRIPTION
- Update dependencies

Update most of the dependencies to their latest version; omits `FluentValidation` as this has a major change that will require some refactoring to support.

- Update to use latest FluentAssertion methods

Some of our methods had been deprecated and required updating.