### PR TITLE
Update FluentValidation dependency

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -7,13 +7,13 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
 		<PackageReference Include="CsvHelper" Version="27.1.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.2.3" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.24" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.3" />
-		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.1.0" />
+		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
 		  <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidatePastTeachingPositionValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidatePastTeachingPositionValidatorTests.cs
@@ -49,25 +49,18 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_SubjectTaughtIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(position => position.SubjectTaughtId, Guid.NewGuid());
+            var result = _validator.TestValidate(new CandidatePastTeachingPosition() { SubjectTaughtId = Guid.NewGuid() });
+
+            result.ShouldHaveValidationErrorFor(c => c.SubjectTaughtId);
         }
 
-        [Fact]
-        public void Validate_SubjectTaughtIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(position => position.SubjectTaughtId, null as Guid?);
-        }
 
         [Fact]
         public void Validate_EducationPhaseIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(position => position.EducationPhaseId, 123);
-        }
+            var result = _validator.TestValidate(new CandidatePastTeachingPosition() { EducationPhaseId = 123 });
 
-        [Fact]
-        public void Validate_EducationPhaseIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(position => position.EducationPhaseId, null as int?);
+            result.ShouldHaveValidationErrorFor(c => c.EducationPhaseId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidatePrivacyPolicyValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidatePrivacyPolicyValidatorTests.cs
@@ -43,7 +43,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_AcceptedPolicyIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(policy => policy.AcceptedPolicyId, Guid.NewGuid());
+            var result = _validator.TestValidate(new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() });
+
+            result.ShouldHaveValidationErrorFor(p => p.AcceptedPolicyId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateQualificationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateQualificationValidatorTests.cs
@@ -50,45 +50,27 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_UkDegreeGradeIdIsInvalid_HasError()
+        public void Validate_IdFieldWithInvalidPickListItemId_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(qualification => qualification.UkDegreeGradeId, 123);
-        }
+            var qualification = new CandidateQualification()
+            {
+                UkDegreeGradeId = 123,
+                DegreeStatusId = 123,
+                TypeId = 123,
+            };
+            var result = _validator.TestValidate(qualification);
 
-        [Fact]
-        public void Validate_UkDegreeGradeIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(qualification => qualification.UkDegreeGradeId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_DegreeStatusIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(qualification => qualification.DegreeStatusId, 123);
-        }
-
-        [Fact]
-        public void Validate_DegreeStatusIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(qualification => qualification.DegreeStatusId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_TypeIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(qualification => qualification.TypeId, 123);
-        }
-
-        [Fact]
-        public void Validate_TypeIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(qualification => qualification.TypeId, null as int?);
+            result.ShouldHaveValidationErrorFor(c => c.UkDegreeGradeId);
+            result.ShouldHaveValidationErrorFor(c => c.DegreeStatusId);
+            result.ShouldHaveValidationErrorFor(c => c.TypeId);
         }
 
         [Fact]
         public void Validate_SubjectTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(qualification => qualification.DegreeSubject, new string('a', 601));
+            var result = _validator.TestValidate(new CandidateQualification() { DegreeSubject = new string('a', 601) });
+
+            result.ShouldHaveValidationErrorFor(c => c.DegreeSubject);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -190,120 +190,121 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_EmailAddressIsEmpty_HasError()
+        public void Validate_RequiredFieldsWhenNullOrEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, "");
+            var candidate = new Candidate()
+            {
+                Email = "",
+                SecondaryEmail = "",
+                FirstName = "",
+                LastName = "",
+                AddressTelephone = "",
+                MobileTelephone = "",
+                Telephone = "",
+                SecondaryTelephone = "",
+
+            };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
+            result.ShouldHaveValidationErrorFor(c => c.FirstName);
+            result.ShouldHaveValidationErrorFor(c => c.LastName);
+            result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.MobileTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.Telephone);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryTelephone);
         }
 
         [Fact]
-        public void Validate_EmailAddressIsInvalid_HasError()
+        public void Validate_EmailAddressInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, "invalid-email@");
+            var invalidEmail = "invalid-email@";
+            var candidate = new Candidate() { Email = invalidEmail, SecondaryEmail = invalidEmail };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_EmailAddressTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
+            var tooLongEmail = $"{new string('a', 50)}@{new string('a', 50)}.com";
+            var candidate = new Candidate() { Email = tooLongEmail, SecondaryEmail = tooLongEmail };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
-        public void Validate_EmailAddressPresent_HasNoError()
+        public void Validate_EmailAddressIsValid_HasNoError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Email, "valid@email.com");
-        }
+            var validEmail = "valid@email.com";
+            var candidate = new Candidate() { Email = validEmail, SecondaryEmail = validEmail };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_SecondaryEmailAddressIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryEmail, null as string);
-        }
-
-        [Fact]
-        public void Validate_SecondaryEmailAddressIsEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "");
-        }
-
-        [Fact]
-        public void Validate_SecondaryEmailAddressIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "invalid-email@");
-        }
-
-        [Fact]
-        public void Validate_SecondaryEmailAddressTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryEmail, $"{new string('a', 50)}@{new string('a', 50)}.com");
-        }
-
-        [Fact]
-        public void Validate_SecondaryEmailAddressPresent_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryEmail, "valid@email.com");
-        }
-
-        [Fact]
-        public void Validate_DateOfBirthIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.DateOfBirth, null as DateTime?);
+            result.ShouldNotHaveValidationErrorFor(c => c.Email);
+            result.ShouldNotHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_DateOfBirthInFuture_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.DateOfBirth, DateTime.UtcNow.AddDays(1));
+            var candidate = new Candidate() { DateOfBirth = DateTime.UtcNow.AddDays(1) };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.DateOfBirth);
         }
 
         [Fact]
