### PR TITLE
Allow ChannelId to be specified on TeacherTrainingAdviserSignUp

### DIFF
--- a/GetIntoTeachingApi/Controllers/PickListItemsController.cs
+++ b/GetIntoTeachingApi/Controllers/PickListItemsController.cs
@@ -85,6 +85,18 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [Route("candidate/teacher_training_adviser_subscription_channels")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of candidate teacher training adviser subscription channels.",
+            OperationId = "GetCandidateTeacherTrainingAdviserSubscriptionChannels",
+            Tags = new[] { "Pick List Items" })]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetCandidateTeacherTrainingAdviserSubscriptionChannels()
+        {
+            return Ok(await _store.GetPickListItems("contact", "dfe_gitisttaservicesubscriptionchannel").ToListAsync());
+        }
+
+        [HttpGet]
         [Route("candidate/gcse_status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of candidate GCSE status.",

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -101,6 +101,9 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitismlservicesubscriptionchannel", store))
                 .Unless(candidate => candidate.MailingListSubscriptionChannelId == null);
+            RuleFor(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId)
+                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitisttaservicesubscriptionchannel", store))
+                .Unless(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId == null);
             RuleFor(candidate => candidate.FindApplyPhaseId)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
                 .Unless(candidate => candidate.FindApplyPhaseId == null);

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -62,6 +62,8 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public int? PlanningToRetakeGcseMathsAndEnglishId { get; set; }
         public int? PlanningToRetakeGcseScienceId { get; set; }
         public int? AdviserStatusId { get; set; }
+        [SwaggerSchema(WriteOnly = true)]
+        public int? ChannelId { get; set; }
 
         public string Email { get; set; }
         public string FirstName { get; set; }
@@ -215,7 +217,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             DefaultPreferredTeachingSubjectId(candidate);
             UpdateClosedAdviserStatus(candidate);
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow, ChannelId);
 
             return candidate;
         }
@@ -237,7 +239,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         {
             if (CandidateId == null)
             {
-                candidate.ChannelId = (int?)Candidate.Channel.TeacherTrainingAdviser;
+                candidate.ChannelId = ChannelId ?? (int?)Candidate.Channel.TeacherTrainingAdviser;
             }
         }
 

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -239,6 +239,7 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("contact", "dfe_isadvisorrequiredos");
             await SyncPickListItem("contact", "dfe_gitismlservicesubscriptionchannel");
             await SyncPickListItem("contact", "dfe_gitiseventsservicesubscriptionchannel");
+            await SyncPickListItem("contact", "dfe_gitisttaservicesubscriptionchannel");
             await SyncPickListItem("dfe_candidatequalification", "dfe_degreestatus");
             await SyncPickListItem("dfe_candidatequalification", "dfe_ukdegreegrade");
             await SyncPickListItem("dfe_candidatequalification", "dfe_type");

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -52,10 +52,10 @@ namespace GetIntoTeachingApi.Services
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, true);
         }
 
-        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow)
+        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasTeacherTrainingAdviserSubscription = true;
-            candidate.TeacherTrainingAdviserSubscriptionChannelId = (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
+            candidate.TeacherTrainingAdviserSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
             candidate.TeacherTrainingAdviserSubscriptionStartAt = utcNow;
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();

--- a/GetIntoTeachingApiTests/Contracts/Data/pick_list_items/candidate/teacher_training_adviser_subscription_channels.json
+++ b/GetIntoTeachingApiTests/Contracts/Data/pick_list_items/candidate/teacher_training_adviser_subscription_channels.json
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "id": 222750000,
+    "entityName": "contact",
+    "attributeName": "dfe_gitisttaservicesubscriptionchannel",
+    "value": "GITIS TTA Service"
+  },
+  {
+    "id": 222750001,
+    "entityName": "contact",
+    "attributeName": "dfe_gitisttaservicesubscriptionchannel",
+    "value": "Within Dynamics"
+  }
+]

