### PR TITLE
Cache candidate while CRM is down

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -26,19 +26,22 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         private readonly ICandidateUpserter _upserter;
         private readonly IBackgroundJobClient _jobClient;
         private readonly IDateTimeProvider _dateTime;
+        private readonly IEnv _env;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             ICandidateUpserter upserter,
             IBackgroundJobClient jobClient,
-            IDateTimeProvider dateTime)
+            IDateTimeProvider dateTime,
+            IEnv env)
         {
             _crm = crm;
             _upserter = upserter;
             _tokenService = tokenService;
             _jobClient = jobClient;
             _dateTime = dateTime;
+            _env = env;
         }
 
         [HttpPost]
@@ -64,6 +67,12 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
 
             if (appSettings.IsCrmIntegrationPaused)
             {
+                // Temporary. To be removed once feature is verified in other environments.
+                if (_env.IsProduction)
+                {
+                    throw new InvalidOperationException("CandidatesController#SignUp - Aborting (CRM integration paused).");
+                }
+
                 // Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better
                 // SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front
                 // because the School Experience app needs the Candidate ID immediately.

--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -25,17 +25,20 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         private readonly ICrmService _crm;
         private readonly ICandidateUpserter _upserter;
         private readonly IBackgroundJobClient _jobClient;
+        private readonly IDateTimeProvider _dateTime;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             ICandidateUpserter upserter,
-            IBackgroundJobClient jobClient)
+            IBackgroundJobClient jobClient,
+            IDateTimeProvider dateTime)
         {
             _crm = crm;
             _upserter = upserter;
             _tokenService = tokenService;
             _jobClient = jobClient;
+            _dateTime = dateTime;
         }
 
         [HttpPost]
@@ -57,13 +60,25 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 return BadRequest(ModelState);
             }
 
+            var candidate = request.Candidate;
+
             if (appSettings.IsCrmIntegrationPaused)
             {
-                throw new InvalidOperationException("CandidatesController#SignUp - Aborting (CRM integration paused).");
-            }
+                // Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better
+                // SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front
+                // because the School Experience app needs the Candidate ID immediately.
+                candidate.Id = Guid.NewGuid();
 
-            var candidate = request.Candidate;
-            _upserter.Upsert(candidate);
+                // This is the only way we can mock/freeze the current date/time
+                // in contract tests (there's no other way to inject it into this class).
+                request.DateTimeProvider = _dateTime;
+                string json = request.Candidate.SerializeChangeTracked();
+                _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+            }
+            else
+            {
+                _upserter.Upsert(candidate);
+            }
 
             return CreatedAtAction(
                 actionName: nameof(Get),

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         private readonly Mock<ICrmService> _mockCrm;
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<ICandidateUpserter> _mockUpserter;
+        private readonly Mock<IDateTimeProvider> _mockDateTime;
         private readonly CandidatesController _controller;
         private readonly ExistingCandidateRequest _request;
 
@@ -34,12 +35,14 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             _mockCrm = new Mock<ICrmService>();
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockUpserter = new Mock<ICandidateUpserter>();
+            _mockDateTime = new Mock<IDateTimeProvider>();
             _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             _controller = new CandidatesController(
                 _mockTokenService.Object,
                 _mockCrm.Object,
                 _mockUpserter.Object,
-                _mockJobClient.Object);
+                _mockJobClient.Object,
+                _mockDateTime.Object);
         }
 
         [Fact]
@@ -119,15 +122,22 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         }
 
         [Fact]
-        public void SignUp_WhenCrmIntegrationIsPaused_RaisesError()
+        public void SignUp_WhenCrmIntegrationPaused_QueuesCandidateUpsert()
         {
+            var request = new SchoolsExperienceSignUp { FirstName = "first" };
             var mockAppSettings = new Mock<IAppSettings>();
             mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
-            var request = new SchoolsExperienceSignUp { FirstName = "first" };
 
-            _controller.Invoking(c => c.SignUp(request, mockAppSettings.Object))
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("CandidatesController#SignUp - Aborting (CRM integration paused).");
+            var response = _controller.SignUp(request, mockAppSettings.Object);
+
+            var created = response.Should().BeOfType<CreatedAtActionResult>().Subject;
+            var signUp = created.Value.Should().BeAssignableTo<SchoolsExperienceSignUp>().Subject;
+            signUp.FirstName.Should().Be(request.FirstName);
+            signUp.CandidateId.Should().NotBeNull();
+            _mockJobClient.Verify(x => x.Create(
+               It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+               IsMatch(request.Candidate, (string)job.Args[0])),
+               It.IsAny<EnqueuedState>()));
         }
 
         [Fact]


### PR DESCRIPTION
## Queue `CandidateUpsertJob` for sign up when CRM integration is paused

The CRM can't accept any new data during releases. The solution to this in Get into Teaching is to queue the request until the CRM is back up.

However, in School Experience, candidate information is needed immediately by the Schools Experience app. So, we must provide a GUID up-front to the Candidate before queuing the request. This way, the School Experience app can persist the CRM GUID when it receives a response (as it usually does when the CRM is operational).

Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front because the School Experience app needs the Candidate ID immediately.

## Put queuing candidate sign ups behind feature flag

We want to test this before enabling it in production.