### PR TITLE
Remove TypeId parameter from events search

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventSearchRequest.cs
@@ -6,32 +6,12 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
 {
     public class TeachingEventSearchRequest : ICloneable
     {
-        private int[] _typeIds;
-
         [SwaggerSchema("Postcode to center search around.")]
         public string Postcode { get; set; }
         [SwaggerSchema("Set to filter results to a radius (in miles) around the postcode.")]
         public int? Radius { get; set; }
-        [SwaggerSchema("Set to filter results to a type of teaching event. Must match an `typeId` of the `TeachingEvent` schema.")]
-        public int? TypeId { get; set; }
         [SwaggerSchema("Set to filter results to a type of teaching event. Each ID must match a `typeId` of the `TeachingEvent` schema.")]
-        public int[] TypeIds
-        {
-            get
-            {
-                if (TypeId != null)
-                {
-                    return new int[] { TypeId.Value };
-                }
-
-                return _typeIds;
-            }
-
-            set
-            {
-                _typeIds = value;
-            }
-        }
+        public int[] TypeIds { get; set; }
 
         [SwaggerSchema("Set to filter results to those that start after a given date.")]
         public DateTime? StartAfter { get; set; }

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
@@ -13,9 +13,6 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
                 .MaximumLength(40)
                 .Matches(Location.OutwardOrFullPostcodeRegex)
                 .Unless(request => request.Postcode == null && request.Radius == null);
-            RuleFor(request => request.TypeId)
-                .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
-                .Unless(request => request.TypeId == null);
             RuleForEach(request => request.TypeIds)
                 .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
                 .Unless(request => request.TypeIds == null);

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
@@ -36,18 +36,5 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             request.StatusIds.Should().Equal(expectedDefaults);
         }
-
-        [Fact]
-        public void TypeIds_WhenTypeIdHasAValue_ReturnsTheValueOfTypeId()
-        {
-            var request = new TeachingEventSearchRequest
-            {
-                TypeId = 101,
-                TypeIds = new int[] { 202 }
-            };
-
-            request.TypeIds.Length.Should().Be(1);
-            request.TypeIds[0].Should().Be(101);
-        }
     }
 }


### PR DESCRIPTION
This was kept for backwards compatibility and is no longer needed now that we have the `TypeIds` parameter.