### PR TITLE
Add Name attribute to ApplicationForm

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -20,6 +20,19 @@ namespace GetIntoTeachingApi.Models.Crm
         public DateTime CreatedAt { get; set; }
         [EntityField("dfe_modifiedon")]
         public DateTime UpdatedAt { get; set; }
+        [EntityField("dfe_name")]
+        public string Name
+        {
+            get
+            {
+                return $"Application Form {FindApplyId}";
+            }
+            set
+            {
+                // BaseModel requires a setter for all mapped
+                // attributes, although we treat this one as read-only.
+            }
+        }
 
         public ApplicationForm()
             : base()

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
@@ -25,6 +25,15 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationformid");
             type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_createdon");
             type.GetProperty("UpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_modifiedon");
+            type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_name");
+        }
+
+        [Fact]
+        public void Name_IsDerivedFromFindApplyId()
+        {
+            var form = new ApplicationForm() { FindApplyId = "123" };
+
+            form.Name.Should().Be("Application Form 123");
         }
     }
 }


### PR DESCRIPTION
The CRM team have requested a `Name` attribute (mapped to `dfe_name`) on the `ApplicationForm` entity that is computed by the API in the format `Application Form <apply id>`.