### PR TITLE
Change Monitoring Cloud Foundry credentials to a read only set.

### DIFF
--- a/terraform/paas/monitoring.tf
+++ b/terraform/paas/monitoring.tf
@@ -24,9 +24,9 @@ module "prometheus" {
   monitoring_instance_name          = local.monitoring_org_name
   monitoring_org_name               = var.paas_org_name
   monitoring_space_name             = var.monitor_space
-  paas_exporter_username            = local.infrastructure_secrets.PAAS-USERNAME
-  paas_exporter_password            = local.infrastructure_secrets.PAAS-PASSWORD
-  alertmanager_slack_url            = lookup( local.monitoring_secrets , "SLACK_ALERTMANAGER_HOOK" , "" )
+  paas_exporter_username            = lookup( local.monitoring_secrets , "PAAS_MONITORING_USER"     , local.infrastructure_secrets.PAAS-USERNAME )
+  paas_exporter_password            = lookup( local.monitoring_secrets , "PAAS_MONITORING_PASSWORD" , local.infrastructure_secrets.PAAS-PASSWORD )
+  alertmanager_slack_url            = lookup( local.monitoring_secrets , "SLACK_ALERTMANAGER_HOOK"  , "" )
   alertmanager_slack_channel        = lookup( local.monitoring_secrets , "SLACK_CHANNEL" , "" )
   alert_rules                       = local.alert_rules
   grafana_elasticsearch_credentials = local.elasticsearch_credentials


### PR DESCRIPTION
[Change Monitoring Cloud Foundry credentials to a read only set.](https://trello.com/c/OUV8BiJu/2639-change-monitoring-cloud-foundry-credentials-to-a-read-only-set)

Use a specific set of credentials that are read only, to reduce the risk of them being hijacked.

