### PR TITLE
Default FindApplyStatusId when no application forms

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -70,7 +70,11 @@ namespace GetIntoTeachingApi.Jobs
 
             var latestApplicationForm = findApplyApplicationForms?.FirstOrDefault();
 
-            if (latestApplicationForm != null)
+            if (latestApplicationForm == null)
+            {
+                candidate.FindApplyStatusId = (int)Models.Crm.ApplicationForm.Status.NeverSignedIn;
+            }
+            else
             {
                 candidate.FindApplyStatusId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Status), latestApplicationForm.ApplicationStatus.ToPascalCase());
                 candidate.FindApplyPhaseId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Phase), latestApplicationForm.ApplicationPhase.ToPascalCase());

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -144,7 +144,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
 
         [Fact]
-        public void Run_OnSuccessWhenThereAreNoApplicationForms_SavesCandidate()
+        public void Run_OnSuccessWhenThereAreNoApplicationForms_SavesCandidateWithNeverSignedInStatus()
         {
             _candidate.Attributes.ApplicationForms = Array.Empty<ApplicationForm>();
 
@@ -152,7 +152,8 @@ namespace GetIntoTeachingApiTests.Jobs
             var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.Candidate>()));
+            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(c =>
+                c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn)));
 
             _job.Run(_candidate);
 


### PR DESCRIPTION
[Trello-2584](https://trello.com/c/SOhjs1oX/2584-set-application-status-when-there-are-no-application-forms)

When a candidate is passed from the Apply API and has 0 application forms we want to default the `FindApplyStatusId` to be `NeverSignedIn`.