### PR TITLE
Make first/last name optional on Candidate

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -14,8 +14,8 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
 
         public CandidateValidator(IStore store, IDateTimeProvider dateTime)
         {
-            RuleFor(candidate => candidate.FirstName).NotEmpty().MaximumLength(256);
-            RuleFor(candidate => candidate.LastName).NotEmpty().MaximumLength(256);
+            RuleFor(candidate => candidate.FirstName).MaximumLength(256);
+            RuleFor(candidate => candidate.LastName).MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -198,30 +198,16 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         }
 
         [Fact]
-        public void Validate_RequiredFieldsWhenNullOrEmpty_HasError()
+        public void Validate_RequiredFieldsWhenNull_HasError()
         {
             var candidate = new Candidate()
             {
-                Email = "",
-                SecondaryEmail = "",
-                FirstName = "",
-                LastName = "",
-                AddressTelephone = "",
-                MobileTelephone = "",
-                Telephone = "",
-                SecondaryTelephone = "",
+                Email = null,
 
             };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.Email);
-            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
-            result.ShouldHaveValidationErrorFor(c => c.FirstName);
-            result.ShouldHaveValidationErrorFor(c => c.LastName);
-            result.ShouldHaveValidationErrorFor(c => c.AddressTelephone);
-            result.ShouldHaveValidationErrorFor(c => c.MobileTelephone);
-            result.ShouldHaveValidationErrorFor(c => c.Telephone);
-            result.ShouldHaveValidationErrorFor(c => c.SecondaryTelephone);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -58,12 +58,12 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         {
             var request = new TeachingEventAddAttendee
             {
-                FirstName = null,
+                Email = "invalid@"
             };
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("Candidate.FirstName");
+            result.ShouldHaveValidationErrorFor("Candidate.Email");
         }
 
 


### PR DESCRIPTION
[Trello-1930](https://trello.com/c/kcWhKB9W/1930-support-syncing-apply-only-candidates-in-the-api)

The candidates that come through from the Apply API will not always have a `FirstName` or `LastName`. We need to be able to accept records where a name has not been set, but still enforce first/last name on sign ups. As the request models already have validation in place to ensure first/last name is present, we can simply remove the `NotEmpty` check from the base `Candidate` model.

The existing validation on `Candidate` that was checking for required fields included some that are not required but were failing because an empty string is not valid; this is covered elsewhere so the test has been reduced to only include the required `Email` field.