-        public void Validate_FirstNameIsEmpty_HasError()
+        public void Validate_NameIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FirstName, "");
-        }
+            var longName = new string('a', 257);
+            var candidate = new Candidate() { FirstName = longName, LastName = longName };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_FirstNameTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FirstName, new string('a', 257));
-        }
-
-        [Fact]
-        public void Validate_LastNameIsEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.LastName, "");
-        }
-
-        [Fact]
-        public void Validate_LastNameTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.LastName, new string('a', 257));
-        }
-
-        [Fact]
-        public void Validate_TelephoneIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, null as string);
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.MobileTelephone, null as string);
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, null as string);
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, null as string);
+            result.ShouldHaveValidationErrorFor(c => c.FirstName);
+            result.ShouldHaveValidationErrorFor(c => c.LastName);
         }
 
         [Fact]
         public void Validate_TelephoneTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 26));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 26));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 26));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 26));
+            var longTelephone = new string('1', 26);
+            var candidate = new Candidate()
+            {
+                AddressTelephone = longTelephone,
+                MobileTelephone = longTelephone,
+                Telephone = longTelephone,
+                SecondaryTelephone = longTelephone
+            };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.MobileTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.Telephone);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryTelephone);
         }
 
         [Fact]
         public void Validate_TelephoneTooShort_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, new string('1', 4));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, new string('1', 4));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, new string('1', 4));
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, new string('1', 4));
+            var shortTelephone = "1111";
+            var candidate = new Candidate()
+            {
+                AddressTelephone = shortTelephone,
+                MobileTelephone = shortTelephone,
+                Telephone = shortTelephone,
+                SecondaryTelephone = shortTelephone
+            };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.MobileTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.Telephone);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryTelephone);
         }
 
         [Theory]
@@ -319,80 +320,64 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [InlineData("5325.56fs326.32", true)]
         public void Validate_TelephoneFormat_ValidatesCorrectly(string telephone, bool hasError)
         {
+            var candidate = new Candidate()
+            {
+                AddressTelephone = telephone,
+                MobileTelephone = telephone,
+                Telephone = telephone,
+                SecondaryTelephone = telephone
+            };
+            var result = _validator.TestValidate(candidate);
+
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.MobileTelephone, telephone);
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, telephone);
+                result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
+                result.ShouldHaveValidationErrorFor(c => c.MobileTelephone);
+                result.ShouldHaveValidationErrorFor(c => c.Telephone);
+                result.ShouldHaveValidationErrorFor(c => c.SecondaryTelephone);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressTelephone, telephone);
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.MobileTelephone, telephone);
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.Telephone, telephone);
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryTelephone, telephone);
+                result.ShouldNotHaveValidationErrorFor(c => c.AddressTelephone);
+                result.ShouldNotHaveValidationErrorFor(c => c.MobileTelephone);
+                result.ShouldNotHaveValidationErrorFor(c => c.Telephone);
+                result.ShouldNotHaveValidationErrorFor(c => c.SecondaryTelephone);
             }
         }
 
         [Fact]
-        public void Validate_AddressLine1IsEmpty_HasNoError()
+        public void Validate_AddressLineTooLong_HasError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressLine1, null as string);
-        }
+            var longAddressLine = new string('a', 1025);
+            var candidate = new Candidate()
+            {
+                AddressLine1 = longAddressLine,
+                AddressLine2 = longAddressLine,
+                AddressLine3 = longAddressLine,
+            };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_AddressLine1IsTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressLine1, new string('a', 1025));
-        }
-
-        [Fact]
-        public void Validate_AddressLine2IsTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressLine2, new string('a', 1025));
-        }
-
-        [Fact]
-        public void Validate_AddressLine3IsTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressLine3, new string('a', 1025));
-        }
-
-        [Fact]
-        public void Validate_AddressCityIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressCity, null as string);
+            result.ShouldHaveValidationErrorFor(c => c.AddressLine1);
+            result.ShouldHaveValidationErrorFor(c => c.AddressLine2);
+            result.ShouldHaveValidationErrorFor(c => c.AddressLine3);
         }
 
         [Fact]
         public void Validate_AddressCityIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressCity, new string('a', 129));
