### PR TITLE
Cache candidate while CRM down

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -25,17 +25,23 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         private readonly ICrmService _crm;
         private readonly ICandidateUpserter _upserter;
         private readonly IBackgroundJobClient _jobClient;
+        private readonly IStore _store;
+        private readonly IDateTimeProvider _dateTime;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             ICandidateUpserter upserter,
-            IBackgroundJobClient jobClient)
+            IBackgroundJobClient jobClient,
+            IStore store,
+            IDateTimeProvider dateTime)
         {
             _crm = crm;
             _upserter = upserter;
             _tokenService = tokenService;
             _jobClient = jobClient;
+            _store = store;
+            _dateTime = dateTime;
         }
 
         [HttpPost]
@@ -57,13 +63,26 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 return BadRequest(ModelState);
             }
 
+            var candidate = request.Candidate;
+
             if (appSettings.IsCrmIntegrationPaused)
             {
-                throw new InvalidOperationException("CandidatesController#SignUp - Aborting (CRM integration paused).");
-            }
+                // Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better
+                // SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front
+                // because the School Experience app needs the Candidate ID immediately.
+                candidate.Id = Guid.NewGuid();
+                _store.SaveAsync(candidate);
 
-            var candidate = request.Candidate;
-            _upserter.Upsert(candidate);
+                // This is the only way we can mock/freeze the current date/time
+                // in contract tests (there's no other way to inject it into this class).
+                request.DateTimeProvider = _dateTime;
+                string json = request.Candidate.SerializeChangeTracked();
+                _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+            }
+            else
+            {
+                _upserter.Upsert(candidate);
+            }
 
             return CreatedAtAction(
                 actionName: nameof(Get),
@@ -136,7 +155,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         [Route("{id}/classroom_experience_notes")]
         [SwaggerOperation(
            Summary = "Add a classroom experience note to the candidate.",
-           Description = @"Adds a new classroom experience note to the candidate record",
+           Description = "Adds a new classroom experience note to the candidate record",
            OperationId = "AddClassroomExperienceNote",
            Tags = new[] { "Schools Experience" })]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Database
         public DbSet<PrivacyPolicy> PrivacyPolicies { get; set; }
         public DbSet<LookupItem> LookupItems { get; set; }
         public DbSet<PickListItem> PickListItems { get; set; }
+        public DbSet<Candidate> Candidates { get; set; }
 
         public GetIntoTeachingDbContext(DbContextOptions<GetIntoTeachingDbContext> options)
             : base(options)

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
@@ -18,6 +19,7 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IMetricService _metrics;
         private readonly IAppSettings _appSettings;
         private readonly ILogger<UpsertCandidateJob> _logger;
+        private readonly IStore _store;
 
         public UpsertCandidateJob(
             IEnv env,
@@ -26,7 +28,8 @@ namespace GetIntoTeachingApi.Jobs
             IPerformContextAdapter contextAdapter,
             IMetricService metrics,
             ILogger<UpsertCandidateJob> logger,
-            IAppSettings appSettings)
+            IAppSettings appSettings,
+            IStore store)
             : base(env)
         {
             _upserter = upserter;
@@ -35,15 +38,11 @@ namespace GetIntoTeachingApi.Jobs
             _metrics = metrics;
             _logger = logger;
             _appSettings = appSettings;
+            _store = store;
         }
 
