### PR TITLE
Undo remapping of QT events to TTT

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -204,14 +204,6 @@ namespace GetIntoTeachingApi.Services
 
             foreach (var te in teachingEvents)
             {
-                // This horrible bit of misdirection is so that we can quickly lump the QT
-                // events in with TTT events on the GiT website for an immediate need. We
-                // should update the GiT website to handle QT events explicitly and remove this.
-                if (te.TypeId == (int)TeachingEvent.EventType.QuestionTime)
-                {
-                    te.TypeId = (int)TeachingEvent.EventType.TrainToTeachEvent;
-                }
-
                 if (te.BuildingId != null)
                 {
                     te.Building = teachingEventBuildings.FirstOrDefault(b => b.Id == te.BuildingId);

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -81,19 +81,6 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async void SyncAsync_ChangesQuestionTimeEventsToBeTrainToTeachEvents()
-        {
-            await SeedMockTeachingEventBuildingsAsync();
-            var mockTeachingEvents = MockTeachingEvents().ToList();
-            _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(mockTeachingEvents);
-            mockTeachingEvents.FirstOrDefault(e => e.TypeId == (int)TeachingEvent.EventType.QuestionTime).Should().NotBeNull();
-
-            await _store.SyncAsync();
-
-            DbContext.TeachingEvents.FirstOrDefault(e => e.TypeId == (int)TeachingEvent.EventType.QuestionTime).Should().BeNull();
-        }
-
-        [Fact]
         public async void SyncAsync_UpdatesExistingTeachingEvents()
         {
             var updatedTeachingEvents = (await SeedMockTeachingEventsAndBuildingsAsync()).ToList();


### PR DESCRIPTION
The front-end has been updated to natively support QT events by displaying them as though they are TTT events. We should now be fine to remove the remapping that occurs in the API.

This will need to be merged down and checked on dev/test before shipping to prod.