-        }
+            var candidate = new Candidate() { AddressCity = new string('a', 129) };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_AddressStateOrProvinceIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressStateOrProvince, null as string);
+            result.ShouldHaveValidationErrorFor(c => c.AddressCity);
         }
 
         [Fact]
         public void Validate_AddressStateOrProvinceIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressStateOrProvince, new string('a', 101));
-        }
+            var candidate = new Candidate() { AddressStateOrProvince = new string('a', 101) };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_AddressPostcodeIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressPostcode, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressPostcodeIsTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressPostcode, new string('a', 41));
+            result.ShouldHaveValidationErrorFor(c => c.AddressStateOrProvince);
         }
 
         [Theory]
@@ -405,128 +390,84 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [InlineData("AZ1VS1", true)]
         public void Validate_AddressPostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
         {
+            var candidate = new Candidate() { AddressPostcode = postcode };
+            var result = _validator.TestValidate(candidate);
+
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(candidate => candidate.AddressPostcode, postcode);
+                result.ShouldHaveValidationErrorFor(c => c.AddressPostcode);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AddressPostcode, postcode);
+                result.ShouldNotHaveValidationErrorFor(c => c.AddressPostcode);
             }
-        }
-
-        [Fact]
-        public void Validate_EligibilityRulesPassedIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.EligibilityRulesPassed, null as string);
         }
 
         [Fact]
         public void Validate_EligibilityRulesPassedIsNotTrueOrFalse_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.EligibilityRulesPassed, "falsy");
+            var candidate = new Candidate() { EligibilityRulesPassed = "falsy" };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.EligibilityRulesPassed);
         }
 
         [Fact]
-        public void Validate_PreferredTeachingSubjectIdIsInvalid_HasError()
+        public void Validate_IdFieldWithInvalidLookupItemId_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PreferredTeachingSubjectId, Guid.NewGuid());
+            var candidate = new Candidate()
+            {
+                PreferredTeachingSubjectId = Guid.NewGuid(),
+                SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
+                CountryId = Guid.NewGuid(),
+            };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.PreferredTeachingSubjectId);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryPreferredTeachingSubjectId);
+            result.ShouldHaveValidationErrorFor(c => c.CountryId);
         }
 
         [Fact]
-        public void Validate_SecondaryPreferredTeachingSubjectIdIsInvalid_HasError()
+        public void Validate_IdFieldWithInvalidPicklistItemId_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.SecondaryPreferredTeachingSubjectId, Guid.NewGuid());
-        }
+            var candidate = new Candidate()
+            {
+                PreferredEducationPhaseId = 123,
+                InitialTeacherTrainingYearId = 123,
+                TypeId = 123,
+                AssignmentStatusId = 123,
+                MailingListSubscriptionChannelId = 123,
+                EventsSubscriptionChannelId = 123,
+                ChannelId = 123,
+                AdviserEligibilityId = 123,
+                AdviserRequirementId = 123,
+                HasGcseMathsId = 123,
+                HasGcseScienceId = 123,
+                HasGcseEnglishId = 123,
+                PlanningToRetakeGcseMathsId = 123,
+                PlanningToRetakeGcseScienceId = 123,
+                PlanningToRetakeGcseEnglishId = 123,
+                ConsiderationJourneyStageId = 123,
+            };
+            var result = _validator.TestValidate(candidate);
 
