### PR TITLE
Support feature switching for Apply API sync

### DIFF
--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -127,7 +127,7 @@ namespace GetIntoTeachingApi.AppStart
                 HangfireJobs.AddLocationSyncJob();
                 HangfireJobs.AddMagicLinkTokenGenerationJob();
 
-                if (!_env.IsProduction)
+                if (_env.IsFeatureOn("APPLY_API"))
                 {
                     HangfireJobs.AddFindApplySyncJob();
                 }

--- a/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/EntityFieldAttribute.cs
@@ -11,22 +11,27 @@ namespace GetIntoTeachingApi.Attributes
         public string Name { get; }
         public Type Type { get; }
         public string Reference { get; }
-        public string[] IgnoreInEnvironments { get; }
+        public string[] Features { get; }
 
         public bool Ignored
         {
             get
             {
-                return IgnoreInEnvironments?.Contains(new Env().EnvironmentName) == true;
+                if (Features == null)
+                {
+                    return false;
+                }
+
+                return Features!.All(f => new Env().IsFeatureOff(f));
             }
         }
 
-        public EntityFieldAttribute(string name, Type type = null, string reference = null, string[] ignoreInEnvironments = null)
+        public EntityFieldAttribute(string name, Type type = null, string reference = null, string[] features = null)
         {
             Name = name;
             Type = type;
             Reference = reference;
-            IgnoreInEnvironments = ignoreInEnvironments;
+            Features = features;
         }
 
         public IDictionary<string, string> ToDictionary()

--- a/GetIntoTeachingApi/Mocks/MockModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockModel.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApi.Mocks
         public int? Field2 { get; set; }
         [EntityField("dfe_field3")]
         public string Field3 { get; set; }
-        [EntityField("dfe_field4", null, null, new string[] { "Test" })]
+        [EntityField("dfe_field4", null, null, new string[] { "TEST" })]
         public string Field4 { get; set; }
         [EntityRelationship("dfe_mock_dfe_relatedmock_mock", typeof(MockRelatedModel))]
         public MockRelatedModel RelatedMock { get; set; }

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -180,19 +180,19 @@ namespace GetIntoTeachingApi.Models.Crm
         public int? AdviserStatusId { get; set; }
         [EntityField("dfe_candidatereregisterstatus", typeof(OptionSetValue))]
         public int? RegistrationStatusId { get; set; }
-        [EntityField("dfe_candidateapplystatus", typeof(OptionSetValue), null, new string[] { "Staging", "Production" })]
+        [EntityField("dfe_candidateapplystatus", typeof(OptionSetValue), null, new[] { "APPLY_API" })]
         public int? FindApplyStatusId { get; set; }
-        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue), null, new string[] { "Staging", "Production" })]
+        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue), null, new[] { "APPLY_API" })]
         public int? FindApplyPhaseId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]
         public bool Merged { get; set; }
-        [EntityField("dfe_applyid", null, null, new[] { "Production" })]
+        [EntityField("dfe_applyid", null, null, new[] { "APPLY_API" })]
         public string FindApplyId { get; set; }
-        [EntityField("dfe_applylastmodifiedon", null, null, new[] { "Staging", "Production" })]
+        [EntityField("dfe_applylastmodifiedon", null, null, new[] { "APPLY_API" })]
         public DateTime? FindApplyUpdatedAt { get; set; }
-        [EntityField("dfe_applycreatedon", null, null, new[] { "Staging", "Production" })]
+        [EntityField("dfe_applycreatedon", null, null, new[] { "APPLY_API" })]
         public DateTime? FindApplyCreatedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -32,7 +32,8 @@
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
-        "TOTP_SECRET_KEY": "def456"
+        "TOTP_SECRET_KEY": "def456",
+        "APPLY_API_FEATURE": "on"
       }
     }
   }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -7,6 +7,7 @@ using GetIntoTeachingApi.Database;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.GetIntoTeaching;
+using GetIntoTeachingApi.Utils;
 using Microsoft.EntityFrameworkCore;
 using MoreLinq;
 using NetTopologySuite.Geometries;
@@ -22,17 +23,20 @@ namespace GetIntoTeachingApi.Services
         private readonly IGeocodeClientAdapter _geocodeClient;
         private readonly ICrmService _crm;
         private readonly IDateTimeProvider _dateTime;