-        public void Run(string json, PerformContext context)
+        public async Task Run(string json, PerformContext context)
         {
-            if (_appSettings.IsCrmIntegrationPaused)
-            {
-                throw new InvalidOperationException("UpsertCandidateJob - Aborting (CRM integration paused).");
-            }
-
             _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
             _logger.LogInformation($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
 
@@ -54,21 +53,38 @@ namespace GetIntoTeachingApi.Jobs
                 var personalisation = new Dictionary<string, dynamic>();
 
                 // We fire and forget the email, ensuring the job succeeds.
-                _notifyService.SendEmailAsync(
+                await _notifyService.SendEmailAsync(
                     candidate.Email,
                     NotifyService.CandidateRegistrationFailedEmailTemplateId,
                     personalisation);
+                await RemoveCandidateFromCache(candidate.Id);
                 _logger.LogInformation("UpsertCandidateJob - Deleted");
             }
             else
             {
                 _upserter.Upsert(candidate);
+                await RemoveCandidateFromCache(candidate.Id);
 
                 _logger.LogInformation($"UpsertCandidateJob - Succeeded - {candidate.Id}");
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
             _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Observe(duration);
+        }
+
+        private async Task RemoveCandidateFromCache(Guid? candidateId)
+        {
+            if (!candidateId.HasValue)
+            {
+                return;
+            }
+
+            var candidate = await _store.GetCandidateAsync(candidateId.Value);
+
+            if (candidate != null)
+            {
+                await _store.DeleteAsync(candidate);
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -79,7 +79,7 @@ namespace GetIntoTeachingApi.Jobs
                 return;
             }
 
-            var candidate = await _store.GetCandidateAsync(candidateId.Value);
+            var candidate = _store.GetCandidate(candidateId.Value);
 
             if (candidate != null)
             {

--- a/GetIntoTeachingApi/Migrations/20211108143439_AddCandidatesCache.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20211108143439_AddCandidatesCache.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211108143439_AddCandidatesCache")]
+    partial class AddCandidatesCache
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20211108143439_AddCandidatesCache.cs
+++ b/GetIntoTeachingApi/Migrations/20211108143439_AddCandidatesCache.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class AddCandidatesCache : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PhoneCall",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<string>(type: "text", nullable: true),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    DestinationId = table.Column<int>(type: "integer", nullable: true),
+                    ScheduledAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    Telephone = table.Column<string>(type: "text", nullable: true),
+                    Subject = table.Column<string>(type: "text", nullable: true),
+                    IsAppointment = table.Column<bool>(type: "boolean", nullable: false),
+                    AppointmentRequired = table.Column<bool>(type: "boolean", nullable: false),
+                    IsDirectionCode = table.Column<bool>(type: "boolean", nullable: false),
+                    TalkingPoints = table.Column<string>(type: "text", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhoneCall", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Candidates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PreferredTeachingSubjectId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SecondaryPreferredTeachingSubjectId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CountryId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OwningBusinessUnitId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MasterId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PreferredEducationPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    InitialTeacherTrainingYearId = table.Column<int>(type: "integer", nullable: true),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseEnglishId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseMathsId = table.Column<int>(type: "integer", nullable: true),
+                    HasGcseScienceId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseEnglishId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseMathsId = table.Column<int>(type: "integer", nullable: true),
+                    PlanningToRetakeGcseScienceId = table.Column<int>(type: "integer", nullable: true),
+                    ConsiderationJourneyStageId = table.Column<int>(type: "integer", nullable: true),
+                    TypeId = table.Column<int>(type: "integer", nullable: true),
+                    AssignmentStatusId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserEligibilityId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserRequirementId = table.Column<int>(type: "integer", nullable: true),
+                    PreferredPhoneNumberTypeId = table.Column<int>(type: "integer", nullable: true),
+                    PreferredContactMethodId = table.Column<int>(type: "integer", nullable: true),
+                    GdprConsentId = table.Column<int>(type: "integer", nullable: true),
+                    MagicLinkTokenStatusId = table.Column<int>(type: "integer", nullable: true),
+                    AdviserStatusId = table.Column<int>(type: "integer", nullable: true),
+                    RegistrationStatusId = table.Column<int>(type: "integer", nullable: true),
+                    FindApplyStatusId = table.Column<int>(type: "integer", nullable: true),
+                    FindApplyPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    StatusIsWaitingToBeAssignedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    Merged = table.Column<bool>(type: "boolean", nullable: false),
+                    FindApplyId = table.Column<string>(type: "text", nullable: true),
+                    FindApplyUpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    FindApplyCreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    Email = table.Column<string>(type: "text", nullable: true),
+                    SecondaryEmail = table.Column<string>(type: "text", nullable: true),
+                    FirstName = table.Column<string>(type: "text", nullable: true),
+                    LastName = table.Column<string>(type: "text", nullable: true),
+                    DateOfBirth = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    MobileTelephone = table.Column<string>(type: "text", nullable: true),
+                    AddressTelephone = table.Column<string>(type: "text", nullable: true),
+                    AddressLine1 = table.Column<string>(type: "text", nullable: true),
+                    AddressLine2 = table.Column<string>(type: "text", nullable: true),
+                    AddressLine3 = table.Column<string>(type: "text", nullable: true),
+                    AddressCity = table.Column<string>(type: "text", nullable: true),
+                    AddressStateOrProvince = table.Column<string>(type: "text", nullable: true),
+                    AddressPostcode = table.Column<string>(type: "text", nullable: true),
+                    Telephone = table.Column<string>(type: "text", nullable: true),
+                    SecondaryTelephone = table.Column<string>(type: "text", nullable: true),
+                    HasDbsCertificate = table.Column<bool>(type: "boolean", nullable: true),
+                    DbsCertificateIssuedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    ClassroomExperienceNotesRaw = table.Column<string>(type: "text", nullable: true),
+                    TeacherId = table.Column<string>(type: "text", nullable: true),
+                    EligibilityRulesPassed = table.Column<string>(type: "text", nullable: true),
+                    DoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    DoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    OptOutOfSms = table.Column<bool>(type: "boolean", nullable: true),
+                    OptOutOfGdpr = table.Column<bool>(type: "boolean", nullable: true),
+                    IsNewRegistrant = table.Column<bool>(type: "boolean", nullable: false),
+                    MagicLinkToken = table.Column<string>(type: "text", nullable: true),
+                    MagicLinkTokenExpiresAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    HasTeacherTrainingAdviserSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    TeacherTrainingAdviserSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    TeacherTrainingAdviserSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    HasMailingListSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    MailingListSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    MailingListSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    MailingListSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    HasEventsSubscription = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionChannelId = table.Column<int>(type: "integer", nullable: true),
+                    EventsSubscriptionTypeId = table.Column<int>(type: "integer", nullable: true),
+                    EventsSubscriptionStartAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    EventsSubscriptionDoNotBulkEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotBulkPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotEmail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotPostalMail = table.Column<bool>(type: "boolean", nullable: true),
+                    EventsSubscriptionDoNotSendMm = table.Column<bool>(type: "boolean", nullable: true),
+                    PhoneCallId = table.Column<Guid>(type: "uuid", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Candidates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Candidates_PhoneCall_PhoneCallId",
+                        column: x => x.PhoneCallId,
+                        principalTable: "PhoneCall",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidatePastTeachingPosition",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubjectTaughtId = table.Column<Guid>(type: "uuid", nullable: true),
+                    EducationPhaseId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidatePastTeachingPosition", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidatePastTeachingPosition_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidatePrivacyPolicy",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AcceptedPolicyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsentReceivedById = table.Column<int>(type: "integer", nullable: false),
+                    MeanOfConsentId = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    AcceptedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidatePrivacyPolicy", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidatePrivacyPolicy_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CandidateQualification",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TypeId = table.Column<int>(type: "integer", nullable: true),
+                    UkDegreeGradeId = table.Column<int>(type: "integer", nullable: true),
+                    DegreeStatusId = table.Column<int>(type: "integer", nullable: true),
+                    DegreeSubject = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CandidateQualification", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CandidateQualification_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TeachingEventRegistration",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CandidateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChannelId = table.Column<int>(type: "integer", nullable: true),
+                    IsCancelled = table.Column<bool>(type: "boolean", nullable: true),
+                    RegistrationNotificationSeen = table.Column<bool>(type: "boolean", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeachingEventRegistration", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeachingEventRegistration_Candidates_CandidateId",
+                        column: x => x.CandidateId,
+                        principalTable: "Candidates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidatePastTeachingPosition_CandidateId",
+                table: "CandidatePastTeachingPosition",
+                column: "CandidateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidatePrivacyPolicy_CandidateId",
+                table: "CandidatePrivacyPolicy",
+                column: "CandidateId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CandidateQualification_CandidateId",
+                table: "CandidateQualification",
+                column: "CandidateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Candidates_PhoneCallId",
+                table: "Candidates",
+                column: "PhoneCallId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeachingEventRegistration_CandidateId",
+                table: "TeachingEventRegistration",
+                column: "CandidateId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CandidatePastTeachingPosition");
+
+            migrationBuilder.DropTable(
+                name: "CandidatePrivacyPolicy");
+
+            migrationBuilder.DropTable(
+                name: "CandidateQualification");
+
+            migrationBuilder.DropTable(
+                name: "TeachingEventRegistration");
+
+            migrationBuilder.DropTable(
+                name: "Candidates");
+
+            migrationBuilder.DropTable(
+                name: "PhoneCall");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -27,6 +27,7 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
-        Task<Candidate> GetCandidateAsync(Guid candidateId);
+        Candidate GetCandidate(Guid candidateId);
+        IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);
     }
 }

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -16,6 +16,8 @@ namespace GetIntoTeachingApi.Services
             where T : BaseModel;
         Task SaveAsync<T>(T model)
             where T : BaseModel;
+        Task DeleteAsync<T>(T model)
+            where T : BaseModel;
         IQueryable<LookupItem> GetLookupItems(string entityName);
         IQueryable<PickListItem> GetPickListItems(string entityName, string attributeName);
         Task<PrivacyPolicy> GetLatestPrivacyPolicyAsync();

--- a/GetIntoTeachingApi/Services/IStore.cs
+++ b/GetIntoTeachingApi/Services/IStore.cs
@@ -27,5 +27,6 @@ namespace GetIntoTeachingApi.Services
         Task<TeachingEvent> GetTeachingEventAsync(Guid id);
         Task<TeachingEvent> GetTeachingEventAsync(string readableId);
         IQueryable<TeachingEventBuilding> GetTeachingEventBuildings();
+        Task<Candidate> GetCandidateAsync(Guid candidateId);
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -161,6 +161,13 @@ namespace GetIntoTeachingApi.Services
             await SaveAsync(new T[] { model });
         }
 
+        public async Task DeleteAsync<T>(T model)
+            where T : BaseModel
+        {
+            _dbContext.Remove(model);
+            await _dbContext.SaveChangesAsync();
+        }
+
         private async Task<IEnumerable<TeachingEvent>> FilterTeachingEventsByRadius(
             IQueryable<TeachingEvent> teachingEvents, TeachingEventSearchRequest request)
         {

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -145,15 +145,21 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TeachingEventBuildings.AsNoTracking();
         }
 
-        public async Task<Candidate> GetCandidateAsync(Guid candidateId)
+        public IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids)
         {
-            return await _dbContext.Candidates.AsNoTracking()
+            return _dbContext.Candidates.AsNoTracking()
                 .Include(c => c.PrivacyPolicy)
                 .Include(c => c.PastTeachingPositions)
                 .Include(c => c.Qualifications)
                 .Include(c => c.TeachingEventRegistrations)
                 .Include(c => c.PhoneCall)
-                .FirstOrDefaultAsync(c => c.Id == candidateId);
+                .Where(c => ids.Contains((Guid)c.Id))
+                .ToList();
+        }
+
+        public Candidate GetCandidate(Guid candidateId)
+        {
+            return GetCandidates(new List<Guid> { candidateId }).FirstOrDefault();
         }
 
         public async Task SaveAsync<T>(IEnumerable<T> models)

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -145,6 +145,17 @@ namespace GetIntoTeachingApi.Services
             return _dbContext.TeachingEventBuildings.AsNoTracking();
         }
 