-        [Fact]
-        public void Validate_CountryIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.CountryId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_CountryIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.CountryId, Guid.NewGuid());
-        }
-
-        [Fact]
-        public void Validate_PreferredTeachingSubjectIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PreferredTeachingSubjectId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.SecondaryPreferredTeachingSubjectId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_PreferredEducationPhaseIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PreferredEducationPhaseId, 123);
-        }
-
-        [Fact]
-        public void Validate_PreferredEducationPhaseIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PreferredEducationPhaseId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_InitialTeacherTrainingYearIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.InitialTeacherTrainingYearId, 123);
-        }
-
-        [Fact]
-        public void Validate_InitialTeacherTrainingYearIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.InitialTeacherTrainingYearId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_TypeIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.TypeId, 123);
-        }
-
-        [Fact]
-        public void Validate_TypeIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.TypeId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_AssignmentStatusIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AssignmentStatusId, 123);
-        }
-
-        [Fact]
-        public void Validate_AssignmentStatusIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AssignmentStatusId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_MailingListSubscriptionChannelIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.MailingListSubscriptionChannelId, 123);
-        }
-
-        [Fact]
-        public void Validate_EventSubscriptionChannelIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.EventsSubscriptionChannelId, 123);
-        }
-
-        [Fact]
-        public void Validate_ChannelIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ChannelId, 123);
+            result.ShouldHaveValidationErrorFor(c => c.PreferredEducationPhaseId);
+            result.ShouldHaveValidationErrorFor(c => c.InitialTeacherTrainingYearId);
+            result.ShouldHaveValidationErrorFor(c => c.TypeId);
+            result.ShouldHaveValidationErrorFor(c => c.AssignmentStatusId);
+            result.ShouldHaveValidationErrorFor(c => c.MailingListSubscriptionChannelId);
+            result.ShouldHaveValidationErrorFor(c => c.EventsSubscriptionChannelId);
+            result.ShouldHaveValidationErrorFor(c => c.ChannelId);
+            result.ShouldHaveValidationErrorFor(c => c.AdviserEligibilityId);
+            result.ShouldHaveValidationErrorFor(c => c.AdviserRequirementId);
+            result.ShouldHaveValidationErrorFor(c => c.HasGcseMathsId);
+            result.ShouldHaveValidationErrorFor(c => c.HasGcseScienceId);
+            result.ShouldHaveValidationErrorFor(c => c.HasGcseEnglishId);
+            result.ShouldHaveValidationErrorFor(c => c.PlanningToRetakeGcseMathsId);
+            result.ShouldHaveValidationErrorFor(c => c.PlanningToRetakeGcseScienceId);
+            result.ShouldHaveValidationErrorFor(c => c.PlanningToRetakeGcseEnglishId);
+            result.ShouldHaveValidationErrorFor(c => c.ConsiderationJourneyStageId);
         }
 
         [Fact]
@@ -548,117 +489,12 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_AdviserEligibilityIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AdviserEligibilityId, 123);
-        }
-
-        [Fact]
-        public void Validate_AdviserEligibilityIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AdviserEligibilityId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_AdviserRequirementIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.AdviserRequirementId, 123);
-        }
-
-        [Fact]
-        public void Validate_AdviserRequirementIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.AdviserRequirementId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_HasGcseMathsIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.HasGcseMathsId, 123);
-        }
-
-        [Fact]
-        public void Validate_HasGcseMathsIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.HasGcseMathsId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_HasGcseScienceIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.HasGcseScienceId, 123);
-        }
-
-        [Fact]
-        public void Validate_HasGcseScienceIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.HasGcseScienceId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_HasGcseEnglishIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.HasGcseEnglishId, 123);
-        }
-
-        [Fact]
-        public void Validate_HasGcseEnglishIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.HasGcseEnglishId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseMathsIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseMathsId, 123);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseMathsIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseMathsId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseScienceIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseScienceId, 123);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseScienceIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseScienceId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseEnglishIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseEnglishId, 123);
-        }
-
-        [Fact]
-        public void Validate_PlanningToRetakeGcseEnglishIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.PlanningToRetakeGcseEnglishId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_ConsiderationJourneyStageIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ConsiderationJourneyStageId, 123);
-        }
-
-        [Fact]
-        public void Validate_ConsiderationJourneyStageIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(candidate => candidate.ConsiderationJourneyStageId, null as int?);
-        }
-
-        [Fact]
         public void Validate_ClassroomExperienceNotesRawIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.ClassroomExperienceNotesRaw, new string('a', 10001));
+            var candidate = new Candidate() { ClassroomExperienceNotesRaw = new string('a', 10001) };
+            var result = _validator.TestValidate(candidate);
+
+            result.ShouldHaveValidationErrorFor(c => c.ClassroomExperienceNotesRaw);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/PhoneCallValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/PhoneCallValidatorTests.cs
@@ -45,13 +45,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_ChannelIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(phoneCall => phoneCall.ChannelId, 123);
-        }
+            var result = _validator.TestValidate(new PhoneCall() { ChannelId = 123 });
 
-        [Fact]
-        public void Validate_ChannelIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(phoneCall => phoneCall.ChannelId, null as int?);
+            result.ShouldHaveValidationErrorFor(r => r.ChannelId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/TeachingEventRegistrationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/TeachingEventRegistrationValidatorTests.cs
@@ -49,7 +49,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_EventIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(registration => registration.EventId, Guid.NewGuid());
+            var result = _validator.TestValidate(new TeachingEventRegistration() { EventId = Guid.NewGuid() });
+
+            result.ShouldHaveValidationErrorFor(r => r.EventId);
         }
 
         [Fact]
