### PR TITLE
Paginate Apply API sync job

### DIFF
--- a/GetIntoTeachingApi/Services/IPaginatorClient.cs
+++ b/GetIntoTeachingApi/Services/IPaginatorClient.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace GetIntoTeachingApi.Services
+{
+    public interface IPaginatorClient<T>
+    {
+        Task<T> NextAsync();
+        bool HasNext { get; }
+    }
+}

--- a/GetIntoTeachingApi/Services/PaginatorClient.cs
+++ b/GetIntoTeachingApi/Services/PaginatorClient.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Flurl.Http;
+
+namespace GetIntoTeachingApi.Services
+{
+    public class PaginatorClient<T> : IPaginatorClient<T>
+    {
+        private readonly IFlurlRequest _request;
+        private bool _hasNext;
+        private int _page;
+
+        public bool HasNext
+        {
+            get
+            {
+                return _hasNext;
+            }
+        }
+
+        public PaginatorClient(IFlurlRequest request)
+        {
+            _request = request;
+            _hasNext = true;
+            _page = 1;
+        }
+
+        public async Task<T> NextAsync()
+        {
+            var response = await _request
+                .SetQueryParam("page", _page)
+                .GetAsync();
+            var headers = response.Headers;
+
+            if (!headers.Contains("Total-Pages") || !headers.Contains("Current-Page"))
+            {
+                throw new KeyNotFoundException("Expected Total-Pages and Current-Page header keys");
+            }
+
+            var totalPages = headers.FirstOrDefault("Total-Pages");
+            var currentPage = headers.FirstOrDefault("Current-Page");
+            _hasNext = currentPage != totalPages;
+
+            _page++;
+
+            return await response.GetJsonAsync<T>();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/PaginatorClientTests.cs
+++ b/GetIntoTeachingApiTests/Services/PaginatorClientTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Flurl;
+using Flurl.Http;
+using Flurl.Http.Testing;
+using GetIntoTeachingApi.Services;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Services
+{
+    public class PaginatorClientTests
+    {
+        private readonly IPaginatorClient<string> _paginator;
+
+        public PaginatorClientTests()
+        {
+            var request = "https://test.com"
+               .AppendPathSegment("data")
+               .WithOAuthBearerToken("abc-123");
+
+            _paginator = new PaginatorClient<string>(request);
+        }
+
+        [Fact]
+        public void HasNext_BeforeRetrievingFirstPage_IsTrue()
+        {
+            _paginator.HasNext.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void HasNext_WhenThereAreMorePages_IsTrue()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data", 1, 2);
+            MockResponse(httpTest, "page 2 data", 2, 2);
+
+            await _paginator.NextAsync();
+
+            _paginator.HasNext.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void HasNext_WhenThereAreNoMorePages_IsFalse()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data", 1, 2);
+            MockResponse(httpTest, "page 2 data", 2, 2);
+
+            await _paginator.NextAsync();
+            await _paginator.NextAsync();
+
+            _paginator.HasNext.Should().BeFalse();
+        }
+
+        [Fact]
+        public async void NextAsync_FirstCall_RetrievesPage1()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data");
+
+            var response = await _paginator.NextAsync();
+
+            response.Should().Be("page 1 data");
+        }
+
+        [Fact]
+        public async void NextAsync_SecondCall_RetrievesPage2()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data", 1, 2);
+            MockResponse(httpTest, "page 2 data", 2, 2);
+
+            await _paginator.NextAsync();
+            var response = await _paginator.NextAsync();
+
+            response.Should().Be("page 2 data");
+        }
+
+        [Fact]
+        public void NextAsync_ResponseIncorrectHeaders_Throws()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data", null, null);
+
+            _paginator.Invoking(p => p.NextAsync())
+                .Should().ThrowAsync<KeyNotFoundException>()
+                .WithMessage("Expected Total-Pages and Current-Page header keys");
+        }
+
+        private void MockResponse(HttpTest httpTest, string response, int? page = 1, int? totalPages = 1)
+        {
+            var json = JsonConvert.SerializeObject(response);
+            var headers = new Dictionary<string, int?>() { { "Total-Pages", totalPages }, { "Current-Page", page } };
+
+            httpTest
+                    .ForCallsTo("https://test.com/data")
+                    .WithVerb("GET")
+                    .WithQueryParam("page", page)
+                    .WithHeader("Authorization", $"Bearer abc-123")
+                    .RespondWith(json, 200, headers);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-2551](https://trello.com/c/bGR36n8s/2551-update-apply-api-integration-to-support-pagination)

The Apply API now supports pagination by passing a `?page=<num>` query string attribute. The response headers include a `Total-Pages` and `Current-Page` key so that we can work out if there are further records to retrieve.

Create a new `PaginatorClient` that can take a `Flurl` resource and paginate according to the above specification. Update the `FindApplySyncJob` to use the new paginator class and queue all pages of candidates for syncing with the CRM.