+        public async Task<Candidate> GetCandidateAsync(Guid candidateId)
+        {
+            return await _dbContext.Candidates.AsNoTracking()
+                .Include(c => c.PrivacyPolicy)
+                .Include(c => c.PastTeachingPositions)
+                .Include(c => c.Qualifications)
+                .Include(c => c.TeachingEventRegistrations)
+                .Include(c => c.PhoneCall)
+                .FirstOrDefaultAsync(c => c.Id == candidateId);
+        }
+
         public async Task SaveAsync<T>(IEnumerable<T> models)
             where T : BaseModel
         {

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -86,7 +86,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             public StoreContainsCandidate()
             {
-                _mockStore.Setup(mock => mock.GetCandidateAsync(It.IsAny<Guid>())).ReturnsAsync(new Candidate());
+                _mockStore.Setup(mock => mock.GetCandidate(It.IsAny<Guid>())).Returns(new Candidate());
             }
 
             public override async Task Run_OnSuccess_UpsertsCandidate()

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -713,6 +713,20 @@ namespace GetIntoTeachingApiTests.Services
             DbContext.TeachingEvents.FirstOrDefault(e => e.Id == teachingEventId).Should().BeNull();
         }
 
+        [Fact]
+        public async Task GetCandidateAsync_WithId_ReturnsMatchingCandidateAndRelatedModels()
+        {
+            var candidates = await SeedMockCandidates();
+            var result = await _store.GetCandidateAsync((Guid)candidates.First().Id);
+
+            result.Id.Should().Be(candidates.First().Id);
+            result.PrivacyPolicy.Should().NotBeNull();
+            result.PastTeachingPositions.Should().NotBeNull();
+            result.Qualifications.Should().NotBeNull();
+            result.TeachingEventRegistrations.Should().NotBeNull();
+            result.PhoneCall.Should().NotBeNull();
+        }
+
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);
@@ -954,6 +968,30 @@ namespace GetIntoTeachingApiTests.Services
 
             DbContext.Locations.AddRange(locations);
             DbContext.SaveChanges();