@@ -82,7 +84,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_ChannelIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(registration => registration.ChannelId, 123);
+            var result = _validator.TestValidate(new TeachingEventRegistration() { ChannelId = 123 });
+
+            result.ShouldHaveValidationErrorFor(r => r.ChannelId);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/TeachingEventValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/TeachingEventValidatorTests.cs
@@ -36,29 +36,28 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_ReadableIdIsNullOrEmpty_HasError()
+        public void Validate_WhenRequiredAttributesAreNullOrEmpty_HasErrors()
         {
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, "");
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ReadableId, null as string);
+            var teachingEvent = new TeachingEvent()
+            {
+                ReadableId = "",
+                Name = "",
+                ProviderContactEmail = "",
+            };
+            var result = _validator.TestValidate(teachingEvent);
+
+            result.ShouldHaveValidationErrorFor(e => e.ReadableId);
+            result.ShouldHaveValidationErrorFor(e => e.Name);
+            result.ShouldHaveValidationErrorFor(e => e.ProviderContactEmail);
         }
 
-        [Fact]
-        public void Validate_NameIsNullOrEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Name, "");
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.Name, null as string);
-        }
-
-        [Fact]
-        public void Validate_ProviderContactEmailIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(teachingEvent => teachingEvent.ProviderContactEmail, null as string);
-        }
 
         [Fact]
         public void Validate_ProviderContactEmailIsPresentAndInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.ProviderContactEmail, "Invalid email");
+            var result = _validator.TestValidate(new TeachingEvent() { ProviderContactEmail = "invalid-email@" });
+
+            result.ShouldHaveValidationErrorFor(c => c.ProviderContactEmail);
         }
 
         [Fact]
@@ -69,7 +68,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 StartAt = DateTime.UtcNow.AddDays(2),
                 EndAt = DateTime.UtcNow.AddDays(1)
             };
-            _validator.ShouldHaveValidationErrorFor(teachingEvent => teachingEvent.EndAt, invalidTeachingEvent);
+            var result = _validator.TestValidate(invalidTeachingEvent);
+
+            result.ShouldHaveValidationErrorFor(c => c.EndAt);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/GetIntoTeachingCallbackValidatorTests.cs
@@ -22,15 +22,27 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         }
 
         [Fact]
-        public void Validate_WhenRequiredAttributesAreNull_HasErrors()
+        public void Validate_RequiredFieldsWhenNull_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressTelephone, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt, null as DateTime?);
-            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
-            _validator.ShouldHaveValidationErrorFor(request => request.TalkingPoints, null as string);
+            var callback = new GetIntoTeachingCallback()
+            {
+                FirstName = null,
+                LastName = null,
+                Email = null,
+                AcceptedPolicyId = null,
+                AddressTelephone = null,
+                PhoneCallScheduledAt = null,
+                TalkingPoints = null,
+            };
+            var result = _validator.TestValidate(callback);
+
+            result.ShouldHaveValidationErrorFor(c => c.FirstName);
+            result.ShouldHaveValidationErrorFor(c => c.LastName);
+            result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
+            result.ShouldHaveValidationErrorFor(c => c.PhoneCallScheduledAt);
+            result.ShouldHaveValidationErrorFor(c => c.AcceptedPolicyId);
+            result.ShouldHaveValidationErrorFor(c => c.TalkingPoints);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/MailingListAddMemberValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/MailingListAddMemberValidatorTests.cs
@@ -65,51 +65,27 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         }
 
         [Fact]
-        public void Validate_FirstNameIsNull_HasError()
+        public void Validate_RequiredFieldsWhenNull_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
-        }
+            var member = new MailingListAddMember()
+            {
+                FirstName = null,
+                LastName = null,
+                Email = null,
+                AcceptedPolicyId = null,
+                ConsiderationJourneyStageId = null,
+                DegreeStatusId = null,
+                PreferredTeachingSubjectId = null,
+            };
+            var result = _validator.TestValidate(member);
 
-        [Fact]
-        public void Validate_LastNameIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
-        }
-
-        [Fact]
-        public void Validate_EmailIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressPostcodeIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.AddressPostcode, null as string);
-        }
-
-        [Fact]
-        public void Validate_AcceptedPolicyIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_ConsiderationJourneyStageIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.ConsiderationJourneyStageId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_DegreeStatusIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.DegreeStatusId, null as int?);
-        }
-
-        [Fact]
-        public void Validate_PreferredTeachingSubjectIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, null as Guid?);
+            result.ShouldHaveValidationErrorFor(m => m.FirstName);
+            result.ShouldHaveValidationErrorFor(m => m.LastName);
+            result.ShouldHaveValidationErrorFor(m => m.Email);
+            result.ShouldHaveValidationErrorFor(m => m.AcceptedPolicyId);
+            result.ShouldHaveValidationErrorFor(m => m.ConsiderationJourneyStageId);
+            result.ShouldHaveValidationErrorFor(m => m.DegreeStatusId);
+            result.ShouldHaveValidationErrorFor(m => m.PreferredTeachingSubjectId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -66,34 +66,25 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
             result.ShouldHaveValidationErrorFor("Candidate.FirstName");
         }
 
-        [Fact]
-        public void Validate_FirstNameIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
-        }
 
         [Fact]
