### PR TITLE
Swallow errors when there are concurrent requests to add a postcode

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -342,7 +342,14 @@ namespace GetIntoTeachingApi.Services
         {
             var location = new Location(postcode, coordinate, Location.SourceType.Google);
             await _dbContext.Locations.AddAsync(location);
-            await _dbContext.SaveChangesAsync();
+            try
+            {
+                await _dbContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException e) when (e.InnerException.Message.Contains("duplicate key"))
+            {
+                // Swallow concurrent requests to add the same postode.
+            }
         }
 
         private async Task<Point> GeocodePostcodeWithLocalLookup(string sanitizedPostcode)


### PR DESCRIPTION
When a user searches for a postcode that isn't in the cache, the API will look it up via Google Geocoding then persist it.

If the API gets multiple requests in quick succession, the requests will be processed concurrently, resulting in a duplicate key exception as the API tries to persist the same postcode multiple times (the key for the Locations table is the postcode).

- Swallow the error in this very specific scenario.