### PR TITLE
Allow multiple event types in event search

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -78,13 +78,15 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);
 
+            var typeIds = request.TypeIds == null ? string.Empty : string.Join(",", request.TypeIds);
+
             _metrics.TeachingEventSearchResults
-                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .WithLabels(typeIds, request.Radius.ToString())
                 .Observe(teachingEvents.Count());
 
             var inPesonTeachingEvents = teachingEvents.Where(e => e.IsInPerson);
             _metrics.InPersonTeachingEventResults
-                .WithLabels(request.TypeId.ToString(), request.Radius.ToString())
+                .WithLabels(typeIds, request.Radius.ToString())
                 .Observe(inPesonTeachingEvents.Count());
 
             return Ok(GroupTeachingEventsByType(teachingEvents, quantityPerType));

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -59,8 +59,9 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_ittyear", store))
                 .Unless(candidate => candidate.InitialTeacherTrainingYearId == null);
             RuleFor(candidate => candidate.ChannelId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_channelcreation", store))
-                .Unless(candidate => candidate.Id != null);
+                .NotNull()
+                .When(candidate => candidate.Id == null)
+                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_channelcreation", store));
             RuleFor(candidate => candidate.HasGcseEnglishId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
                 .Unless(candidate => candidate.HasGcseEnglishId == null);

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
@@ -6,12 +6,33 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
 {
     public class TeachingEventSearchRequest : ICloneable
     {
+        private int[] _typeIds;
+
         [SwaggerSchema("Postcode to center search around.")]
         public string Postcode { get; set; }
         [SwaggerSchema("Set to filter results to a radius (in miles) around the postcode.")]
         public int? Radius { get; set; }
         [SwaggerSchema("Set to filter results to a type of teaching event. Must match an `typeId` of the `TeachingEvent` schema.")]
         public int? TypeId { get; set; }
+        [SwaggerSchema("Set to filter results to a type of teaching event. Each ID must match a `typeId` of the `TeachingEvent` schema.")]
+        public int[] TypeIds
+        {
+            get
+            {
+                if (TypeId != null)
+                {
+                    return new int[] { TypeId.Value };
+                }
+
+                return _typeIds;
+            }
+
+            set
+            {
+                _typeIds = value;
+            }
+        }
+
         [SwaggerSchema("Set to filter results to those that start after a given date.")]
         public DateTime? StartAfter { get; set; }
         [SwaggerSchema("Set to filter results to those that start before a given date.")]

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
@@ -16,6 +16,9 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
             RuleFor(request => request.TypeId)
                 .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
                 .Unless(request => request.TypeId == null);
+            RuleForEach(request => request.TypeIds)
+                .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
+                .Unless(request => request.TypeIds == null);
             RuleFor(request => request.Radius).GreaterThan(0);
             RuleFor(request => request)
                 .Must(StartAfterEarlierThanStartBefore)

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -20,12 +20,12 @@ namespace GetIntoTeachingApi.Services
         private static readonly Histogram _teachingEventSearchResults = Metrics
             .CreateHistogram("api_teaching_event_search_results_count", "Histogram of teaching event search results.", new HistogramConfiguration
             {
-                LabelNames = new[] { "type_id", "radius" },
+                LabelNames = new[] { "type_ids", "radius" },
             });
         private static readonly Histogram _inPersonTeachingEventResults = Metrics
             .CreateHistogram("api_in_person_teaching_event_results_count", "Histogram of teaching event search results (in person).", new HistogramConfiguration
             {
-                LabelNames = new[] { "type_id", "radius" },
+                LabelNames = new[] { "type_ids", "radius" },
             });
         private static readonly Gauge _hangfireJobs = Metrics
             .CreateGauge("api_hangfire_jobs", "Gauge number of Hangifre jobs.", "state");

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -95,9 +95,10 @@ namespace GetIntoTeachingApi.Services
                 .Include(te => te.Building)
                 .OrderBy(te => te.StartAt);
 
-            if (request.TypeId != null)
+            if (request.TypeIds != null)
             {
-                teachingEvents = teachingEvents.Where(te => te.TypeId == request.TypeId);
+                teachingEvents = teachingEvents.Where(te =>
+                   request.TypeIds.Contains(te.TypeId));
             }
 
             if (request.StartAfter != null)

--- a/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
+++ b/GetIntoTeachingApi/Validators/PickListItemIdValidator.cs
@@ -5,21 +5,20 @@ using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Validators
 {
-    public class PickListItemIdValidator<T> : PropertyValidator<T, int?>
+    public class PickListItemIdValidator<T> : PropertyValidator<T, int>
     {
         private readonly string _entityName;
         private readonly string _attributeName;
         private readonly IStore _store;
 
         public PickListItemIdValidator(string entityName, string attributeName, IStore store)
-            : base()
         {
             _entityName = entityName;
             _attributeName = attributeName;
             _store = store;
         }
 
-        public override bool IsValid(ValidationContext<T> context, int? value)
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
             var exists = _store.GetPickListItems(_entityName, _attributeName).Any(i => i.Id == value);
 

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -129,8 +129,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             _mockLogger.VerifyInformationWasCalled("SearchGroupedByType: KY12 8FG");
 
-            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
-            _metrics.TeachingEventSearchResults.WithLabels(new[] { request.TypeId.ToString(), request.Radius.ToString() }).Count.Should().Be(1);
+            _metrics.TeachingEventSearchResults.WithLabels(new[] { string.Empty, request.Radius.ToString() }).Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
@@ -21,11 +21,11 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
         [Fact]
         public void Clone_WithBlock_ClonesAndCallsBlock()
         {
-            var request = new TeachingEventSearchRequest() { Radius = 10, TypeId = 123 };
+            var request = new TeachingEventSearchRequest() { Radius = 10, TypeIds = new int[] { 123 } };
             var clone = request.Clone((te) => te.Radius = 100);
 
             clone.Radius.Should().Be(100);
-            clone.TypeId.Should().Be(request.TypeId);
+            clone.TypeIds.Should().BeEquivalentTo(request.TypeIds);
         }
 
         [Fact]
@@ -35,6 +35,19 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             var expectedDefaults = new int[] { (int)TeachingEvent.Status.Open, (int)TeachingEvent.Status.Closed };
 
             request.StatusIds.Should().Equal(expectedDefaults);
+        }
+
+        [Fact]
+        public void TypeIds_WhenTypeIdHasAValue_ReturnsTheValueOfTypeId()
+        {
+            var request = new TeachingEventSearchRequest
+            {
+                TypeId = 101,
+                TypeIds = new int[] { 202 }
+            };
+
+            request.TypeIds.Length.Should().Be(1);
+            request.TypeIds[0].Should().Be(101);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
             {
                 Postcode = "KY11 9HF",
                 Radius = 10,
-                TypeId = mockPickListItem.Id,
+                TypeIds = new int[] { mockPickListItem.Id },
                 StartAfter = DateTime.UtcNow.AddDays(-1),
                 StartBefore = DateTime.UtcNow.AddDays(1)
             };
@@ -104,9 +104,9 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         [Fact]
         public void Validate_TypeIdIsInvalid_HasError()
         {
-            var result = _validator.TestValidate(new TeachingEventSearchRequest() { TypeId = 123 });
+            var result = _validator.TestValidate(new TeachingEventSearchRequest() { TypeIds = new int[] { 123 } });
 
-            result.ShouldHaveValidationErrorFor(r => r.TypeId);
+            result.ShouldHaveValidationErrorFor(r => r.TypeIds);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -81,7 +81,7 @@ namespace GetIntoTeachingApiTests.Services
         public void TeachingEventSearchResults_ReturnsMetric()
         {
             _metrics.TeachingEventSearchResults.Name.Should().Be("api_teaching_event_search_results_count");
-            _metrics.TeachingEventSearchResults.LabelNames.Should().BeEquivalentTo(new[] { "type_id", "radius" });
+            _metrics.TeachingEventSearchResults.LabelNames.Should().BeEquivalentTo(new[] { "type_ids", "radius" });
         }
 
 
@@ -89,7 +89,7 @@ namespace GetIntoTeachingApiTests.Services
         public void InPersonTeachingEventResults_ReturnsMetric()
         {
             _metrics.InPersonTeachingEventResults.Name.Should().Be("api_in_person_teaching_event_results_count");
-            _metrics.InPersonTeachingEventResults.LabelNames.Should().BeEquivalentTo(new[] { "type_id", "radius" });
+            _metrics.InPersonTeachingEventResults.LabelNames.Should().BeEquivalentTo(new[] { "type_ids", "radius" });
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -430,7 +430,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 15,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -451,7 +451,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 13,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -472,7 +472,7 @@ namespace GetIntoTeachingApiTests.Services
             {
                 Postcode = "KY6 2NJ",
                 Radius = 12,
-                TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop,
+                TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop },
                 StartAfter = DateTime.UtcNow,
                 StartBefore = DateTime.UtcNow.AddDays(3)
             };
@@ -521,11 +521,30 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SearchTeachingEvents_FilteredByMultipleTypes_ReturnsMatching()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAndBuildingsAsync();
+            var request = new TeachingEventSearchRequest()
+            {
+                TypeIds = new int[]
+                {
+                    (int)TeachingEvent.EventType.TrainToTeachEvent,
+                    (int)TeachingEvent.EventType.ApplicationWorkshop
+                }
+            };
+
+            var results = await _store.SearchTeachingEventsAsync(request);
+
+            results.Select(e => e.Name).Should().Contain(new string[] { "Event 1", "Event 2" });
+        }
+
+        [Fact]
         public async void SearchTeachingEvents_FilteredByType_ReturnsMatching()
         {
             SeedMockLocations();
             await SeedMockTeachingEventsAndBuildingsAsync();
-            var request = new TeachingEventSearchRequest() { TypeId = (int)TeachingEvent.EventType.ApplicationWorkshop };
+            var request = new TeachingEventSearchRequest() { TypeIds = new int[] { (int)TeachingEvent.EventType.ApplicationWorkshop } };
 
             var result = await _store.SearchTeachingEventsAsync(request);
 


### PR DESCRIPTION
[Trello](https://trello.com/c/qbuoFw8L)

Sometimes we want to search by multiple event types so that we don't have to filter events in the client. 

For now we are keeping the `TypeId` property for backwards compatibility. It will be removed when the clients have been updated. 

- Add a `TypeIds` property that accepts an array of type IDs.
- Update any use of `TypeId` to `TypeIds` throughout the project, and temporarily set `TypeIds` to the value of `TypeId` if it is present.
- Update the `TeachingEventSearchRequestValidator` to a non-nullable `int`. This only broke one test, so I think it should be okay.