### PR TITLE
Map phase/status to FindApply application forms

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -10,10 +10,36 @@ namespace GetIntoTeachingApi.Models.Crm
     [Entity("dfe_applyapplicationform")]
     public class ApplicationForm : BaseModel, IHasCandidateId
     {
+        // The keys for this enum need to mirror the
+        // Apply API naming so we can match them up.
+        public enum Status
+        {
+            NeverSignedIn = 222750000,
+            UnsubmittedNotStartedForm = 222750001,
+            UnsubmittedInProgress = 222750002,
+            AwaitingProviderDecisions = 222750003,
+            AwaitingCandidateResponse = 222750004,
+            Recruited = 222750005,
+            PendingConditions = 222750006,
+            OfferDeferred = 222750007,
+            EndedWithoutSuccess = 222750008,
+            UnknownState = 222750009,
+        }
+
+        // The keys for this enum need to mirror the
+        // Apply API naming so we can match them up.
+        public enum Phase
+        {
+            Apply1 = 222750000,
+            Apply2 = 222750001,
+        }
+
         [EntityField("dfe_contact", typeof(EntityReference), "contact")]
         public Guid CandidateId { get; set; }
-        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue))]
+        [EntityField("dfe_applyphase", typeof(OptionSetValue))]
         public int? PhaseId { get; set; }
+        [EntityField("dfe_applystatus", typeof(OptionSetValue))]
+        public int? StatusId { get; set; }
         [EntityField("dfe_applicationformid")]
         public string FindApplyId { get; set; }
         [EntityField("dfe_createdon")]

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -105,30 +105,6 @@ namespace GetIntoTeachingApi.Models.Crm
             ReRegistered = 222750000,
         }
 
-        // The keys for this enum need to mirror the
-        // Apply API naming so we can match them up.
-        public enum FindApplyApplicationStatus
-        {
-            NeverSignedIn = 222750000,
-            UnsubmittedNotStartedForm = 222750001,
-            UnsubmittedInProgress = 222750002,
-            AwaitingProviderDecisions = 222750003,
-            AwaitingCandidateResponse = 222750004,
-            Recruited = 222750005,
-            PendingConditions = 222750006,
-            OfferDeferred = 222750007,
-            EndedWithoutSuccess = 222750008,
-            UnknownState = 222750009,
-        }
-
-        // The keys for this enum need to mirror the
-        // Apply API naming so we can match them up.
-        public enum FindApplyApplicationPhase
-        {
-            Apply1 = 222750000,
-            Apply2 = 222750001,
-        }
-
         public string FullName => $"{FirstName} {LastName}".NullIfEmptyOrWhitespace();
         [EntityField("dfe_preferredteachingsubject01", typeof(EntityReference), "dfe_teachingsubjectlist")]
         public Guid? PreferredTeachingSubjectId { get; set; }

--- a/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
@@ -10,8 +10,11 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
         {
             RuleFor(form => form.FindApplyId).NotEmpty();
             RuleFor(form => form.PhaseId)
-                .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_candidateapplyphase", store))
-                .Unless(form => form.PhaseId == null);
+                .NotNull()
+                .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_applyphase", store));
+            RuleFor(form => form.StatusId)
+                .NotNull()
+                .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_applystatus", store));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -104,8 +104,11 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(candidate => candidate.FindApplyPhaseId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
                 .Unless(candidate => candidate.FindApplyPhaseId == null);
-            RuleFor(candidate => candidate.FindApplyStatusId)
+            RuleFor(candidate => candidate.FindApplyPhaseId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplyphase", store))
+                .Unless(candidate => candidate.FindApplyPhaseId == null);
+            RuleFor(candidate => candidate.FindApplyStatusId)
+                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
                 .Unless(candidate => candidate.FindApplyStatusId == null);
         }
     }

--- a/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
@@ -11,5 +11,9 @@ namespace GetIntoTeachingApi.Models.FindApply
         public DateTime CreatedAt { get; set; }
         [JsonProperty("updated_at")]
         public DateTime UpdatedAt { get; set; }
