### PR TITLE
Extend comma separated attribute so that it can handle complex types

### DIFF
--- a/GetIntoTeachingApi/Attributes/CommaSeparatedAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CommaSeparatedAttribute.cs
@@ -1,8 +1,19 @@
 ﻿using System;
+
 namespace GetIntoTeachingApi.Attributes
 {
     [AttributeUsage(AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
     public class CommaSeparatedAttribute : Attribute
     {
+        public CommaSeparatedAttribute()
+        {
+        }
+
+        public CommaSeparatedAttribute(params string[] attributeNames)
+        {
+            AttributeNames = attributeNames;
+        }
+
+        public string[] AttributeNames { get; }
     }
 }

--- a/GetIntoTeachingApi/Attributes/CommaSeparatedQueryStringAttribute.cs
+++ b/GetIntoTeachingApi/Attributes/CommaSeparatedQueryStringAttribute.cs
@@ -19,9 +19,9 @@ namespace GetIntoTeachingApi.Attributes
             _factory = new CommaSeparatedQueryStringValueProviderFactory(separator);
         }
 
-        public CommaSeparatedQueryStringAttribute(string key, string separator)
+        public CommaSeparatedQueryStringAttribute(string[] keys, string separator)
         {
-            _factory = new CommaSeparatedQueryStringValueProviderFactory(key, separator);
+            _factory = new CommaSeparatedQueryStringValueProviderFactory(keys, separator);
         }
 
         public void OnResourceExecuted(ResourceExecutedContext context)

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -57,13 +57,13 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
         [Route("search_grouped_by_type")]
         [SwaggerOperation(
     Summary = "Searches for teaching events, returning grouped by type.",
-    Description = @"Searches for teaching events. Optionally limit the results by distance (in miles) from a postcode, event type and start date.",
+    Description = "Searches for teaching events. Optionally limit the results by distance (in miles) from a postcode, event type and start date.",
     OperationId = "SearchTeachingEventsGroupedByType",
     Tags = new[] { "Teaching Events" })]
         [ProducesResponseType(typeof(IEnumerable<TeachingEventsByType>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> SearchGroupedByType(
-    [FromQuery, SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request,
+    [FromQuery, CommaSeparated("TypeIds", "StatusIds"), SwaggerParameter("Event search criteria.", Required = true)] TeachingEventSearchRequest request,
     [FromQuery, SwaggerParameter("Quantity to return (per type).")] int quantityPerType = 3)
         {
             if (!ModelState.IsValid)

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringConvention.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringConvention.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using GetIntoTeachingApi.Attributes;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
@@ -12,9 +13,23 @@ namespace GetIntoTeachingApi.Utils
             {
                 if (parameter.Attributes.OfType<CommaSeparatedAttribute>().Any() && !parameter.Action.Filters.OfType<CommaSeparatedQueryStringAttribute>().Any())
                 {
-                    parameter.Action.Filters.Add(new CommaSeparatedQueryStringAttribute(parameter.ParameterName, ","));
+                    var attributeNames = parameter.Attributes.OfType<CommaSeparatedAttribute>().First().AttributeNames;
+
+                    if (attributeNames != null)
+                    {
+                        AddToActionFilterAsCommaSeparated(parameter, attributeNames);
+                    }
+                    else
+                    {
+                        AddToActionFilterAsCommaSeparated(parameter, new string[] { parameter.ParameterName });
+                    }
                 }
             }
+        }
+
+        private static void AddToActionFilterAsCommaSeparated(ParameterModel parameter, string[] keys)
+        {
+            parameter.Action.Filters.Add(new CommaSeparatedQueryStringAttribute(keys, ","));
         }
     }
 }

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProvider.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProvider.cs
@@ -9,7 +9,7 @@ namespace GetIntoTeachingApi.Utils
 {
     public class CommaSeparatedQueryStringValueProvider : QueryStringValueProvider
     {
-        private readonly string _key;
+        private readonly string[] _keys;
         private readonly string _separator;
 
         public CommaSeparatedQueryStringValueProvider(IQueryCollection values, string separator)
@@ -18,10 +18,10 @@ namespace GetIntoTeachingApi.Utils
             _separator = separator;
         }
 
-        public CommaSeparatedQueryStringValueProvider(string key, IQueryCollection values, string separator)
+        public CommaSeparatedQueryStringValueProvider(string[] keys, IQueryCollection values, string separator)
             : base(BindingSource.Query, values, CultureInfo.InvariantCulture)
         {
-            _key = key;
+            _keys = keys;
             _separator = separator;
         }
 
@@ -29,7 +29,7 @@ namespace GetIntoTeachingApi.Utils
         {
             var result = base.GetValue(key);
 
-            if (_key != key)
+            if (!_keys.Contains(key))
             {
                 return result;
             }

--- a/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProviderFactory.cs
+++ b/GetIntoTeachingApi/Utils/CommaSeparatedQueryStringValueProviderFactory.cs
@@ -6,23 +6,23 @@ namespace GetIntoTeachingApi.Utils
     public class CommaSeparatedQueryStringValueProviderFactory : IValueProviderFactory
     {
         private readonly string _separator;
-        private readonly string _key;
+        private readonly string[] _keys;
 
         public CommaSeparatedQueryStringValueProviderFactory(string separator)
             : this(null, separator)
         {
         }
 
-        public CommaSeparatedQueryStringValueProviderFactory(string key, string separator)
+        public CommaSeparatedQueryStringValueProviderFactory(string[] keys, string separator)
         {
-            _key = key;
+            _keys = keys;
             _separator = separator;
         }
 
         public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
         {
             var provider = new CommaSeparatedQueryStringValueProvider(
-                _key,
+                _keys,
                 context.ActionContext.HttpContext.Request.Query,
                 _separator);
 

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -98,6 +98,20 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         }
 
         [Fact]
+        public void SearchGroupedByType_SearchRequestIsDecoratedWithCommaSeparatedAttributeForArrayProperties()
+        {
+            var expectedAttribute = new CommaSeparatedAttribute(
+                nameof(TeachingEventSearchRequest.TypeIds), nameof(TeachingEventSearchRequest.StatusIds));
+
+            typeof(TeachingEventsController)
+                .GetMethod("SearchGroupedByType")
+                .GetParameters()
+                .FirstOrDefault(param => param.ParameterType == typeof(TeachingEventSearchRequest))
+                .GetCustomAttributes(false)
+                .Should().ContainEquivalentOf(expectedAttribute);
+        }
+
+        [Fact]
         public async void SearchGroupedByType_InvalidRequest_RespondsWithValidationErrors()
         {
             var request = new TeachingEventSearchRequest() { Postcode = null };

--- a/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderFactoryTests.cs
+++ b/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderFactoryTests.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApiTests.Utils
         [Fact]
         public void CreateValueProviderAsync_InsertsCommaSepratedQueryStrinValueProvider()
         {
-            var factory = new CommaSeparatedQueryStringValueProviderFactory("key", ",");
+            var factory = new CommaSeparatedQueryStringValueProviderFactory(new string[] { "key" }, ",");
             var actionContext = new ActionContext();
             var httpContext = new DefaultHttpContext();
             httpContext.Request.QueryString = new QueryString("?key=value");
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApiTests.Utils
 
             factory.CreateValueProviderAsync(context);
 
-            var expectedProvider = new CommaSeparatedQueryStringValueProvider("key",
+            var expectedProvider = new CommaSeparatedQueryStringValueProvider(new string[] { "key" },
                 context.ActionContext.HttpContext.Request.Query, ",");
             context.ValueProviders[0].Should().BeEquivalentTo(expectedProvider);
         }

--- a/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderTests.cs
+++ b/GetIntoTeachingApiTests/Utils/CommaSeparatedQueryStringValueProviderTests.cs
@@ -9,13 +9,13 @@ namespace GetIntoTeachingApiTests.Utils
 {
     public class CommaSeparatedQueryStringValueProviderTests
     {
-        private readonly string _key;
+        private readonly string[] _keys;
         private readonly IQueryCollection _values;
         private readonly CommaSeparatedQueryStringValueProvider _provider;
 
         public CommaSeparatedQueryStringValueProviderTests()
         {
-            _key = "key1";
+            _keys = new string[] { "key1", "key2" };
             _values = new QueryCollection(new Dictionary<string, StringValues>()
             {
                 { "key1", "value1,value2,value3" },
@@ -23,15 +23,15 @@ namespace GetIntoTeachingApiTests.Utils
                 { "key3", "other_value1|other_value2" },
             });
 
-            _provider = new CommaSeparatedQueryStringValueProvider(_key, _values, ",");
+            _provider = new CommaSeparatedQueryStringValueProvider(_keys, _values, ",");
         }
 
         [Fact]
         public void GetValue_WithNonMatchingKey_ReturnsASingleValue()
         {
-            var result = _provider.GetValue("key2");
+            var result = _provider.GetValue("key3");
 
-            result.Values.Should().BeEquivalentTo(new string[] { "other_value1,other_value2" });
+            result.Values.Should().BeEquivalentTo(new string[] { "other_value1|other_value2" });
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace GetIntoTeachingApiTests.Utils
         [Fact]
         public void GetValue_WithMatchingKeyAndNoSeparator_ReturnsSingleValue()
         {
-            var provider = new CommaSeparatedQueryStringValueProvider("key3", _values, ",");
+            var provider = new CommaSeparatedQueryStringValueProvider(new string[] { "key3" }, _values, ",");
 
             var result = provider.GetValue("key3");
 


### PR DESCRIPTION
[Trello](https://trello.com/c/qbuoFw8L)

We want to search events by multiple TypeIds. To do this we have added a new collection type parameter. Unfortunately, ASP.NET expects the request in the following format:

```
?TypeIds=101&TypeIds=202
```

whereas the Swagger Codegen API client library produces incompatible queries that look like this:

```
?TypeIds=101,202
``` 

There is already a `CommaSeparatedAttribute` which handles this, but it only works for simple types because the `CommaSeparatedQueryStringConvention` passes the name of the parameter itself to the `CommaSeparatedQueryStringValueProvider`.

Extend the attribute so that we can specify which properties of complex types should be comma separated.