### PR TITLE
Add test CSP violation alert

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -75,6 +75,14 @@ groups:
           description: Alerts when any of the app instances exceed 70% memory utilisation.
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#HighMemory-MEDIUM
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=33&orgId=1
+      - alert: TestCspViolation
+        expr: 'sum(increase(app_csp_violations_total[24h])) > 0'
+        labels:
+          severity: low
+        annotations:
+          summary: Test CSP violation.
+          description: Test CSP violation.
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/qZjcqcpGz/csp-violations?orgId=1&viewPanel=28
   - name: TTA
     rules:
       - alert: TooManyRequests


### PR DESCRIPTION
This should go off continuously if there have been any CSP violations in the last 24h, which will allow us to debug Prometheus alerts.