+        }
+
+        private async Task<List<Candidate>> SeedMockCandidates()
+        {
+            var privacyPolicy = new CandidatePrivacyPolicy { Id = Guid.NewGuid() };
+            var pastTeachingPosition = new CandidatePastTeachingPosition { Id = Guid.NewGuid() };
+            var qualification = new CandidateQualification { Id = Guid.NewGuid() };
+            var teachingeventRegistration = new TeachingEventRegistration { Id = Guid.NewGuid() };
+            var phoneCall = new PhoneCall { Id = Guid.NewGuid() };
+            var candidates = new List<Candidate> {
+                new Candidate {
+                    Id = Guid.NewGuid() ,
+                    PrivacyPolicy = privacyPolicy,
+                    PastTeachingPositions = new List<CandidatePastTeachingPosition> { pastTeachingPosition },
+                    Qualifications = new List<CandidateQualification> { qualification },
+                    TeachingEventRegistrations = new List<TeachingEventRegistration> { teachingeventRegistration },
+                    PhoneCall = phoneCall,
+                }
+            };
+
+            await DbContext.Candidates.AddRangeAsync(candidates);
+            await DbContext.SaveChangesAsync();
+
+            return candidates;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -701,6 +701,18 @@ namespace GetIntoTeachingApiTests.Services
             DbContext.TeachingEvents.FirstOrDefault(e => e.Id == teachingEvent2.Id).Should().NotBeNull();
         }
 
