### PR TITLE
Use differernt channel for unverified walk-in registrations

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
@@ -14,6 +14,7 @@ namespace GetIntoTeachingApi.Models.Crm
         {
             Event = 222750003,
             EventWalkIn = 222750004,
+            EventWalkInUnverified = 222750005,
         }
 
         [EntityField("msevtmgt_contactid", typeof(EntityReference), "contact")]

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
@@ -169,10 +169,17 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         {
             if (EventId != null)
             {
+                var channelId = (int)TeachingEventRegistration.Channel.Event;
+
+                if (IsWalkIn)
+                {
+                    channelId = IsVerified ? (int)TeachingEventRegistration.Channel.EventWalkIn : (int)TeachingEventRegistration.Channel.EventWalkInUnverified;
+                }
+
                 candidate.TeachingEventRegistrations.Add(new TeachingEventRegistration()
                 {
                     EventId = (Guid)EventId,
-                    ChannelId = IsWalkIn ? (int)TeachingEventRegistration.Channel.EventWalkIn : (int)TeachingEventRegistration.Channel.Event,
+                    ChannelId = channelId,
                     IsCancelled = false,
                     RegistrationNotificationSeen = false,
                 });

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidator.cs
@@ -20,6 +20,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
             RuleFor(request => request.ConsiderationJourneyStageId).NotNull().When(request => request.SubscribeToMailingList);
             RuleFor(request => request.DegreeStatusId).NotNull().When(request => request.SubscribeToMailingList);
             RuleFor(request => request.PreferredTeachingSubjectId).NotNull().When(request => request.SubscribeToMailingList);
+            RuleFor(request => request.IsVerified).Must(isVerified => isVerified).Unless(request => request.IsWalkIn);
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
@@ -206,6 +206,14 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
         }
 
         [Fact]
+        public void Candidate_WhenUnverifiedWalkIn_HasCorrectChannel()
+        {
+            var request = new TeachingEventAddAttendee() { IsWalkIn = true, IsVerified = false, EventId = Guid.NewGuid() };
+
+            request.Candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.EventWalkInUnverified);
+        }
+
+        [Fact]
         public void ClearAttributesForUnverifiedAccess_ClearsPersonalAttributesExcludingMatchbackFields()
         {
             var request = new TeachingEventAddAttendee() { AddressTelephone = "1234567", AddressPostcode = "TE51NG" };

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventAddAttendeeValidatorTests.cs
@@ -43,6 +43,8 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
                 LastName = "Doe",
                 AddressTelephone = "1234567",
                 AddressPostcode = "KY11 9YU",
+                IsWalkIn = true,
+                IsVerified = false,
             };
 
             var result = _validator.TestValidate(request);
@@ -51,6 +53,22 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
             // properties as we can't mock them).
             var propertiesWithErrors = result.Errors.Select(e => e.PropertyName);
             propertiesWithErrors.All(p => p.StartsWith("Candidate.")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_IsNotVerifiedAndIsNotWalkIn_HasError()
+        {
+            var request = new TeachingEventAddAttendee() { IsWalkIn = false, IsVerified = false };
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor("IsVerified");
+
+            request.IsVerified = true;
+
+            result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor("IsVerified");
         }
 
         [Fact]


### PR DESCRIPTION
When a candidate walks-in to an event and signs up without verifying their email address we want to log the event registration as an 'unverified walk in' via the channel that we set.

Set the correct channel and validate that only walk-in registrations can be unverified.

The new channel is not yet available in production, but we will be restricting the front-end until its ready so it should never be called.