### PR TITLE
Add google csp table grafana

### DIFF
--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,5 @@
+route:
+  repeat_interval: 1h
+  routes:
+    - match:
+      alertname: GoogleCspViolation

--- a/monitoring/grafana/dashboards/csp_violations.json
+++ b/monitoring/grafana/dashboards/csp_violations.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1603439685425,
+  "iteration": 1632403062667,
   "links": [],
   "panels": [
     {
@@ -49,7 +48,7 @@
         "label": "Others",
         "threshold": 0
       },
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -86,8 +85,9 @@
       "targets": [
         {
           "expr": "sum(increase($metric[$__range])) by (violated_directive)",
+          "instant": true,
           "interval": "",
-          "legendFormat": "{{violated_directive}}",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -98,7 +98,7 @@
       "valueName": "current"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -204,7 +204,7 @@
       "type": "table"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -320,7 +320,7 @@
       },
       "id": 24,
       "panels": [],
-      "repeatIteration": 1603439685425,
+      "repeatIteration": 1632403062667,
       "repeatPanelId": 2,
       "scopedVars": {
         "metric": {
@@ -340,7 +340,7 @@
         "label": "Others",
         "threshold": 0
       },
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -366,7 +366,7 @@
       "nullPointMode": "connected",
       "pieType": "pie",
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1603439685425,
+      "repeatIteration": 1632403062667,
       "repeatPanelId": 4,
       "repeatedByRow": true,
       "scopedVars": {
@@ -380,8 +380,9 @@
       "targets": [
         {
           "expr": "sum(increase($metric[$__range])) by (violated_directive)",
+          "instant": true,
           "interval": "",
-          "legendFormat": "{{violated_directive}}",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -392,7 +393,7 @@
       "valueName": "current"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -462,7 +463,7 @@
         ]
       },
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1603439685425,
+      "repeatIteration": 1632403062667,
       "repeatPanelId": 6,
       "repeatedByRow": true,
       "scopedVars": {
@@ -501,7 +502,7 @@
       "type": "table"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -571,7 +572,7 @@
         ]
       },
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1603439685425,
+      "repeatIteration": 1632403062667,
       "repeatPanelId": 9,
       "repeatedByRow": true,
       "scopedVars": {
@@ -618,127 +619,6 @@
         "x": 0,
         "y": 42
       },
-      "id": 22,
-      "panels": [],
-      "repeatIteration": 1603439685425,
-      "repeatPanelId": 21,
-      "scopedVars": {
-        "cf_app": {
-          "selected": false,
-          "text": "get-teacher-training-adviser-service-prod",
-          "value": "get-teacher-training-adviser-service-prod"
-        }
-      },
-      "title": "$cf_app",
-      "type": "row"
-    },
-    {
-      "datasource": "Elasticseach",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": null,
-            "filterable": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 14,
-        "w": 24,
-        "x": 0,
-        "y": 43
-      },
-      "id": 23,
-      "options": {
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": true
-      },
-      "pluginVersion": "7.2.2",
-      "repeatIteration": 1603439685425,
-      "repeatPanelId": 15,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "cf_app": {
-          "selected": false,
-          "text": "get-teacher-training-adviser-service-prod",
-          "value": "get-teacher-training-adviser-service-prod"
-        }
-      },
-      "targets": [
-        {
-          "bucketAggs": [],
-          "metrics": [
-            {
-              "field": "select field",
-              "id": "1",
-              "meta": {},
-              "pipelineVariables": [
-                {
-                  "name": "var1",
-                  "pipelineAgg": "select metric"
-                }
-              ],
-              "settings": {
-                "size": 500
-              },
-              "type": "raw_data"
-            }
-          ],
-          "query": "\"csp-report\" AND cf.app:\"$cf_app\"",
-          "refId": "A",
-          "timeField": "@timestamp"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Latest CSP Violations",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "@timestamp",
-                "payload.csp-report.effective-directive",
-                "payload.csp-report.original-policy",
-                "payload.csp-report.referrer",
-                "payload.csp-report.script-sample",
-                "payload.csp-report.status-code",
-                "payload.csp-report.violated-directive",
-                "message"
-              ]
-            }
-          }
-        }
-      ],
-      "type": "logs"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
       "id": 21,
       "panels": [],
       "repeat": "cf_app",
@@ -781,7 +661,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 43
       },
       "id": 15,
       "options": {
@@ -846,6 +726,127 @@
         }
       ],
       "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 30,
+      "panels": [],
+      "repeatIteration": 1632403062667,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-teacher-training-adviser-service-prod",
+          "value": "get-teacher-training-adviser-service-prod"
+        }
+      },
+      "title": "$cf_app",
+      "type": "row"
+    },
+    {
+      "datasource": "Elasticseach",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 31,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "7.2.2",
+      "repeatIteration": 1632403062667,
+      "repeatPanelId": 15,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "cf_app": {
+          "selected": false,
+          "text": "get-teacher-training-adviser-service-prod",
+          "value": "get-teacher-training-adviser-service-prod"
+        }
+      },
+      "targets": [
+        {
+          "bucketAggs": [],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "meta": {},
+              "pipelineVariables": [
+                {
+                  "name": "var1",
+                  "pipelineAgg": "select metric"
+                }
+              ],
+              "settings": {
+                "size": 500
+              },
+              "type": "raw_data"
+            }
+          ],
+          "query": "\"csp-report\" AND cf.app:\"$cf_app\"",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latest CSP Violations",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "@timestamp",
+                "payload.csp-report.effective-directive",
+                "payload.csp-report.original-policy",
+                "payload.csp-report.referrer",
+                "payload.csp-report.script-sample",
+                "payload.csp-report.status-code",
+                "payload.csp-report.violated-directive",
+                "message"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "logs"
     }
   ],
   "schemaVersion": 26,
