### PR TITLE
Stricter partial URL validation

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
 using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
@@ -13,7 +14,8 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
 
             RuleFor(operation => operation.ReadableId)
                 .Must((te, _) => BeUniqueReadableId(te))
-                .WithMessage("Must be unique");
+                .WithMessage("Must be unique")
+                .Matches(new Regex(@"\A[\w-]+\Z"));
         }
 
         private bool BeUniqueReadableId(TeachingEventUpsertOperation operation)

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidator.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
             RuleFor(operation => operation.ReadableId)
                 .Must((te, _) => BeUniqueReadableId(te))
                 .WithMessage("Must be unique")
-                .Matches(new Regex(@"\A[\w-]+\Z"));
+                .Matches(new Regex(@"\A[^_\W][\w-]+[^_\W]\Z"));
         }
 
         private bool BeUniqueReadableId(TeachingEventUpsertOperation operation)

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
@@ -69,7 +69,11 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         [InlineData("event?name", true)]
         [InlineData("event@name", true)]
         [InlineData("event:name", true)]
-        public void Validate_ReadableId_AllowsOnlyAlphanumericHyphensUnderscores(string readableId, bool hasError)
+        [InlineData("eventname-", true)]
+        [InlineData("-eventname", true)]
+        [InlineData("eventname_", true)]
+        [InlineData("_eventname", true)]
+        public void Validate_ReadableId_ValidatesCorrectly(string readableId, bool hasError)
         {
             var operation = new TeachingEventUpsertOperation() { ReadableId = readableId };
             var result = _validator.TestValidate(operation);

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using FluentAssertions;
+using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.GetIntoTeaching;
 using GetIntoTeachingApi.Models.GetIntoTeaching.Validators;
@@ -27,9 +28,9 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
 
             _mockCrm.Setup(m => m.GetTeachingEvent("new")).Returns<TeachingEvent>(null);
 
-            var result = _validator.Validate(operation);
+            var result = _validator.TestValidate(operation);
 
-            result.IsValid.Should().BeTrue();
+            result.ShouldNotHaveValidationErrorFor(te => te.ReadableId);
         }
 
         [Fact]
@@ -40,21 +41,24 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
 
             _mockCrm.Setup(m => m.GetTeachingEvent("existing")).Returns(existingTeachingEvent);
 
-            var result = _validator.Validate(operation);
+            var result = _validator.TestValidate(operation);
 
-            result.IsValid.Should().BeTrue();
+            result.ShouldNotHaveValidationErrorFor(te => te.ReadableId);
         }
 
         [Fact]
-        public void Validate_WhenExistingEventWithReadableIdHasDifferentTeachingEventId_HasErrors()
+        public void Validate_WhenExistingEventWithReadableIdHasDifferentTeachingEventId_HasError()
         {
             var operation = new TeachingEventUpsertOperation() { Id = Guid.NewGuid(), ReadableId = "existing" };
             var teachingEvent = new TeachingEvent() { Id = Guid.NewGuid() };
 
             _mockCrm.Setup(m => m.GetTeachingEvent("existing")).Returns(teachingEvent);
 
-            var result = _validator.Validate(operation);
+            var result = _validator.TestValidate(operation);
 
+            result.ShouldHaveValidationErrorFor(te => te.ReadableId)
+                .WithErrorMessage("Must be unique");
+        }
 
         [Theory]
         [InlineData("eventname", false)]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventUpsertOperationValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.GetIntoTeaching;
@@ -55,7 +55,29 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
 
             var result = _validator.Validate(operation);
 
-            result.IsValid.Should().BeFalse();
+
+        [Theory]
+        [InlineData("eventname", false)]
+        [InlineData("eventname1", false)]
+        [InlineData("event-name", false)]
+        [InlineData("event_name", false)]
+        [InlineData("event name", true)]
+        [InlineData("event?name", true)]
+        [InlineData("event@name", true)]
+        [InlineData("event:name", true)]
+        public void Validate_ReadableId_AllowsOnlyAlphanumericHyphensUnderscores(string readableId, bool hasError)
+        {
+            var operation = new TeachingEventUpsertOperation() { ReadableId = readableId };
+            var result = _validator.TestValidate(operation);
+
+            if (hasError)
+            {
+                result.ShouldHaveValidationErrorFor(te => te.ReadableId);
+            }
+            else
+            {
+                result.ShouldNotHaveValidationErrorFor(te => te.ReadableId);
+            }
         }
     }
 }


### PR DESCRIPTION
 - Add stricter validation to teaching event readable ID (partial URL) - Currently there is only minimal validation on the event readable ID (partial URL), so we have seen partial URLs with non-alphanumeric characters such as brackets, colons, and question marks. Update the partial URL validation so that only alphanumeric, hyphens, and underscores are allowed.

- Use FluentValidation test helpers - Minor clean-up to ensure unique readable ID validations are coming through on the correct property.
