### PR TITLE
Bulk update dependencies take #2

### DIFF
--- a/GetIntoTeachingApi/AppStart/ApplicationBuilderExtensions.cs
+++ b/GetIntoTeachingApi/AppStart/ApplicationBuilderExtensions.cs
@@ -12,16 +12,8 @@ namespace GetIntoTeachingApi.AppStart
 {
     public static class ApplicationBuilderExtensions
     {
-        public static void ConfigureHangfire(this IApplicationBuilder app, int? workerCount, bool addBasicAuthFilter, IEnv env)
+        public static void ConfigureHangfire(this IApplicationBuilder app, bool addBasicAuthFilter, IEnv env)
         {
-            var hangfireOptions = new BackgroundJobServerOptions();
-            if (workerCount.HasValue)
-            {
-                hangfireOptions.WorkerCount = workerCount.Value;
-            }
-
-            app.UseHangfireServer(hangfireOptions);
-
             var filters = new List<IDashboardAuthorizationFilter> { new HangfireDashboardEnvironmentAuthorizationFilter(env) };
 
             if (addBasicAuthFilter)

--- a/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
+++ b/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
@@ -135,6 +135,14 @@ The GIT API aims to provide:
                     config.UsePostgreSqlStorage(DbConfiguration.HangfireConnectionString(env));
                 }
             });
+
+            services.AddHangfireServer(options =>
+            {
+                if (!env.IsDevelopment)
+                {
+                    options.WorkerCount = 20;
+                }
+            });
         }
 
         public static void ConfigureRedis(this IServiceCollection services, IEnv env)

--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -93,10 +93,7 @@ namespace GetIntoTeachingApi.AppStart
 
             app.UseRequestResponseLogging();
 
-            app.ConfigureHangfire(
-                workerCount: _env.IsDevelopment ? null : 20,
-                addBasicAuthFilter: _env.IsStaging,
-                _env);
+            app.ConfigureHangfire(addBasicAuthFilter: _env.IsStaging, _env);
 
             // The UI generated for V2 is buggy, so use V3 in development.
             app.UseSwagger(c => c.SerializeAsV2 = !_env.IsDevelopment);

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -7,13 +7,13 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
 		<PackageReference Include="CsvHelper" Version="27.1.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.24" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.25" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.25" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.3" />
-		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.2.0" />
+		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.3.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
 		  <PrivateAssets>all</PrivateAssets>
@@ -29,16 +29,16 @@
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
-		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.5" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -20,7 +20,7 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.0.0" />
+	<PackageReference Include="FluentAssertions" Version="6.1.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#780

This was reverted originally due to seeing an error in the CrmSync job, which turned out to be caused by an option set getting deleted prematurely in the dev CRM and not this PR.