### PR TITLE
Fix heading markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ var myChangeTrackedObject = json.DeserializeChangeTracked<ChangeTrackedObject>()
 var json = myChangeTrackedObject.SerializeChangeTracked();
 ```
 
-### Feature Switches
+### Feature Switches
 
 We have basic support for feature switching in the API. The `IEnv` interface provides methods to check if a feature is on or off:
 


### PR DESCRIPTION
Not sure what went on here but replacing the space between the `###` and the heading fixes it 🤷

Just a typo so merging it straight down 🔥 