### PR TITLE
Allow unverified access to event registration

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -163,7 +163,14 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
                 return NotFound();
             }
 
-            return Ok(new TeachingEventAddAttendee(candidate));
+            var attendee = new TeachingEventAddAttendee(candidate)
+            {
+                IsVerified = false,
+            };
+
+            attendee.ClearAttributesForUnverifiedAccess();
+
+            return Ok(attendee);
         }
 
         [HttpPost]

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
@@ -27,6 +27,8 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
         public string AddressTelephone { get; set; }
+        public bool IsVerified { get; set; } = true;
+        [SwaggerSchema(WriteOnly = true)]
         public bool IsWalkIn { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public bool SubscribeToMailingList { get; set; }
@@ -49,6 +51,16 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         public TeachingEventAddAttendee(Candidate candidate)
         {
             PopulateWithCandidate(candidate);
+        }
+
+        // We do not want to pre-fill any sign up forms if a
+        // user is continuing as 'unverified'. Any fields that
+        // contain personal data should be cleared, excluding
+        // attributes used in match back (first/last/email).
+        public void ClearAttributesForUnverifiedAccess()
+        {
+            AddressPostcode = null;
+            AddressTelephone = null;
         }
 
         private void PopulateWithCandidate(Candidate candidate)
@@ -85,13 +97,21 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
                 Email = Email,
                 FirstName = FirstName,
                 LastName = LastName,
-                AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                AddressTelephone = AddressTelephone,
                 PreferredPhoneNumberTypeId = (int)Candidate.PhoneNumberType.Home,
                 PreferredContactMethodId = (int)Candidate.ContactMethod.Any,
                 GdprConsentId = (int)Candidate.GdprConsent.Consent,
                 OptOutOfGdpr = false,
             };
+
+            if (AddressPostcode != null)
+            {
+                candidate.AddressPostcode = AddressPostcode.AsFormattedPostcode();
+            }
+
+            if (AddressTelephone != null)
+            {
+                candidate.AddressTelephone = AddressTelephone;
+            }
 
             if (ConsiderationJourneyStageId != null)
             {

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -207,7 +207,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         [Fact]
         public void ExchangeUnverifiedRequestForAttendee_ValidRequest_RespondsWithTeachingEventAddAttendee()
         {
-            var candidate = new Candidate { Id = Guid.NewGuid() };
+            var candidate = new Candidate { Id = Guid.NewGuid(), AddressPostcode = "TE51NG" };
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
 
             var response = _controller.ExchangeUnverifiedRequestForAttendee(_request);
@@ -215,6 +215,8 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as TeachingEventAddAttendee;
             responseModel.CandidateId.Should().Be(candidate.Id);
+            responseModel.IsVerified.Should().BeFalse();
+            responseModel.AddressPostcode.Should().BeNull();
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
@@ -59,6 +59,8 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             response.AlreadySubscribedToEvents.Should().BeTrue();
             response.AlreadySubscribedToMailingList.Should().BeFalse();
             response.AlreadySubscribedToTeacherTrainingAdviser.Should().BeTrue();
+
+            response.IsVerified.Should().BeTrue();
         }
 
         [Fact]
@@ -122,19 +124,20 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
         }
 
         [Fact]
-        public void Candidate_ConsiderationJourneyStageIdIsNull_DoesNotSet()
+        public void Candidate_OptionalAttributesWhenNull_DoesNotSet()
         {
-            var request = new TeachingEventAddAttendee() { ConsiderationJourneyStageId = null };
+            var request = new TeachingEventAddAttendee()
+            {
+                ConsiderationJourneyStageId = null,
+                PreferredTeachingSubjectId = null,
+                AddressTelephone = null,
+                AddressPostcode = null,
+            };
 
             request.Candidate.ChangedPropertyNames.Should().NotContain("ConsiderationJourneyStageId");
-        }
-
-        [Fact]
-        public void Candidate_PreferredTeachingSubjectIdIsNull_DoesNotSet()
-        {
-            var request = new TeachingEventAddAttendee() { ConsiderationJourneyStageId = null };
-
             request.Candidate.ChangedPropertyNames.Should().NotContain("PreferredTeachingSubjectId");
+            request.Candidate.ChangedPropertyNames.Should().NotContain("AddressTelephone");
+            request.Candidate.ChangedPropertyNames.Should().NotContain("AddressPostcode");
         }
 
         [Fact]
@@ -200,6 +203,17 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             var request = new TeachingEventAddAttendee() { IsWalkIn = true, EventId = Guid.NewGuid() };
 
             request.Candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.EventWalkIn);
+        }
+
+        [Fact]
+        public void ClearAttributesForUnverifiedAccess_ClearsPersonalAttributesExcludingMatchbackFields()
+        {
+            var request = new TeachingEventAddAttendee() { AddressTelephone = "1234567", AddressPostcode = "TE51NG" };
+
+            request.ClearAttributesForUnverifiedAccess();
+
+            request.AddressTelephone.Should().BeNull();
+            request.AddressPostcode.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
[Trello-2489](https://trello.com/c/DwQun3mR/2489-events-address-walk-in-registrations-with-matchback-issue)

- Allow exchanging unverified request for event sign up

We are allowing walk-in event registrations to continue as an existing user without verifying their access token. This is in case they don't have access to the inbox or internet connectivity at the venue is poor and they don't receive the code.

We will be flagging the contact record in the CRM as 'unverified' when this mechanism is used to keep track of those that have chosen to bypass the verification procedure. We will also not be exposing pre-existing personal information.

- Prevent access to personal data for unverified candidates

If a candidate is continuing as 'unverified' we are allowing them to update an existing candidate record without verifying via matchback. In order to make this more secure we are going to clear any non-matchback fields that contain personal data (in the event sign up this is postcode/telephone).