+        private readonly IEnv _env;
 
         public Store(
             GetIntoTeachingDbContext dbContext,
             IGeocodeClientAdapter geocodeClient,
             ICrmService crm,
-            IDateTimeProvider dateTime)
+            IDateTimeProvider dateTime,
+            IEnv env)
         {
             _dbContext = dbContext;
             _geocodeClient = geocodeClient;
             _crm = crm;
             _dateTime = dateTime;
+            _env = env;
         }
 
         public async Task<string> CheckStatusAsync()
@@ -242,8 +246,6 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("contact", "dfe_isadvisorrequiredos");
             await SyncPickListItem("contact", "dfe_gitismlservicesubscriptionchannel");
             await SyncPickListItem("contact", "dfe_gitiseventsservicesubscriptionchannel");
-            await SyncPickListItem("contact", "dfe_candidateapplystatus");
-            await SyncPickListItem("contact", "dfe_candidateapplyphase");
             await SyncPickListItem("dfe_candidatequalification", "dfe_degreestatus");
             await SyncPickListItem("dfe_candidatequalification", "dfe_ukdegreegrade");
             await SyncPickListItem("dfe_candidatequalification", "dfe_type");
@@ -253,7 +255,13 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("msevtmgt_eventregistration", "dfe_channelcreation");
             await SyncPickListItem("phonecall", "dfe_channelcreation");
             await SyncPickListItem("dfe_servicesubscription", "dfe_servicesubscriptiontype");
-            await SyncPickListItem("dfe_applyapplicationform", "dfe_candidateapplyphase");
+
+            if (_env.IsFeatureOn("APPLY_API"))
+            {
+                await SyncPickListItem("contact", "dfe_candidateapplystatus");
+                await SyncPickListItem("contact", "dfe_candidateapplyphase");
+                await SyncPickListItem("dfe_applyapplicationform", "dfe_candidateapplyphase");
+            }
         }
 
         private async Task SyncModels<T>(IEnumerable<T> models, IQueryable<T> dbSet)

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -50,6 +50,18 @@ namespace GetIntoTeachingApi.Utils
             }
         }
 
+        public bool IsFeatureOn(string feature)
+        {
+            var value = Environment.GetEnvironmentVariable($"{feature}_FEATURE");
+
+            return value.ToBool();
+        }
+
+        public bool IsFeatureOff(string feature)
+        {
+            return !IsFeatureOn(feature);
+        }
+
         public string Get(string variable)
         {
             return Environment.GetEnvironmentVariable(variable);

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -27,6 +27,8 @@
         string GoogleApiKey { get; }
         bool IsMasterInstance { get; }
 
+        bool IsFeatureOn(string feature);
+        bool IsFeatureOff(string feature);
         string Get(string variable);
     }
 }

--- a/GetIntoTeachingApi/Utils/StringExtensions.cs
+++ b/GetIntoTeachingApi/Utils/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using GetIntoTeachingApi.Models;
 
@@ -6,6 +7,8 @@ namespace GetIntoTeachingApi.Utils
 {
     public static class StringExtensions
     {
+        private static readonly string[] TrueValues = new string[] { "true", "t", "1", "on" };
+
         public static string AsFormattedPostcode(this string str)
         {
             str = str?.Replace(" ", string.Empty);
@@ -55,6 +58,16 @@ namespace GetIntoTeachingApi.Utils
             str = str.ToLower().Replace("_", " ");
             var info = CultureInfo.CurrentCulture.TextInfo;
             return info.ToTitleCase(str).Replace(" ", string.Empty);
+        }
+
+        public static bool ToBool(this string str)
+        {
+            if (string.IsNullOrWhiteSpace(str))
+            {
+                return false;
+            }
+
+            return TrueValues.Contains(str.Trim().ToLower());
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
@@ -44,10 +44,27 @@ namespace GetIntoTeachingApiTests.Models.Crm
         }
 
         [Fact]
-        public void EntityFieldAttribute_OnPropertyWithIgnoreInEnvironmentAttribute_ReturnsNull()
+        public void EntityFieldAttribute_OnPropertyWithFeatureFlag_ReturnsNullIfFeatureFlagIsOff()
         {
+            var previous = Environment.GetEnvironmentVariable("TEST");
+            Environment.SetEnvironmentVariable("TEST_FEATURE", "off");
+
             var property = typeof(MockModel).GetProperty("Field4");
             BaseModel.EntityFieldAttribute(property).Should().BeNull();
+
+            Environment.SetEnvironmentVariable("TEST_FEATURE", previous);
+        }
+
+        [Fact]
+        public void EntityFieldAttribute_OnPropertyWithFeatureFlag_ReturnsAttributeIfFeatureFlagIsOn()
+        {
+            var previous = Environment.GetEnvironmentVariable("TEST");
+            Environment.SetEnvironmentVariable("TEST_FEATURE", "on");
+
+            var property = typeof(MockModel).GetProperty("Field4");
+            BaseModel.EntityFieldAttribute(property).Should().BeOfType<EntityFieldAttribute>();
+
+            Environment.SetEnvironmentVariable("TEST_FEATURE", previous);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Attributes;
@@ -74,13 +75,13 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("RegistrationStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidatereregisterstatus" && a.Type == typeof(OptionSetValue));
             type.GetProperty("FindApplyStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_candidateapplystatus" && a.Type == typeof(OptionSetValue));
+                a => a.Name == "dfe_candidateapplystatus" && a.Type == typeof(OptionSetValue) && a.Features.Contains("APPLY_API"));
             type.GetProperty("FindApplyPhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue));
+                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue) && a.Features.Contains("APPLY_API"));
 
-            type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");
-            type.GetProperty("FindApplyUpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applylastmodifiedon");
-            type.GetProperty("FindApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon");
+            type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid" && a.Features.Contains("APPLY_API"));
+            type.GetProperty("FindApplyUpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applylastmodifiedon" && a.Features.Contains("APPLY_API"));
+            type.GetProperty("FindApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon" && a.Features.Contains("APPLY_API"));
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -274,9 +274,12 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("Production", "Production")]
         public void EnvironmentName_ReturnsCorrectly(string environment, string expected)
         {
+            var previous = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
 
             _env.EnvironmentName.Should().Be(expected);
+
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previous);
         }
 
         [Fact]
