### PR TITLE
Fix deprecation warnings for FluentValidation

### DIFF
--- a/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
@@ -46,19 +46,19 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_FindApplyIdIsEmpty_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(form => form.FindApplyId, "");
-        }
+            var form = new ApplicationForm() { FindApplyId = "" };
+            var result = _validator.TestValidate(form);
 
-        [Fact]
-        public void Validate_PhaseIdIsNull_HasNoError()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(form => form.PhaseId, null as int?);
+            result.ShouldHaveValidationErrorFor("FindApplyId");
         }
 
         [Fact]
         public void Validate_PhaseIdIsNotValid_HasError()
         {
-            _validator.ShouldHaveValidationErrorFor(form => form.PhaseId, 456);
+            var form = new ApplicationForm() { PhaseId = 456 };
+            var result = _validator.TestValidate(form);
+
+            result.ShouldHaveValidationErrorFor("PhaseId");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -457,6 +457,8 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 PlanningToRetakeGcseScienceId = 123,
                 PlanningToRetakeGcseEnglishId = 123,
                 ConsiderationJourneyStageId = 123,
+                FindApplyPhaseId = 123,
+                FindApplyStatusId = 123,
             };
             var result = _validator.TestValidate(candidate);
 
@@ -476,6 +478,8 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
             result.ShouldHaveValidationErrorFor(c => c.PlanningToRetakeGcseScienceId);
             result.ShouldHaveValidationErrorFor(c => c.PlanningToRetakeGcseEnglishId);
             result.ShouldHaveValidationErrorFor(c => c.ConsiderationJourneyStageId);
+            result.ShouldHaveValidationErrorFor(c => c.FindApplyPhaseId);
+            result.ShouldHaveValidationErrorFor(c => c.FindApplyStatusId);
         }
 
         [Fact]
@@ -503,18 +507,6 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.ClassroomExperienceNotesRaw);
-        }
-
-        [Fact]
-        public void Validate_FindApplyPhaseIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FindApplyPhaseId, 123);
-        }
-
-        [Fact]
-        public void Validate_FindApplyStatusIdIsInvalid_HasError()
-        {
-            _validator.ShouldHaveValidationErrorFor(candidate => candidate.FindApplyStatusId, 123);
         }
     }
 }


### PR DESCRIPTION
These were missed in the original PR as they were in a separate branch that was subsequently merged in after the FluentValidation upgrade PR.