### PR TITLE
Ensure FindApplyCandidateSyncJob is atomic

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -291,6 +291,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public List<CandidateQualification> Qualifications { get; set; } = new List<CandidateQualification>();
         [EntityRelationship("dfe_contact_dfe_candidatepastteachingposition_ContactId", typeof(CandidatePastTeachingPosition))]
         public List<CandidatePastTeachingPosition> PastTeachingPositions { get; set; } = new List<CandidatePastTeachingPosition>();
+        [EntityRelationship("dfe_contact_dfe_applyapplicationform_contact", typeof(ApplicationForm))]
+        public List<ApplicationForm> ApplicationForms { get; set; } = new List<ApplicationForm>();
         [SwaggerSchema("Set to schedule a phone call.", WriteOnly = true)]
         [EntityRelationship("dfe_contact_phonecall_contactid", typeof(PhoneCall))]
         public PhoneCall PhoneCall { get; set; }

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -6,6 +6,9 @@ using GetIntoTeachingApi.Models.FindApply;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -17,6 +20,7 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<GetIntoTeachingApi.Models.IAppSettings> _mockAppSettings;
         private readonly Mock<ILogger<FindApplyCandidateSyncJob>> _mockLogger;
         private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly FindApplyCandidateSyncJob _job;
         private readonly Candidate _candidate;
         private readonly CandidateAttributes _attributes;
@@ -27,10 +31,12 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger = new Mock<ILogger<FindApplyCandidateSyncJob>>();
             _mockAppSettings = new Mock<GetIntoTeachingApi.Models.IAppSettings>();
             _mockCrm = new Mock<ICrmService>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
             _job = new FindApplyCandidateSyncJob(
                 new Env(),
                 _mockLogger.Object,
                 _mockCrm.Object,
+                _mockJobClient.Object,
                 _mockAppSettings.Object);
             _forms = new List<ApplicationForm>()
             {
@@ -65,53 +71,7 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_OnSuccessWithExistingCandidate_SavesCandidate()
-        {
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(
-                c => c.Id == match.Id
-                && c.FindApplyId == _candidate.Id
-                && c.Email == _attributes.Email
-                && c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn
-                && c.FindApplyPhaseId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2
-                && c.FindApplyCreatedAt == _attributes.CreatedAt
-                && c.FindApplyUpdatedAt == _attributes.UpdatedAt)));
-            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.ApplicationForm>()));
-
-            _job.Run(_candidate);
-
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Hit - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
-        }
-
-        [Fact]
-        public void Run_OnSuccessWhenWithNewCandidate_SavesCandidate()
-        {
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(
-                c => c.Id == null
-                && c.ChannelId == (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining
-                && c.FindApplyId == _candidate.Id
-                && c.Email == _attributes.Email
-                && c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn
-                && c.FindApplyPhaseId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2
-                && c.FindApplyCreatedAt == _attributes.CreatedAt
-                && c.FindApplyUpdatedAt == _attributes.UpdatedAt))).Callback<GetIntoTeachingApi.Models.Crm.BaseModel>(c => c.Id = Guid.NewGuid());
-            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.ApplicationForm>()));
-
-            _job.Run(_candidate);
-
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Miss - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
-        }
-
-        [Fact]
-        public void Run_OnSuccess_SavesApplicationForms()
+        public void Run_OnSuccessWithExistingCandidate_QueuesUpsertJobForCandidateWithApplicationForms()
         {
             var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
             var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
@@ -119,46 +79,79 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
             _mockCrm.Setup(m => m.GetApplicationForm("1")).Returns<GetIntoTeachingApi.Models.Crm.ApplicationForm>(null);
             _mockCrm.Setup(m => m.GetApplicationForm("2")).Returns(existingApplicationForm);
-            _mockCrm.Setup(m => m.Save(It.IsAny<GetIntoTeachingApi.Models.Crm.Candidate>()));
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.ApplicationForm>(
-                f => f.Id == null
-                && f.FindApplyId == _forms[0].Id.ToString()
-                && f.CreatedAt == _forms[0].CreatedAt
-                && f.PhaseId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2
-                && f.StatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn
-                && f.UpdatedAt == _forms[0].UpdatedAt)));
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.ApplicationForm>(
-                f => f.Id == existingApplicationForm.Id
-                && f.FindApplyId == _forms[1].Id.ToString()
-                && f.PhaseId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1
-                && f.StatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse
-                && f.CreatedAt == _forms[1].CreatedAt
-                && f.UpdatedAt == _forms[1].UpdatedAt)));
 
             _job.Run(_candidate);
+
+            var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+            {
+                Id = null,
+                FindApplyId = _forms[0].Id.ToString(),
+                CreatedAt = _forms[0].CreatedAt,
+                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                UpdatedAt = _forms[0].UpdatedAt,
+            };
+
+            var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+            {
+                Id = existingApplicationForm.Id,
+                FindApplyId = _forms[1].Id.ToString(),
+                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
+                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
+                CreatedAt = _forms[1].CreatedAt,
+                UpdatedAt = _forms[1].UpdatedAt,
+            };
+
+            var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
+            {
+                Id = match.Id,
+                FindApplyId = _candidate.Id,
+                Email = _attributes.Email,
+                FindApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                FindApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+                FindApplyCreatedAt = _attributes.CreatedAt,
+                FindApplyUpdatedAt = _attributes.UpdatedAt,
+                ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form1, form2 },
+            };
+
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                IsMatch(candidate, (string)job.Args[0])),
+                It.IsAny<EnqueuedState>()));
 
             _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
             _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Hit - {_candidate.Id}");
             _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
         }
 