--- a/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
@@ -72,6 +72,18 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public async void GetCandidateTeacherTrainingAdviserSubscriptionChannels_ReturnsAllChannels()
+        {
+            var mockItems = MockPickListItems();
+            _mockStore.Setup(mock => mock.GetPickListItems("contact", "dfe_gitisttaservicesubscriptionchannel")).Returns(mockItems.AsAsyncQueryable());
+
+            var response = await _controller.GetCandidateTeacherTrainingAdviserSubscriptionChannels();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockItems);
+        }
+
+        [Fact]
         public async void GetCandidateMailingListSubscriptionChannels_ReturnsAllChannels()
         {
             var mockItems = MockPickListItems();

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -183,6 +183,9 @@
     <None Update="Fixtures\zip-bomb-fixtures\contains-two-files.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Contracts\Data\pick_list_items\candidate\teacher_training_adviser_subscription_channels.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -52,6 +52,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
             _mockStore
+                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitisttaservicesubscriptionchannel"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
                 .Setup(mock => mock.GetPickListItems("contact", "dfe_websitehasgcseenglish"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
             _mockStore
@@ -117,6 +120,7 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 ChannelId = mockPickListItem.Id,
                 MailingListSubscriptionChannelId = mockPickListItem.Id,
                 EventsSubscriptionChannelId = mockPickListItem.Id,
+                TeacherTrainingAdviserSubscriptionChannelId = mockPickListItem.Id,
                 FindApplyPhaseId = mockPickListItem.Id,
                 FindApplyStatusId = mockPickListItem.Id,
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
@@ -433,6 +437,7 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 AssignmentStatusId = 123,
                 MailingListSubscriptionChannelId = 123,
                 EventsSubscriptionChannelId = 123,
+                TeacherTrainingAdviserSubscriptionChannelId = 123,
                 ChannelId = 123,
                 AdviserEligibilityId = 123,
                 AdviserRequirementId = 123,
@@ -454,6 +459,7 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
             result.ShouldHaveValidationErrorFor(c => c.AssignmentStatusId);
             result.ShouldHaveValidationErrorFor(c => c.MailingListSubscriptionChannelId);
             result.ShouldHaveValidationErrorFor(c => c.EventsSubscriptionChannelId);
+            result.ShouldHaveValidationErrorFor(c => c.TeacherTrainingAdviserSubscriptionChannelId);
             result.ShouldHaveValidationErrorFor(c => c.ChannelId);
             result.ShouldHaveValidationErrorFor(c => c.AdviserEligibilityId);
             result.ShouldHaveValidationErrorFor(c => c.AdviserRequirementId);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -292,6 +292,15 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
         }
 
         [Fact]
+        public void Candidate_WhenChannelIsProvided_SetsOnAllModels()
+        {
+            var request = new TeacherTrainingAdviserSignUp() { ChannelId = 123 };
+
+            request.Candidate.ChannelId.Should().Be(123);
+            request.Candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be(123);
+        }
+
+        [Fact]
         public void Candidate_PhoneCallScheduledAtIsNull_NoPhoneCallIsCreated()
         {
             var request = new TeacherTrainingAdviserSignUp() { PhoneCallScheduledAt = null };

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -116,6 +116,17 @@ namespace GetIntoTeachingApiTests.Services
             candidate.DoNotPostalMail.Should().BeFalse();
         }
 
+
+        [Fact]
+        public void SubscribeToTeacherTrainingAdviser_CustomChannel_UsesChannel()
+        {
+            var candidate = new Candidate();
+
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow, 123);
+
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be(123);
+        }
+
         [Fact]
         public void SubscribeToTeacherTrainingAdviser_NotReturningToTeaching_CorrectSubscription()
         {


### PR DESCRIPTION
The events team are pushing the TTA sign up at face-to-face events and want to be able to attribute sign ups back to the event.

Expose the `ChannelId` in the request model and map it to the `Candidate` (if a new candidate) and `TeacherTrainingAdviserSignUp` on sign up.

The field is optional so that existing sign ups still work as expected and the field is validated by the nested `CandidateValidator`.