### PR TITLE
Sync new Apply candidates to the CRM

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -63,6 +63,11 @@ namespace GetIntoTeachingApi.Jobs
                 FindApplyUpdatedAt = findApplyCandidate.Attributes.UpdatedAt,
             };
 
+            if (match == null)
+            {
+                candidate.ChannelId = (int)Models.Crm.Candidate.Channel.ApplyForTeacherTraining;
+            }
+
             var latestApplicationForm = findApplyApplicationForms?.FirstOrDefault();
 
             if (latestApplicationForm != null)

--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -40,30 +40,24 @@ namespace GetIntoTeachingApi.Jobs
 
         public void SyncCandidate(Candidate findApplyCandidate)
         {
-            var match = _crm.MatchCandidate(findApplyCandidate.Attributes.Email);
+            var applicationForms = findApplyCandidate.Attributes.ApplicationForms;
+            var candidate = UpdateCandidate(findApplyCandidate, applicationForms);
 
-            if (match != null)
-            {
-                _logger.LogInformation($"FindApplyCandidateSyncJob - Hit - {findApplyCandidate.Id}");
-
-                var candidateId = (Guid)match.Id;
-                var applicationForms = findApplyCandidate.Attributes.ApplicationForms;
-                UpdateCandidate(candidateId, findApplyCandidate, applicationForms);
-                UpsertApplicationForms(candidateId, applicationForms);
-            }
-            else
-            {
-                _logger.LogInformation($"FindApplyCandidateSyncJob - Miss - {findApplyCandidate.Id}");
-            }
+            UpsertApplicationForms((Guid)candidate.Id, applicationForms);
         }
 
-        private void UpdateCandidate(Guid candidateId, Candidate findApplyCandidate, IEnumerable<ApplicationForm> findApplyApplicationForms)
+        private Models.Crm.Candidate UpdateCandidate(Candidate findApplyCandidate, IEnumerable<ApplicationForm> findApplyApplicationForms)
         {
+            var match = _crm.MatchCandidate(findApplyCandidate.Attributes.Email);
+
+            _logger.LogInformation($"FindApplyCandidateSyncJob - {(match == null ? "Miss" : "Hit")} - {findApplyCandidate.Id}");
+
             // We persist a new Candidate to ensure we only write the find/apply
             // attributes back to the CRM and not existing attributes on the match.
             var candidate = new Models.Crm.Candidate()
             {
-                Id = candidateId,
+                Id = match?.Id,
+                Email = findApplyCandidate.Attributes.Email,
                 FindApplyId = findApplyCandidate.Id,
                 FindApplyCreatedAt = findApplyCandidate.Attributes.CreatedAt,
                 FindApplyUpdatedAt = findApplyCandidate.Attributes.UpdatedAt,
@@ -78,6 +72,8 @@ namespace GetIntoTeachingApi.Jobs
             }
 
             _crm.Save(candidate);
+
+            return candidate;
         }
 
         private void UpsertApplicationForms(Guid candidateId, IEnumerable<ApplicationForm> findApplyApplicationForms)

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -85,6 +85,7 @@ namespace GetIntoTeachingApi.Models.Crm
             TeacherTrainingAdviser = 222750027,
             SchoolsExperience = 222750021,
             GetIntoTeachingCallback = 222750043,
+            ApplyForTeacherTraining = 222750025,
         }
 
         public enum GcseStatus

--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -13,14 +13,19 @@ namespace GetIntoTeachingApi.Models
         public string Email { get; set; }
         public DateTime? DateOfBirth { get; set; }
 