+        [JsonProperty("application_status")]
+        public string ApplicationStatus { get; set; }
+        [JsonProperty("application_phase")]
+        public string ApplicationPhase { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
+++ b/GetIntoTeachingApi/Models/FindApply/CandidateAttributes.cs
@@ -12,10 +12,6 @@ namespace GetIntoTeachingApi.Models.FindApply
         public DateTime CreatedAt { get; set; }
         [JsonProperty("updated_at")]
         public DateTime? UpdatedAt { get; set; }
-        [JsonProperty("application_status")]
-        public string ApplicationStatus { get; set; }
-        [JsonProperty("application_phase")]
-        public string ApplicationPhase { get; set; }
         [JsonProperty("application_forms")]
         public IEnumerable<ApplicationForm> ApplicationForms { get; set; }
     }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -261,7 +261,8 @@ namespace GetIntoTeachingApi.Services
             {
                 await SyncPickListItem("contact", "dfe_candidateapplystatus");
                 await SyncPickListItem("contact", "dfe_candidateapplyphase");
-                await SyncPickListItem("dfe_applyapplicationform", "dfe_candidateapplyphase");
+                await SyncPickListItem("dfe_applyapplicationform", "dfe_applyphase");
+                await SyncPickListItem("dfe_applyapplicationform", "dfe_applystatus");
             }
         }
 

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
@@ -20,7 +20,9 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 && a.Type == typeof(EntityReference) && a.Reference == "contact");
 
             type.GetProperty("PhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue));
+                a => a.Name == "dfe_applyphase" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_applystatus" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationformid");
             type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_createdon");

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
@@ -28,7 +28,10 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
             var mockPickListItem = new PickListItem { Id = 123 };
 
             _mockStore
-                .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_candidateapplyphase"))
+                .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_applyphase"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_applystatus"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
 
             var form = new ApplicationForm()
@@ -36,6 +39,7 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 CandidateId = Guid.NewGuid(),
                 FindApplyId = "67890",
                 PhaseId = mockPickListItem.Id,
+                StatusId = mockPickListItem.Id,
             };
 
             var result = _validator.TestValidate(form);
@@ -53,12 +57,23 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_PhaseIdIsNotValid_HasError()
+        public void Validate_OptionSetIsNotValid_HasError()
         {
-            var form = new ApplicationForm() { PhaseId = 456 };
+            var form = new ApplicationForm() { PhaseId = 456, StatusId = 789 };
             var result = _validator.TestValidate(form);
 
             result.ShouldHaveValidationErrorFor("PhaseId");
+            result.ShouldHaveValidationErrorFor("StatusId");
+        }
+
+        [Fact]
+        public void Validate_RequiredAttributeIsNull_HasError()
+        {
+            var form = new ApplicationForm() { PhaseId = null, StatusId = null };
+            var result = _validator.TestValidate(form);
+
+            result.ShouldHaveValidationErrorFor("PhaseId");
+            result.ShouldHaveValidationErrorFor("StatusId");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
@@ -18,6 +18,10 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
             type.GetProperty("UpdatedAt").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+            type.GetProperty("ApplicationStatus").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_status");
+            type.GetProperty("ApplicationPhase").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_phase");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CandidateAttributesTests.cs
@@ -18,10 +18,6 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
             type.GetProperty("UpdatedAt").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
-            type.GetProperty("ApplicationStatus").Should()
-                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_status");
-            type.GetProperty("ApplicationPhase").Should()
-                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_phase");
             type.GetProperty("ApplicationForms").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_forms");
         }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -325,7 +325,8 @@ namespace GetIntoTeachingApiTests.Services
 
             _mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_candidateapplystatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
             _mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_candidateapplyphase")).Returns(Array.Empty<PickListItem>()).Verifiable();
-            _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationform", "dfe_candidateapplyphase")).Returns(Array.Empty<PickListItem>()).Verifiable();
+            _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationform", "dfe_applyphase")).Returns(Array.Empty<PickListItem>()).Verifiable();
+            _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationform", "dfe_applystatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
 
             await _store.SyncAsync();
 


### PR DESCRIPTION
[Trello-1908](https://trello.com/c/soONwBZQ/1908-update-apply-api-integration-with-recent-changes)

Previously we were mapping the phase/status at the candidate-level. Instead, the Apply team have updated their API to provide the phase/status for each application form and will be deprecating the fields at the candidate-level.

The CRM team want to retain the candidate-level phase/status, having it contain the latest applicable application forms details; this is inferred from the first application form in the list we get back.

This commit maps the additional fields on `ApplicationForm` from the apply and CRM models, infers the candidate-level values and updates the store to sync the additional option sets.

All changes are only running in the dev environment for now.