### PR TITLE
Prometheus Restart

### DIFF
--- a/.github/workflows/restart_prometheus.yml
+++ b/.github/workflows/restart_prometheus.yml
@@ -1,0 +1,35 @@
+name: Restart Prometheus 
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 2 * * *'  # 2:00am daily
+
+jobs:
+  cf:
+    name: Cloud Foundry Network
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Cloud Foundry
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli  
+          
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1.2
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'PAAS-USERNAME, PAAS-PASSWORD'
+
+      - name: Login to Cloud Foundry
+        run: cf login -a api.london.cloud.service.gov.uk -u ${{steps.azSecret.outputs.PAAS-USERNAME}} -p ${{steps.azSecret.outputs.PAAS-PASSWORD}} -s get-into-teaching
+             
+      - name: Restart Application
+        run:  |
+            cf target -s get-into-teaching-monitoring
+            cf restart prometheus-prod-get-into-teaching 


### PR DESCRIPTION
Prometheus gets memory bound and hangs after a few days of running.
We cannot allocate much more memory, so for a quick fix,
use a GitHub action to restart the service.