+        [Fact]
+        public async Task DeleteAsync_RemovesModel()
+        {
+            Guid teachingEventId = Guid.NewGuid();
+            var teachingEvent = new TeachingEvent { Id = teachingEventId };
+            await _store.SaveAsync(teachingEvent);
+
+            await _store.DeleteAsync(teachingEvent);
+
+            DbContext.TeachingEvents.FirstOrDefault(e => e.Id == teachingEventId).Should().BeNull();
+        }
+
         private static bool CheckGetTeachingEventsAfterDate(DateTime date)
         {
             var afterDate = DateTime.UtcNow.Subtract(Store.TeachingEventArchiveSize);

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -714,10 +714,24 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async Task GetCandidateAsync_WithId_ReturnsMatchingCandidateAndRelatedModels()
+        public async Task GetCandidate_WithId_ReturnsMatchingCandidateAndRelatedModels()
         {
             var candidates = await SeedMockCandidates();
-            var result = await _store.GetCandidateAsync((Guid)candidates.First().Id);
+            var result = _store.GetCandidate((Guid)candidates.First().Id);
+
+            result.Id.Should().Be(candidates.First().Id);
+            result.PrivacyPolicy.Should().NotBeNull();
+            result.PastTeachingPositions.Should().NotBeNull();
+            result.Qualifications.Should().NotBeNull();
+            result.TeachingEventRegistrations.Should().NotBeNull();
+            result.PhoneCall.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task GetCandidates_WithIds_ReturnsMatchingCandidatesAndRelatedModels()
+        {
+            var candidates = await SeedMockCandidates();
+            var result = _store.GetCandidates(new List<Guid> { (Guid)candidates.First().Id }).First();
 
             result.Id.Should().Be(candidates.First().Id);
             result.PrivacyPolicy.Should().NotBeNull();


### PR DESCRIPTION
## 1. Add delete method

We are going to cache the Candidate model temporarily while the CRM integration is paused. We will need to delete the cache when it is back up.

## 2. Add `Candidate` cache

The CRM can't accept any new data during releases. The solution to this in Get into Teaching is to queue the request until the CRM is back up.

However, in School Experience, the Candidate upsert cannot be queued because the candidate information is needed immediately by the Schools Experience app.

Add a Candidate cache. The cache can be used when the CRM integration is paused.

Note: This creates a table for each entity related to Candidate, despite not declaring a DbSet for them.

## 3. Cache `Candidate` in Store if CRM integration is paused

When the CRM integration is paused, we want to provide a GUID to the Candidate, and cache it.

Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front because the School Experience app needs the Candidate ID immediately.

The Candidate upsert job is also triggered, so that when the CRM is operational again, we can persist the stored Candidate there, deleting the cache.

## 4. Update `UpsertCandidateJob` to remove candidate cache when successful

We cache the `Candidate` while the CRM integration is paused. However, we don't want to persist this permanently as it contains personal information. 

Ensure that when the `Candidate` is inserted into the CRM, the API cache record is deleted. Due to the way the `CandidateUpserter` job is configured, the API record will always be deleted within 24 hours (which it needs to be because it contains personal data).

## 5. Update `Candidate` controller actions to use cache when CRM down

When the CRM integration is paused, the record may exist in the cache (if they have completed their sign up recently). When that is the case, fetch the record from there instead of the CRM.

# Thoughts
- Fetching from the cache won't work when the candidate has signed up **before** the CRM integration was paused. This is used for various stuff like cancelling a placement and accepting a placement. If we can't figure out a way to make the GETs work, we might as well get rid of the Store code.
- Linked to the above. I am querying the database/CRM conditionally based on whether the CRM integration is paused. There will be a period of time when it is unpaused, but that CandidateUpsertJob has not yet completed.