@@ -856,7 +857,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -890,7 +891,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },

--- a/monitoring/grafana/dashboards/csp_violations.json
+++ b/monitoring/grafana/dashboards/csp_violations.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1632403062667,
+  "iteration": 1632408570181,
   "links": [],
   "panels": [
     {
@@ -310,17 +310,116 @@
       "type": "table"
     },
     {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "basic",
+            "filterable": false
+          },
+          "decimals": 0,
+          "displayName": "Total",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(115, 191, 105, 0)",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "blocked_uri"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Blocked URI"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 0,
+        "y": 21
+      },
+      "id": 28,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.2",
+      "targets": [
+        {
+          "expr": "sum(increase(app_csp_violations_total{blocked_uri=~\".*google.*\"}[$__range])) by (blocked_uri) > 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Google CSP Violations by Blocked URI",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "blocked_uri",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 41
       },
-      "id": 24,
+      "id": 22,
       "panels": [],
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 2,
       "scopedVars": {
         "metric": {
@@ -353,9 +452,9 @@
         "h": 20,
         "w": 6,
         "x": 0,
-        "y": 22
+        "y": 42
       },
-      "id": 25,
+      "id": 23,
       "interval": null,
       "legend": {
         "show": true,
@@ -366,7 +465,7 @@
       "nullPointMode": "connected",
       "pieType": "pie",
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 4,
       "repeatedByRow": true,
       "scopedVars": {
@@ -450,9 +549,9 @@
         "h": 20,
         "w": 9,
         "x": 6,
-        "y": 22
+        "y": 42
       },
-      "id": 26,
+      "id": 24,
       "options": {
         "showHeader": true,
         "sortBy": [
@@ -463,7 +562,7 @@
         ]
       },
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 6,
       "repeatedByRow": true,
       "scopedVars": {
@@ -559,9 +658,9 @@
         "h": 20,
         "w": 9,
         "x": 15,
-        "y": 22
+        "y": 42
       },
-      "id": 27,
+      "id": 25,
       "options": {
         "showHeader": true,
         "sortBy": [
@@ -572,7 +671,7 @@
         ]
       },
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 9,
       "repeatedByRow": true,
       "scopedVars": {
@@ -617,7 +716,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 62
       },
       "id": 21,
       "panels": [],
@@ -661,7 +760,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 63
       },
       "id": 15,
       "options": {
@@ -734,11 +833,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 77
       },
-      "id": 30,
+      "id": 26,
       "panels": [],
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 21,
       "scopedVars": {
         "cf_app": {
@@ -779,9 +878,9 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 78
       },
-      "id": 31,
+      "id": 27,
       "options": {
         "showLabels": false,
         "showTime": true,
@@ -789,7 +888,7 @@
         "wrapLogMessage": true
       },
       "pluginVersion": "7.2.2",
-      "repeatIteration": 1632403062667,
+      "repeatIteration": 1632408570181,
       "repeatPanelId": 15,
       "repeatedByRow": true,
       "scopedVars": {
@@ -932,5 +1031,5 @@
   "timezone": "",
   "title": "CSP Violations",
   "uid": "qZjcqcpGz",
-  "version": 1
+  "version": 2
 }

--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -75,6 +75,14 @@ groups:
           description: Alerts when any of the app instances exceed 70% memory utilisation.
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#HighMemory-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=33&orgId=1
+      - alert: GoogleCspViolation
+        expr: 'sum(increase(app_csp_violations_total{blocked_uri=~"google"}[24h])) and ON() hour() == 11'
+        labels:
+          severity: low
+        annotations:
+          summary: Alerts when there have been Google CSP violations in production in the last 24 hours.
+          description: Alerts when there have been Google CSP violations in production in the last 24 hours (see Grafana panel).
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/qZjcqcpGz/csp-violations?orgId=1&viewPanel=28
   - name: TTA
     rules:
       - alert: TooManyRequests

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -123,6 +123,6 @@ variable "alertmanager" {
   type = map(any)
   default = {
     "name"   = "get-into-teaching"
-    "config" = "../../monitoring/alertmanager/alertmanager.yml.tmpl"
+    "config" = "../../monitoring/alertmanager/alertmanager.yml"
   }
 }


### PR DESCRIPTION
- Fix existing Grafana CSP panels - There are two repeating rows of Grafana panels for CSP violations for the GiT app and TTA app. At some point these have broken, possibly due to an update.
![image](https://user-images.githubusercontent.com/47089130/134540823-097f68b2-7955-4aef-ad4d-1269c9eafae7.png)

- Add a Grafana table of Google CSP violations - We want to build up a CSP whitelist of Google domains in the GiT app. Adding a table showing the last 24 hours of violations so that we can have an alert posted to Slack.
![image](https://user-images.githubusercontent.com/47089130/134898896-53656f1f-b73e-4317-a15c-1ae31e3a6cee.png)

- Add daily alert if /there are Google CSP violations - This alert will fire at 10am daily if there are any Google violations in the last 24 hours, and will contain a link to a table displaying them.

- Add Prometheus config - We can declare rules for certain alerts in Prometheus groups. Ensure that the Google CSP alert only fires once rather than continuously during the time specified in the alert rule.