### PR TITLE
Ignore legacy paths in HighNotFound alert

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -49,7 +49,7 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#TooManyRequests-HIGH
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1
       - alert: HighNotFound
-        expr: 'sum(increase(app_requests_total{path=~".+",status=~"404"}[10m])) > 120'
+        expr: 'sum(increase(app_requests_total{path!~"(apple|logo.svg|login|sites|user|wp|node)",status=~"404"}[10m])) > 120'
         labels:
           severity: medium
         annotations:


### PR DESCRIPTION
The `HighNotFound` alert goes off quite often due to either bots poking about or inbound links to legacy website URLs. This attempts to strip out some of the noise around requests that 404 but are not a sign of any underlying issue.