-        public void Validate_LastNameIsNull_HasError()
+        public void Validate_RequiredFieldsWhenNull_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
-        }
+            var attendee = new TeachingEventAddAttendee()
+            {
+                FirstName = null,
+                LastName = null,
+                Email = null,
+                AcceptedPolicyId = null,
+                EventId = null,
+            };
+            var result = _validator.TestValidate(attendee);
 
-        [Fact]
-        public void Validate_EmailIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-        }
-
-        [Fact]
-        public void Validate_AcceptedPolicyIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_EventIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.EventId, null as Guid?);
+            result.ShouldHaveValidationErrorFor(a => a.FirstName);
+            result.ShouldHaveValidationErrorFor(a => a.LastName);
+            result.ShouldHaveValidationErrorFor(a => a.Email);
+            result.ShouldHaveValidationErrorFor(a => a.AcceptedPolicyId);
+            result.ShouldHaveValidationErrorFor(a => a.EventId);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -104,19 +104,17 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         [Fact]
         public void Validate_TypeIdIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.TypeId, 123);
-        }
+            var result = _validator.TestValidate(new TeachingEventSearchRequest() { TypeId = 123 });
 
-        [Fact]
-        public void Validate_TypeIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.TypeId, null as int?);
+            result.ShouldHaveValidationErrorFor(r => r.TypeId);
         }
 
         [Fact]
         public void Validate_PostcodeIsEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Postcode, "");
+            var result = _validator.TestValidate(new TeachingEventSearchRequest() { Postcode = "" });
+
+            result.ShouldHaveValidationErrorFor(r => r.Postcode);
         }
 
         [Theory]
@@ -132,32 +130,24 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         [InlineData("TE57 ING", true)]
         public void Validate_PostcodeFormat_ValidatesCorrectly(string postcode, bool hasError)
         {
+            var result = _validator.TestValidate(new TeachingEventSearchRequest() { Postcode = postcode });
+
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(request => request.Postcode, postcode);
+                result.ShouldHaveValidationErrorFor(r => r.Postcode);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(request => request.Postcode, postcode);
+                result.ShouldNotHaveValidationErrorFor(r => r.Postcode);
             }
-        }
-
-        [Fact]
-        public void Validate_PostcodeIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.Postcode, null as string);
-        }
-
-        [Fact]
-        public void Validate_RadiusIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.Radius, null as int?);
         }
 
         [Fact]
         public void Validate_RadiusIsNegative_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Radius, -1);
+            var result = _validator.TestValidate(new TeachingEventSearchRequest() { Radius = -1 });
+
+            result.ShouldHaveValidationErrorFor(r => r.Radius);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/ClassroomExperienceNoteValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/ClassroomExperienceNoteValidatorTests.cs
@@ -34,15 +34,22 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
         }
 
         [Fact]
-        public void Validate_ActionIsEmpty_HasError()
+        public void Validate_RequiredFieldsWhenNullOrEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Action, "");
-        }
+            var note = new ClassroomExperienceNote()
+            {
+                Action = "",
+                RecordedAt = null,
+                SchoolName = "",
+                SchoolUrn = null,
 
-        [Fact]
-        public void Validate_RecordedAtIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.RecordedAt, null as DateTime?);
+            };
+            var result = _validator.TestValidate(note);
+
+            result.ShouldHaveValidationErrorFor(s => s.Action);
+            result.ShouldHaveValidationErrorFor(s => s.RecordedAt);
+            result.ShouldHaveValidationErrorFor(s => s.SchoolName);
+            result.ShouldHaveValidationErrorFor(s => s.SchoolUrn);
         }
 
         [Theory]
@@ -58,38 +65,35 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
         [InlineData("CANCELLED BY JOHN", true)]
         public void Validate_ActionFormat_ValidatesCorrectly(string action, bool hasError)
         {
+            var note = new ClassroomExperienceNote() { Action = action };
+            var result = _validator.TestValidate(note);
+
             if (hasError)
             {
-                _validator.ShouldHaveValidationErrorFor(request => request.Action, action);
+                result.ShouldHaveValidationErrorFor(s => s.Action);
             }
             else
             {
-                _validator.ShouldNotHaveValidationErrorFor(request => request.Action, action);
+                result.ShouldNotHaveValidationErrorFor(s => s.Action);
             }
-        }
-
-        [Fact]
-        public void Validate_SchoolNameIsEmpty_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.SchoolName, "");
         }
 
         [Fact]
         public void Validate_SchoolUrnIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, 1234567);
+            var note = new ClassroomExperienceNote() { SchoolUrn = 1234567 };
+            var result = _validator.TestValidate(note);
+
+            result.ShouldHaveValidationErrorFor(s => s.Action);
         }
 
         [Fact]
-        public void Validate_SchoolUrnIsWrongLength_HasError()
+        public void Validate_SchoolUrnIsTooShort_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, 11);
-        }
+            var note = new ClassroomExperienceNote() { SchoolUrn = 11 };
+            var result = _validator.TestValidate(note);
 