-
         [Fact]
-        public void Run_OnSuccessWhenThereAreNoApplicationForms_SavesCandidateWithNeverSignedInStatus()
+        public void Run_OnSuccessWithNewCandidateAndNoApplicationForms_QueuesUpsertJobForCandidateWithNeverSignedInStatus()
         {
             _candidate.Attributes.ApplicationForms = Array.Empty<ApplicationForm>();
 
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
-            var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.Save(It.Is<GetIntoTeachingApi.Models.Crm.Candidate>(c =>
-                c.FindApplyStatusId == (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn)));
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
 
             _job.Run(_candidate);
 
+            var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
+            {
+                Id = null,
+                ChannelId = (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining,
+                FindApplyId = _candidate.Id,
+                Email = _attributes.Email,
+                FindApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                FindApplyCreatedAt = _attributes.CreatedAt,
+                FindApplyUpdatedAt = _attributes.UpdatedAt,
+            };
+
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+                IsMatch(candidate, (string)job.Args[0])),
+                It.IsAny<EnqueuedState>()));
+
             _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Hit - {_candidate.Id}");
+            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Miss - {_candidate.Id}");
             _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
         }
 
@@ -171,6 +164,13 @@ namespace GetIntoTeachingApiTests.Jobs
 
             action.Should().Throw<InvalidOperationException>()
                 .WithMessage("FindApplyCandidateSyncJob - Aborting (CRM integration paused).");
+        }
+
+        private static bool IsMatch(GetIntoTeachingApi.Models.Crm.Candidate candidateA, string candidateBJson)
+        {
+            var candidateB = candidateBJson.DeserializeChangeTracked<GetIntoTeachingApi.Models.Crm.Candidate>();
+            candidateA.Should().BeEquivalentTo(candidateB);
+            return true;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -162,6 +162,9 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("PastTeachingPositions").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_contact_dfe_candidatepastteachingposition_ContactId" &&
                      a.Type == typeof(CandidatePastTeachingPosition));
+            type.GetProperty("ApplicationForms").Should().BeDecoratedWith<EntityRelationshipAttribute>(
+                a => a.Name == "dfe_contact_dfe_applyapplicationform_contact" &&
+                     a.Type == typeof(ApplicationForm));
             type.GetProperty("PhoneCall").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_contact_phonecall_contactid" && a.Type == typeof(PhoneCall));
             type.GetProperty("PrivacyPolicy").Should().BeDecoratedWith<EntityRelationshipAttribute>(

--- a/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
@@ -72,6 +72,24 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public void Upsert_WithApplicationForms_SavesApplicationForms()
+        {
+            var candidateId = Guid.NewGuid();
+            var applicationForm = new ApplicationForm();
+            _candidate.ApplicationForms.Add(applicationForm);
+            _mockCrm.Setup(mock => mock.Save(It.IsAny<Candidate>())).Callback<BaseModel>(c => c.Id = candidateId);
+
+            _upserter.Upsert(_candidate);
+
+            applicationForm.CandidateId = candidateId;
+
+            _mockJobClient.Verify(x => x.Create(
+               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<ApplicationForm>) && job.Method.Name == "Run" &&
+               IsMatch(applicationForm, (string)job.Args[0])),
+               It.IsAny<EnqueuedState>()));
+        }
+
+        [Fact]
         public void Upsert_WithTeachingEventRegistrations_SavesTeachingEventRegistrations()
         {
             var candidateId = Guid.NewGuid();


### PR DESCRIPTION
[Trello-2601](https://trello.com/c/VfWHN46B/2601-make-the-apply-candidate-sync-job-atomic)

Currently, the `FindApplyCandidateSyncJob` could persist a candidate then subsequently fail when trying to persist application forms. This would result in the whole job retrying and the candidate being re-created as a duplicate.

To prevent this from happening we are going to update the existing `CandidateUpserter` to also persist application forms and queue another job to use this service off the back of the `FindApplyCandidateSyncJob`. This will mean that the related application forms wont be persisted until the candidate has synced successfully (and it also queues the forms in individual jobs so retries are no longer a problem).

- Add relationship to application forms

Currently we persist application forms independently of the candidate (it has a foreign key back to candidate). To make the application forms compatible with the existing `CandidateUpserter` we need to establish a relationship between the two models (we only pass the `Candidate` model to the upserter, so we need to be able to navigate down to the forms from there).

- Add application form support to CandidateUpserter

Update the `CandidateUpserter` to support sending application forms to the CRM by way of the existing `UpsertModelJob` job. This means we can upsert a `Candidate` with application forms and it will all happen atomically (the forms are only queued once the candidate job succeeds and each form is an individual job).

- Update to queue a separate upsert job

Instead of persisting the candidate and application forms within the sync job we are going to populate the candidate and forms then queue another upserter job to perform the save operation to the CRM.

The benefit of doing this is that it will all happen atomically; currently if the sync job fails after creating the candidate it will be retried and can create a duplicate. To prevent this we utilise the existing `CandidateUpserter`, which persists the candidate to the CRM and only when that is successful does it enqueue additional jobs for the related entities.
