### PR TITLE
Make date of birth optional for School Experience sign up

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidator.cs
@@ -18,7 +18,6 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience.Validators
             RuleFor(request => request.Email).NotEmpty();
             RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.LastName).NotEmpty();
-            RuleFor(request => request.DateOfBirth).NotNull();
             RuleFor(request => request.AddressLine1).NotNull();
             RuleFor(request => request.AddressCity).NotNull();
             RuleFor(request => request.AddressStateOrProvince).NotNull();

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -79,7 +79,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
                 FirstName = null,
                 LastName = null,
                 Email = null,
-                DateOfBirth = null,
                 AddressLine1 = null,
                 AddressCity = null,
                 AddressStateOrProvince = null,
@@ -97,7 +96,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
             result.ShouldHaveValidationErrorFor(s => s.FirstName);
             result.ShouldHaveValidationErrorFor(s => s.LastName);
             result.ShouldHaveValidationErrorFor(s => s.Email);
-            result.ShouldHaveValidationErrorFor(s => s.DateOfBirth);
             result.ShouldHaveValidationErrorFor(s => s.AddressLine1);
             result.ShouldHaveValidationErrorFor(s => s.AddressCity);
             result.ShouldHaveValidationErrorFor(s => s.AddressStateOrProvince);


### PR DESCRIPTION
[Trello](https://trello.com/c/eS5vBUeC)

The School Experience sign up asks users for their date of birth for the matchback process.

However, date of birth is not needed anymore for this, so we can make it optional.