@@ -294,6 +297,27 @@ namespace GetIntoTeachingApiTests.Utils
         public void Get_WhenVariableDoesNotExist_ReturnsNull()
         {
             _env.Get("NON_EXISTANT").Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("TEST", "on", true)]
+        [InlineData("TEST", "true", true)]
+        [InlineData("TEST", "1", true)]
+        [InlineData("TEST", "off", false)]
+        [InlineData("TEST", "false", false)]
+        [InlineData("TEST", "0", false)]
+        [InlineData("TEST", " ", false)]
+        [InlineData("TEST", null, false)]
+        public void IsFeatureOnOff_ReturnsCorrectly(string feature, string value, bool expected)
+        {
+            var envVariable = $"{feature}_FEATURE";
+            var previous = Environment.GetEnvironmentVariable(envVariable);
+            Environment.SetEnvironmentVariable(envVariable, value);
+
+            _env.IsFeatureOn(feature).Should().Be(expected);
+            _env.IsFeatureOff(feature).Should().Be(!expected);
+
+            Environment.SetEnvironmentVariable(envVariable, previous);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
+++ b/GetIntoTeachingApiTests/Utils/StringExtensionsTests.cs
@@ -61,5 +61,24 @@ namespace GetIntoTeachingApiTests.Utils
         {
             input.ToPascalCase().Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("  ", false)]
+        [InlineData("true", true)]
+        [InlineData("True", true)]
+        [InlineData("TRUE", true)]
+        [InlineData("1", true)]
+        [InlineData("on", true)]
+        [InlineData("ON", true)]
+        [InlineData(" on ", true)]
+        [InlineData("false", false)]
+        [InlineData("f", false)]
+        [InlineData("off", false)]
+        [InlineData("Banana", false)]
+        public void ToBool_ReturnsCorrectly(string input, bool expected)
+        {
+            input.ToBool().Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
- Support environment-based feature switches

As we class both hosted dev and test environments as 'Staging' We currently have no way to toggle something on/off independently for each environment.

Add basic support for feature switching based on environment variables.

- Switch EntityFieldAttribute Ignored attribute to use features

We had a `Ignored` attribute that worked off the environment name. This works for most scenarios, but has the limitation of not being able to differentiate between our hosted dev and test environments, as they both run with the ASP.NET Core 'Staging' environment.

By switching it over to feature flags we can control which of these map to the CRM more granularly, so if the CRM team have only deployed a schema change to dev and not test, we can still deploy all the way to production and enable the specific fields only in the dev environment.

- Only sync apply-related pick list items when feature is on

The sync is currently failing on the test environment as we're trying to sync some pick list items that don't exist in the test CRM environment.

As we can now differentiate per-environment with the feature flags we can skip it unless the feature is on.

- Only run Apply sync job when feature is on

We only want to run the Apply API sync job when the feature is on, instead of on all staging environments.