### PR TITLE
Update with client configuration recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Endpoints that are potentially exploitable have global rate limits applied. If y
 
 More information on rate limiting can be found [below](#rate-limiting).
 
+### Client Configuration
+
+When the client is configured to point to the API, we need to ensure it uses the `https` version and does not rely on the insecure redirect of `http` traffic. We are looking into ways to disable `http` traffic entirely in the API, however it doesn't appear to be trivial to do and whilst we only have internal API clients that we have full control over we should instead be enforcing the policy of directly accessing the `https` version of the API.
 
 ## Getting Started
 


### PR DESCRIPTION
[Trello-1805](https://trello.com/c/vOtypff0/1805-api-pen-test-insecure-redirection)

A penetration test highlighted our insecure http redirect as a possible point of exploitation. Looking into disabling http traffic it turned out that given the current infrastructure its not currently possible without a substantial change of how the API is hosted (as the redirect happens at the infrastructure level).

Instead, the readme is being updated with client configuration recommendations to ensure all clients point directly at the `http` version of the API.