-        public bool Match(Entity entity)
+        public bool IsFullMatch(Entity entity)
+        {
+            return IsEmailMatch(entity) && MinimumAdditionalAttributesMatch(entity);
+        }
+
+        public bool IsEmailMatch(Entity entity)
         {
             if (entity == null)
             {
                 return false;
             }
 
-            return EmailMatchesCandidate(entity) && MinimumAdditionalAttributesMatch(entity);
+            return EmailMatchesCandidate(entity);
         }
 
         public string Slugify()

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -94,6 +94,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
             _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(
                 c => c.Id == null
+                && c.ChannelId == (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining
                 && c.FindApplyId == _candidate.Id
                 && c.Email == _attributes.Email
                 && c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn

--- a/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
@@ -12,6 +12,7 @@ using GetIntoTeachingApi.Mocks;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Moq;
@@ -23,6 +24,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
     {
         private readonly Mock<IOrganizationServiceAdapter> _mockService;
         private readonly Mock<IValidatorFactory> _mockValidatorFactory;
+        private readonly Mock<ILogger<ICrmService>> _mockLogger;
         private readonly CrmService _crm;
         private readonly OrganizationServiceContext _context;
 
@@ -32,8 +34,9 @@ namespace GetIntoTeachingApiTests.Models.Crm
             _mockValidatorFactory = new Mock<IValidatorFactory>();
             _mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
             _mockService = new Mock<IOrganizationServiceAdapter>();
+            _mockLogger = new Mock<ILogger<ICrmService>>();
             _context = _mockService.Object.Context();
-            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object, mockAppSettings.Object, new DateTimeProvider());
+            _crm = new CrmService(_mockService.Object, _mockValidatorFactory.Object, mockAppSettings.Object, new DateTimeProvider(), _mockLogger.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/ExistingCandidateRequestTests.cs
@@ -22,39 +22,54 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Match_WithNullCandidate_ReturnsFalse()
+        public void IsEmailMatch_WithNullCandidate_ReturnsFalse()
         {
-            _request.Match(null).Should().BeFalse();
+            _request.IsEmailMatch(null).Should().BeFalse();
         }
 
         [Fact]
-        public void Match_WithEmailAndNoAdditionalAttributes_ReturnsFalse()
+        public void IsFullMatch_WithNullCandidate_ReturnsFalse()
+        {
+            _request.IsFullMatch(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsEmailMatch_WithEmail_ReturnsTrue()
         {
             var entity = new Entity();
             entity["emailaddress1"] = "email@address.com";
 
-            _request.Match(entity).Should().BeFalse();
+            _request.IsEmailMatch(entity).Should().BeTrue();
         }
 
         [Fact]
-        public void Match_WithEmailAndOneAdditionalAttribute_ReturnsFalse()
+        public void IsFullMatch_WithEmailAndNoAdditionalAttributes_ReturnsFalse()
+        {
+            var entity = new Entity();
+            entity["emailaddress1"] = "email@address.com";
+
+            _request.IsFullMatch(entity).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsFullMatch_WithEmailAndOneAdditionalAttribute_ReturnsFalse()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email;
             entity["firstname"] = _request.FirstName;
 
-            _request.Match(entity).Should().BeFalse();
+            _request.IsFullMatch(entity).Should().BeFalse();
         }
 
         [Fact]
-        public void Match_WithEmailAndTwoAdditionalAttributes_ReturnsTrue()
+        public void IsFullMatch_WithEmailAndTwoAdditionalAttributes_ReturnsTrue()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email;
             entity["firstname"] = _request.FirstName;
             entity["lastname"] = _request.LastName;
 
-            _request.Match(entity).Should().BeTrue();
+            _request.IsFullMatch(entity).Should().BeTrue();
         }
 
         [Fact]
@@ -65,22 +80,22 @@ namespace GetIntoTeachingApiTests.Models
             entity["firstname"] = $" {_request.FirstName} ";
             entity["lastname"] = $" {_request.LastName} ";
 
-            _request.Match(entity).Should().BeTrue();
+            _request.IsFullMatch(entity).Should().BeTrue();
         }
 
         [Fact]
-        public void Match_WithoutEmailAndWithTwoAdditionalAttributes_ReturnsFalse()
+        public void IsFullMatch_WithoutEmailAndWithTwoAdditionalAttributes_ReturnsFalse()
         {
             var entity = new Entity();
             entity["emailaddress1"] = "wrong@email.com";
             entity["firstname"] = _request.FirstName;
             entity["lastname"] = _request.LastName;
 
-            _request.Match(entity).Should().BeFalse();
+            _request.IsFullMatch(entity).Should().BeFalse();
         }
 
         [Fact]
-        public void Match_WithWrongEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
+        public void IsFullMatch_WithWrongEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
         {
             var entity = new Entity();
             entity["emailaddress1"] = "wrong@email.com";
@@ -88,11 +103,11 @@ namespace GetIntoTeachingApiTests.Models
             entity["lastname"] = _request.LastName;
             entity["birthdate"] = _request.DateOfBirth;
 
-            _request.Match(entity).Should().BeFalse();
+            _request.IsFullMatch(entity).Should().BeFalse();
         }
 
         [Fact]
-        public void Match_WithNullEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
+        public void IsFullMatch_WithNullEmailAndWithThreeAdditionalAttributes_ReturnsFalse()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email;
@@ -101,11 +116,11 @@ namespace GetIntoTeachingApiTests.Models
             entity["birthdate"] = _request.DateOfBirth;
             _request.Email = null;
 
-            _request.Match(entity).Should().BeFalse();
+            _request.IsFullMatch(entity).Should().BeFalse();
         }
 
         [Fact]
-        public void Match_WithEmailAndThreeAdditionalAttributes_ReturnsTrue()
+        public void IsFullMatch_WithEmailAndThreeAdditionalAttributes_ReturnsTrue()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email;
@@ -113,29 +128,29 @@ namespace GetIntoTeachingApiTests.Models
             entity["lastname"] = _request.LastName;
             entity["birthdate"] = _request.DateOfBirth;
 
-            _request.Match(entity).Should().BeTrue();
+            _request.IsFullMatch(entity).Should().BeTrue();
         }
 
         [Fact]
-        public void Match_WithCaseInsensitiveMatch_ReturnsTrue()
+        public void IsFullMatch_WithCaseInsensitiveMatch_ReturnsTrue()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email.ToUpper();
             entity["firstname"] = _request.FirstName.ToUpper();
             entity["lastname"] = _request.LastName.ToUpper();
 
-            _request.Match(entity).Should().BeTrue();
+            _request.IsFullMatch(entity).Should().BeTrue();
         }
 
         [Fact]
-        public void Match_WithMatchingDateButDifferentTimes_ReturnsTrue()
+        public void IsFullMatch_WithMatchingDateButDifferentTimes_ReturnsTrue()
         {
             var entity = new Entity();
             entity["emailaddress1"] = _request.Email;
             entity["firstname"] = _request.FirstName;
             entity["birthdate"] = _request.DateOfBirth?.AddMinutes(30);
 
-            _request.Match(entity).Should().BeTrue();
+            _request.IsFullMatch(entity).Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-1930](https://trello.com/c/kcWhKB9W/1930-support-syncing-apply-only-candidates-in-the-api)

- Sync new Apply candidates to the CRM

Now that first/last name is not required in the base `Candidate` model we can map new Apply API candidates and persist them back to the CRM.

- Set channel for new Apply candidates

When we create a candidate through the Apply API integration we need to ensure the correct channel is set so that it can be attributed to that source.

- Fallback to matching on email only

We are now accepting candidates from Apply that only have an email address and no first/last name, however we need to be able to match back on these candidate records. In order to do this, we first attempt a 'full' match back on first/last/email and, if that fails, we perform a second match back lookup using only the email address.