### PR TITLE
Temp cache candidate

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
@@ -102,6 +103,28 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             if (candidate == null)
             {
                 return NotFound();
+            }
+
+            return Ok(new SchoolsExperienceSignUp(candidate));
+        }
+
+        [HttpGet]
+        [Route("cached/{id}")]
+        [SwaggerOperation(
+            Summary = "Retrieves a cached SchoolsExperienceSignUp for the candidate by intermediate ID.",
+            OperationId = "GetSchoolsExperienceSignUp",
+            Tags = new[] { "Schools Experience" })]
+        [ProducesResponseType(typeof(SchoolsExperienceSignUp), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetByIntermediateId([FromRoute, SwaggerParameter("The `intermediateId` of the `Candidate`.", Required = true)] Guid intermediateId)
+        {
+            var candidate = await _store.FindCandidateByIntermediateId(intermediateId);
+
+            if (candidate == null)
+            {
+                // Candidate cache has been cleared and candidate will exist in CRM
+                var crmId = _store.GetCandidateCrmIdByIntermediateId(intermediateId);
+                candidate = _crm.GetCandidate(crmId);
             }
 
             return Ok(new SchoolsExperienceSignUp(candidate));

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -12,6 +12,8 @@ namespace GetIntoTeachingApi.Database
         public DbSet<PrivacyPolicy> PrivacyPolicies { get; set; }
         public DbSet<LookupItem> LookupItems { get; set; }
         public DbSet<PickListItem> PickListItems { get; set; }
+        public DbSet<Candidate> Candidates { get; set; }
+        public DbSet<CandidateIntermediateKeys> CandidateIntermediateKeys { get; set; }
 
         public GetIntoTeachingDbContext(DbContextOptions<GetIntoTeachingDbContext> options)
             : base(options)

--- a/GetIntoTeachingApi/Migrations/20211025104327_AddTemporaryCandidateTables.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20211025104327_AddTemporaryCandidateTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211025104327_AddTemporaryCandidateTables")]
+    partial class AddTemporaryCandidateTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20211025104327_AddTemporaryCandidateTables.cs
+++ b/GetIntoTeachingApi/Migrations/20211025104327_AddTemporaryCandidateTables.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class AddTemporaryCandidateTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CandidateIntermediateKeys",
+                columns: table => new
+                {
+                    IntermediateCandidateId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CrmCandidateId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidateIntermediateKeys", x => x.IntermediateCandidateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PhoneCall",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<string>(type: "text", nullable: true),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    DestinationId = table.Column<int>(type: "integer", nullable: true),
+                    ScheduledAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    Telephone = table.Column<string>(type: "text", nullable: true),
+                    Subject = table.Column<string>(type: "text", nullable: true),
+                    IsAppointment = table.Column<bool>(type: "boolean", nullable: false),
+                    AppointmentRequired = table.Column<bool>(type: "boolean", nullable: false),
+                    IsDirectionCode = table.Column<bool>(type: "boolean", nullable: false),
+                    TalkingPoints = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhoneCall", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Candidates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PreferredTeachingSubjectId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SecondaryPreferredTeachingSubjectId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CountryId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OwningBusinessUnitId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MasterId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PreferredEducationPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    InitialTeacherTrainingYearId = table.Column<int>(type: "integer", nullable: true),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseEnglishId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseMathsId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseScienceId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseEnglishId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseMathsId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseScienceId = table.Column<int>(type: "integer", nullable: true),
+                    ConsiderationJourneyStageId = table.Column<int>(type: "integer", nullable: true),
+                    TypeId = table.Column<int>(type: "integer", nullable: true),
+                    AssignmentStatusId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserEligibilityId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserRequirementId = table.Column<int>(type: "integer", nullable: true),
+                    PreferredPhoneNumberTypeId = table.Column<int>(type: "integer", nullable: true),
+                    PreferredContactMethodId = table.Column<int>(type: "integer", nullable: true),
+                    GdprConsentId = table.Column<int>(type: "integer", nullable: true),
+                    MagicLinkTokenStatusId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserStatusId = table.Column<int>(type: "integer", nullable: true),
+                    RegistrationStatusId = table.Column<int>(type: "integer", nullable: true),
+                    FindApplyStatusId = table.Column<int>(type: "integer", nullable: true),
+                    FindApplyPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    StatusIsWaitingToBeAssignedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    Merged = table.Column<bool>(type: "boolean", nullable: false),
+                    FindApplyId = table.Column<string>(type: "text", nullable: true),
+                    FindApplyUpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    FindApplyCreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    Email = table.Column<string>(type: "text", nullable: true),
+                    SecondaryEmail = table.Column<string>(type: "text", nullable: true),
+                    FirstName = table.Column<string>(type: "text", nullable: true),
+                    LastName = table.Column<string>(type: "text", nullable: true),
+                    DateOfBirth = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    MobileTelephone = table.Column<string>(type: "text", nullable: true),
+                    AddressTelephone = table.Column<string>(type: "text", nullable: true),
+                    AddressLine1 = table.Column<string>(type: "text", nullable: true),
+                    AddressLine2 = table.Column<string>(type: "text", nullable: true),
+                    AddressLine3 = table.Column<string>(type: "text", nullable: true),
+                    AddressCity = table.Column<string>(type: "text", nullable: true),
+                    AddressStateOrProvince = table.Column<string>(type: "text", nullable: true),
+                    AddressPostcode = table.Column<string>(type: "text", nullable: true),
+                    Telephone = table.Column<string>(type: "text", nullable: true),
+                    SecondaryTelephone = table.Column<string>(type: "text", nullable: true),
+                    HasDbsCertificate = table.Column<bool>(type: "boolean", nullable: true),
+                    DbsCertificateIssuedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    ClassroomExperienceNotesRaw = table.Column<string>(type: "text", nullable: true),
+                    TeacherId = table.Column<string>(type: "text", nullable: true),
+                    EligibilityRulesPassed = table.Column<string>(type: "text", nullable: true),
+                    DoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    OptOutOfSms = table.Column<bool>(type: "boolean", nullable: true),
+                    OptOutOfGdpr = table.Column<bool>(type: "boolean", nullable: true),
+                    IsNewRegistrant = table.Column<bool>(type: "boolean", nullable: false),
+                    MagicLinkToken = table.Column<string>(type: "text", nullable: true),
+                    MagicLinkTokenExpiresAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    HasTeacherTrainingAdviserSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    TeacherTrainingAdviserSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    HasMailingListSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    MailingListSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    MailingListSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    HasEventsSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    EventsSubscriptionTypeId = table.Column<int>(type: "integer", nullable: true),
+                    EventsSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    EventsSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    PhoneCallId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Candidates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Candidates_PhoneCall_PhoneCallId",
+                        column: x => x.PhoneCallId,
+                        principalTable: "PhoneCall",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidatePastTeachingPosition",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubjectTaughtId = table.Column<Guid>(type: "uuid", nullable: true),
+                    EducationPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidatePastTeachingPosition", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidatePastTeachingPosition_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidatePrivacyPolicy",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AcceptedPolicyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsentReceivedById = table.Column<int>(type: "integer", nullable: false),
+                    MeanOfConsentId = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    AcceptedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidatePrivacyPolicy", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidatePrivacyPolicy_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidateQualification",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TypeId = table.Column<int>(type: "integer", nullable: true),
+                    UkDegreeGradeId = table.Column<int>(type: "integer", nullable: true),
+                    DegreeStatusId = table.Column<int>(type: "integer", nullable: true),
+                    DegreeSubject = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidateQualification", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidateQualification_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TeachingEventRegistration",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    IsCancelled = table.Column<bool>(type: "boolean", nullable: true),
+                    RegistrationNotificationSeen = table.Column<bool>(type: "boolean", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeachingEventRegistration", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeachingEventRegistration_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidatePastTeachingPosition_CandidateId",
+                table: "CandidatePastTeachingPosition",
+                column: "CandidateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidatePrivacyPolicy_CandidateId",
+                table: "CandidatePrivacyPolicy",
+                column: "CandidateId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidateQualification_CandidateId",
+                table: "CandidateQualification",
+                column: "CandidateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Candidates_PhoneCallId",
+                table: "Candidates",
+                column: "PhoneCallId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeachingEventRegistration_CandidateId",
+                table: "TeachingEventRegistration",
+                column: "CandidateId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CandidateIntermediateKeys");
+
+            migrationBuilder.DropTable(
+                name: "CandidatePastTeachingPosition");
+
+            migrationBuilder.DropTable(
+                name: "CandidatePrivacyPolicy");
+
+            migrationBuilder.DropTable(
+                name: "CandidateQualification");
+
+            migrationBuilder.DropTable(
+                name: "TeachingEventRegistration");
+
+            migrationBuilder.DropTable(
+                name: "Candidates");
+
+            migrationBuilder.DropTable(
+                name: "PhoneCall");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateIntermediateKeys.cs
+++ b/GetIntoTeachingApi/Models/CandidateIntermediateKeys.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GetIntoTeachingApi.Models
+{
+    public class CandidateIntermediateKeys
+    {
+        [Key]
+        public int IntermediateCandidateId { get; set; }
+        public int CrmCandidateId { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/CandidateIntermediateKeys.cs
+++ b/GetIntoTeachingApi/Models/CandidateIntermediateKeys.cs
@@ -1,11 +1,12 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GetIntoTeachingApi.Models
 {
     public class CandidateIntermediateKeys
     {
         [Key]
-        public int IntermediateCandidateId { get; set; }
-        public int CrmCandidateId { get; set; }
+        public Guid IntermediateCandidateId { get; set; }
+        public Guid CrmCandidateId { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -298,6 +298,18 @@ namespace GetIntoTeachingApi.Models.Crm
         [EntityRelationship("dfe_contact_dfe_candidateprivacypolicy_Candidate", typeof(CandidatePrivacyPolicy))]
         public CandidatePrivacyPolicy PrivacyPolicy { get; set; }
 
+        public Guid? IntermediateId { get; set; }
+
+        public bool PersistedInCrm
+        {
+            get => Id.HasValue;
+        }
+
+        public bool IntermedidateCacheOnly
+        {
+            get => !Id.HasValue && IntermediateId.HasValue;
+        }
+
         public Candidate()
             : base()
         {

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -25,5 +25,7 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
+        void Delete<T>(IEnumerable<T> models);
+        Task<Candidate> FindCandidateByIntermediateId(Guid intermediatedId);
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -27,5 +27,7 @@ namespace GetIntoTeachingApi.Services
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
         void Delete<T>(IEnumerable<T> models);
         Task<Candidate> FindCandidateByIntermediateId(Guid intermediatedId);
+        void AddCandidateIntermediateIdMapping(Guid crmId, Guid intermediateId);
+        Guid GetCandidateCrmIdByIntermediateId(Guid intermediateId);
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -145,6 +145,11 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TeachingEventBuildings.AsNoTracking();
         }
 
+        public async Task<Candidate> FindCandidateByIntermediateId(Guid intermediatedId)
+        {
+            return await _dbContext.Candidates.FindAsync(intermediatedId);
+        }
+
         public async Task SaveAsync<T>(IEnumerable<T> models)
             where T : BaseModel
         {
@@ -159,6 +164,12 @@ namespace GetIntoTeachingApi.Services
             where T : BaseModel
         {
             await SaveAsync(new T[] { model });
+        }
+
+        public void Delete<T>(IEnumerable<T> models)
+        {
+            _dbContext.RemoveRange(models);
+            _dbContext.SaveChangesAsync();
         }
 
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -172,6 +172,22 @@ namespace GetIntoTeachingApi.Services
             _dbContext.SaveChangesAsync();
         }
 
+        public void AddCandidateIntermediateIdMapping(Guid crmId, Guid intermediateId)
+        {
+            var mapping = new CandidateIntermediateKeys
+            {
+                CrmCandidateId = crmId,
+                IntermediateCandidateId = intermediateId,
+            };
+
+            _dbContext.CandidateIntermediateKeys.Add(mapping);
+        }
+
+        public Guid GetCandidateCrmIdByIntermediateId(Guid intermediateId)
+        {
+            return _dbContext.CandidateIntermediateKeys.Find(intermediateId).CrmCandidateId;
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {


### PR DESCRIPTION
TODO:
- testing
- handle other candidate controller actions
- move some of the intermediate key stuff into new classes
- update schools experience - when they fetch a candidate, they can do it based on whether a CRM Guid is present - if it isn't present, they can use the new endpoint with the intermediate Guid

## 1. Add `Candidate` cache
   
The CRM can't accept any new data during releases. The solution to this in Get into Teaching is to queue the request until the CRM is back up.

However, in School Experience, the Candidate upsert cannot be queued because the candidate information is needed immediately by the Schools Experience app.

Add a `Candidate` cache and a intermediate table. The cache can be used when the CRM integration is paused. We can persist a temporary ID in the intermediate table which can be used to retrieve the CRM Candidate record once the cache has been cleared.

## 2. Cache `Candidate` in store if CRM integration paused

## 3. Queue candidate CRM job

We cache the `Candidate` while the CRM integration is paused. However, we don't want to persist this permanently as it contains personal information. 

Ensure that when the `Candidate` is inserted into the CRM, the API cache record is deleted. Due to the way the `CandidateUpserter` job is configured, the API record will always be deleted within 24 hours.

## 4. Add endpoint to get candidate by intermediate ID

If a candidate is created when the CRM is down, we can store the candidate intermediate ID in the School Experience app.

When we want to retrieve the record, we can check whether it still exists in the cache. If it does, return it, else lookup the CRM ID from the mapping table (this will populate the CRM ID for any further requests)