-        [Fact]
-        public void Validate_SchoolUrnIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.SchoolUrn, null as int?);
+            result.ShouldHaveValidationErrorFor(s => s.Action);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -72,93 +72,42 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
         }
 
         [Fact]
-        public void Validate_FirstNameIsNull_HasError()
+        public void Validate_RequiredFieldsWhenNull_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
-        }
+            var signUp = new SchoolsExperienceSignUp()
+            {
+                FirstName = null,
+                LastName = null,
+                Email = null,
+                DateOfBirth = null,
+                AddressLine1 = null,
+                AddressCity = null,
+                AddressStateOrProvince = null,
+                AddressPostcode = null,
+                AddressTelephone = null,
+                Telephone = null,
+                SecondaryTelephone = null,
+                HasDbsCertificate = null,
+                AcceptedPolicyId = null,
+                PreferredTeachingSubjectId = null,
 
-        [Fact]
-        public void Validate_LastNameIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
-        }
+            };
+            var result = _validator.TestValidate(signUp);
 
-        [Fact]
-        public void Validate_EmailIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-        }
-
-        [Fact]
-        public void Validate_DateOfBirthIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, null as DateTime?);
-        }
-
-        [Fact]
-        public void Validate_AddressLine1IsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressLine1, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressCityIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressCity, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressStateOrProvinceIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressStateOrProvince, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressPostcodeIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressPostcode, null as string);
-        }
-
-        [Fact]
-        public void Validate_AddressTelephoneIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AddressTelephone, null as string);
-        }
-
-        [Fact]
-        public void Validate_TelephoneIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.Telephone, null as string);
-        }
-
-        [Fact]
-        public void Validate_SecondaryTelephoneIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.SecondaryTelephone, null as string);
-        }
-
-        [Fact]
-        public void Validate_HasDbsCertificateIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.HasDbsCertificate, null as bool?);
-        }
-
-        [Fact]
-        public void Validate_AcceptedPolicyIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_PreferredTeachingSubjectIdIsNull_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId, null as Guid?);
-        }
-
-        [Fact]
-        public void Validate_SecondaryPreferredTeachingSubjectIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.SecondaryPreferredTeachingSubjectId, null as Guid?);
+            result.ShouldHaveValidationErrorFor(s => s.FirstName);
+            result.ShouldHaveValidationErrorFor(s => s.LastName);
+            result.ShouldHaveValidationErrorFor(s => s.Email);
+            result.ShouldHaveValidationErrorFor(s => s.DateOfBirth);
+            result.ShouldHaveValidationErrorFor(s => s.AddressLine1);
+            result.ShouldHaveValidationErrorFor(s => s.AddressCity);
+            result.ShouldHaveValidationErrorFor(s => s.AddressStateOrProvince);
+            result.ShouldHaveValidationErrorFor(s => s.AddressPostcode);
+            result.ShouldHaveValidationErrorFor(s => s.AddressTelephone);
+            result.ShouldHaveValidationErrorFor(s => s.Telephone);
+            result.ShouldHaveValidationErrorFor(s => s.SecondaryTelephone);
+            result.ShouldHaveValidationErrorFor(s => s.HasDbsCertificate);
+            result.ShouldHaveValidationErrorFor(s => s.AcceptedPolicyId);
+            result.ShouldHaveValidationErrorFor(s => s.PreferredTeachingSubjectId);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -26,13 +26,23 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
         [Fact]
         public void Validate_WhenRequiredAttributesAreNull_HasErrors()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, null as string);
-            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, null as DateTime?);
-            _validator.ShouldHaveValidationErrorFor(request => request.AcceptedPolicyId, null as Guid?);
-            _validator.ShouldHaveValidationErrorFor(request => request.CountryId, null as Guid?);
-            _validator.ShouldHaveValidationErrorFor(request => request.TypeId, null as int?);
+            _request.FirstName = null;
+            _request.LastName = null;
+            _request.Email = null;
+            _request.DateOfBirth = null;
+            _request.AcceptedPolicyId = null;
+            _request.CountryId = null;
+            _request.TypeId = null;
+
+            var result = _validator.TestValidate(_request);
+
+            result.ShouldHaveValidationErrorFor(c => c.FirstName);
+            result.ShouldHaveValidationErrorFor(c => c.LastName);
+            result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.DateOfBirth);
+            result.ShouldHaveValidationErrorFor(c => c.AcceptedPolicyId);
+            result.ShouldHaveValidationErrorFor(c => c.CountryId);
+            result.ShouldHaveValidationErrorFor(c => c.TypeId);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Validators/ClientValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ClientValidatorTests.cs
@@ -38,9 +38,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("KE _Y")]
         [InlineData("_KEY")]
         [InlineData("KEY_")]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
         public void Validate_ApiKeyPrefixInvalidFormat_HasErrors(string value)
         {
-            _validator.ShouldHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
+            var request = new Client() { ApiKeyPrefix = value };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(c => c.ApiKeyPrefix);
         }
 
         [Theory]
