### PR TITLE
Use FluentAssertions.Json in contract test assertion

### DIFF
--- a/GetIntoTeachingApiTests/Contracts/TeacherTrainingAdviserTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/TeacherTrainingAdviserTests.cs
@@ -7,12 +7,14 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Json;
 using GetIntoTeachingApi.AppStart;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApiTests.Helpers;
 using Hangfire;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Contracts
@@ -59,7 +61,11 @@ namespace GetIntoTeachingApiTests.Contracts
 
             await WriteInitialOutputFile(outputFile, requestJson);
 
-            requestJson.Should().BeEquivalentTo(File.ReadAllText(outputFile));
+            var request = JToken.Parse(requestJson);
+            var snapshot = JToken.Parse(File.ReadAllText(outputFile));
+
+            request.Should().HaveCount(snapshot.Count());
+            request.Should().BeEquivalentTo(snapshot);
         }
 
         private static StringContent ConstructBody(string filename)

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -10,6 +10,7 @@
     <None Remove="Controllers\GetIntoTeaching\" />
     <None Remove="Models\FindApply\" />
     <None Remove="Contracts\Data\teacher_training_adviser\" />
+    <None Remove="FluentAssertions.Json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
@@ -33,6 +34,7 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
+    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use FluentAssertions.Json in contract test assertion

The contract tests are flakey and can fail on occasion in CI. I'm not sure how this is happening yet, but in an effort to debug it (and maybe even resolve it) we're switching to use `FluentAssertions.Json` in order to check equivalency of of the request JSON with that of our snapshot JSON. If it fails again this should hopefully give us a more detailed diff of where it's is matched.

- Sort entities and attributes prior to comparison

Looking at the diff when the contract test fails in CI it appears to be because the ordering of the entity attributes has changed. As the attributes are not a collection the ordering is probably undefined and we can't sort it prior to serialising. Instead, we deserialise the snapshot and then sort it manually before performing the comparison.