@@ -51,7 +57,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("KEY_KEY_KEY")]
         public void Validate_ApiKeyPrefixValidFormat_HasNoErrors(string value)
         {
-            _validator.ShouldNotHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
+            var request = new Client() { ApiKeyPrefix = value };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(c => c.ApiKeyPrefix);
         }
 
         [Theory]
@@ -60,9 +69,15 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("Admin Role")]
         [InlineData("Admin_Role")]
         [InlineData("admin_role")]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
         public void Validate_RoleInvalidFormat_HasErrors(string value)
         {
-            _validator.ShouldHaveValidationErrorFor(client => client.Role, value);
+            var request = new Client() { Role = value };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(c => c.Role);
         }
 
         [Theory]
@@ -70,7 +85,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData("AdminRole")]
         public void Validate_RoleValidFormat_HasNoErrors(string value)
         {
-            _validator.ShouldNotHaveValidationErrorFor(client => client.Role, value);
+            var request = new Client() { Role = value };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(c => c.Role);
         }
 
         [Theory]
@@ -79,7 +97,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData(null)]
         public void Validate_InvalidName_HasError(string value)
         {
-            _validator.ShouldHaveValidationErrorFor(client => client.Name, value);
+            var request = new Client() { Name = value };
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(c => c.Name);
         }
 
         [Theory]
@@ -88,25 +109,10 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [InlineData(null)]
         public void Validate_InvalidDescription_HasError(string value)
         {
-            _validator.ShouldHaveValidationErrorFor(client => client.Description, value);
-        }
+            var request = new Client() { Description = value };
+            var result = _validator.TestValidate(request);
 
-        [Theory]
-        [InlineData("")]
-        [InlineData("  ")]
-        [InlineData(null)]
-        public void Validate_InvalidApiKeyPrefixHasError(string value)
-        {
-            _validator.ShouldHaveValidationErrorFor(client => client.ApiKeyPrefix, value);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData("  ")]
-        [InlineData(null)]
-        public void Validate_InvalidRole_HasError(string value)
-        {
-            _validator.ShouldHaveValidationErrorFor(client => client.Role, value);
+            result.ShouldHaveValidationErrorFor(c => c.Description);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -30,43 +30,53 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_EmailAddressIsEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, "");
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = "" });
+
+            result.ShouldHaveValidationErrorFor(r => r.Email);
         }
+
 
         [Fact]
         public void Validate_EmailAddressIsInvalid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, "invalid-email@");
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = "invalid-email@" });
+
+            result.ShouldHaveValidationErrorFor(r => r.Email);
         }
 
         [Fact]
         public void Validate_EmailAddressTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.Email, $"{new string('a', 50)}@{new string('a', 50)}.com");
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = $"{new string('a', 50)}@{new string('a', 50)}.com" });
+
+            result.ShouldHaveValidationErrorFor(r => r.Email);
         }
 
         [Fact]
         public void Validate_EmailAddressPresent_HasNoError()
         {
-            _validator.ShouldNotHaveValidationErrorFor(request => request.Email, "valid@email.com");
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = "valid@email.com" });
+
+            result.ShouldNotHaveValidationErrorFor(r => r.Email);
         }
 
         [Fact]
         public void Validate_DateOfBirthInFuture_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.DateOfBirth, DateTime.UtcNow.AddDays(1));
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { DateOfBirth = DateTime.UtcNow.AddDays(1) });
+
+            result.ShouldHaveValidationErrorFor(r => r.DateOfBirth);
         }
 
         [Fact]
-        public void Validate_FirstNameTooLong_HasError()
+        public void Validate_NameIsTooLong_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(request => request.FirstName, new string('a', 257));
-        }
+            var tooLongName = new string('a', 257);
+            var request = new ExistingCandidateRequest() { FirstName = tooLongName, LastName = tooLongName };
+            var result = _validator.TestValidate(request);
 
-        [Fact]
-        public void Validate_LastNameTooLong_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(request => request.LastName, new string('a', 257));
+            result.ShouldHaveValidationErrorFor(r => r.FirstName);
+            result.ShouldHaveValidationErrorFor(r => r.LastName);
         }
 
         [Fact]


### PR DESCRIPTION
- Update FluentValidation

- Address deprecation warnings for FluentValidation

The `validator.ShouldHaveValidationErrorFor(attr, value)` has been deprecated in favour of using `TestValidate`. This updates all references, consolidates some of the separate tests into single tests to make them easier to read and removes some of the assertions for the inverse of rules (checking `null` is allowed, for example) as these don't add much value and bloat the test  suite quite a bit.