### PR TITLE
Add an `AddClassroomExperienceNoteJob` so that request can be queued

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -174,25 +174,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 return BadRequest(ModelState);
             }
 
-            var existingCandidate = _crm.GetCandidate(id);
-
-            if (existingCandidate == null)
-            {
-                return NotFound();
-            }
-
-            // Create a new candidate to encapsulate the actual changes - avoids writing
-            // all the existingCandidate fields back to the CRM.
-            var candidate = new Candidate()
-            {
-                Id = id,
-                ClassroomExperienceNotesRaw = existingCandidate.ClassroomExperienceNotesRaw,
-            };
-
-            candidate.AddClassroomExperienceNote(note);
-
-            string json = candidate.SerializeChangeTracked();
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+            _jobClient.Enqueue<AddClassroomExperienceNoteJob>((x) => x.Run(null, note, id));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Jobs/AddClassroomExperienceNoteJob.cs
+++ b/GetIntoTeachingApi/Jobs/AddClassroomExperienceNoteJob.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Models.SchoolsExperience;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class AddClassroomExperienceNoteJob : BaseJob
+    {
+        private const int NumberOfQuietRetries = 3;
+        private readonly IPerformContextAdapter _contextAdapter;
+        private readonly IAppSettings _appSettings;
+        private readonly ILogger<AddClassroomExperienceNoteJob> _logger;
+        private readonly ICrmService _crm;
+        private readonly IBackgroundJobClient _jobClient;
+
+        public AddClassroomExperienceNoteJob(
+            IEnv env,
+            IPerformContextAdapter contextAdapter,
+            IAppSettings appSettings,
+            ILogger<AddClassroomExperienceNoteJob> logger,
+            ICrmService crm,
+            IBackgroundJobClient jobClient)
+            : base(env)
+        {
+            _contextAdapter = contextAdapter;
+            _appSettings = appSettings;
+            _logger = logger;
+            _crm = crm;
+            _jobClient = jobClient;
+        }
+
+        public void Run(
+            PerformContext context,
+            ClassroomExperienceNote note,
+            Guid candidateId)
+        {
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException($"{GetType().Name} - Aborting (CRM integration paused).");
+            }
+
+            var existingCandidate = _crm.GetCandidate(candidateId);
+
+            if (existingCandidate == null)
+            {
+                if (CurrentAttempt(context, _contextAdapter) <= NumberOfQuietRetries)
+                {
+                    _logger.LogInformation($"{GetType().Name} - Candidate not found (may be in concurrent job queue)");
+                    _jobClient.Requeue(context.BackgroundJob.Id);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"{GetType().Name} - Candidate not found");
+                }
+            }
+            else
+            {
+                // Create a new candidate to encapsulate the actual changes - avoids writing
+                // all the existingCandidate fields back to the CRM.
+                var candidate = new Candidate()
+                {
+                    Id = candidateId,
+                    ClassroomExperienceNotesRaw = existingCandidate.ClassroomExperienceNotesRaw,
+                };
+
+                candidate.AddClassroomExperienceNote(note);
+
+                string json = candidate.SerializeChangeTracked();
+                _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
+            }
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Helpers/BackgroundJobMock.cs
+++ b/GetIntoTeachingApiTests/Helpers/BackgroundJobMock.cs
@@ -1,0 +1,29 @@
+﻿using Hangfire;
+using Hangfire.Common;
+using System;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    class BackgroundJobMock
+    {
+        private readonly Lazy<BackgroundJob> _object;
+
+        public BackgroundJobMock()
+        {
+            Id = "JobId";
+            Job = Job.FromExpression(() => SomeMethod());
+            CreatedAt = DateTime.UtcNow;
+
+            _object = new Lazy<BackgroundJob>(
+                () => new BackgroundJob(Id, Job, CreatedAt));
+        }
+
+        public string Id { get; set; }
+        public Job Job { get; set; }
+        public DateTime CreatedAt { get; set; }
+
+        public BackgroundJob Object => _object.Value;
+
+        public static void SomeMethod() { }
+    }
+}

--- a/GetIntoTeachingApiTests/Helpers/PerformContextMock.cs
+++ b/GetIntoTeachingApiTests/Helpers/PerformContextMock.cs
@@ -1,0 +1,35 @@
+﻿using Hangfire;
+using Hangfire.Server;
+using Hangfire.Storage;
+using Moq;
+using System;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    class PerformContextMock
+    {
+        private readonly Lazy<PerformContext> _context;
+
+        public PerformContextMock()
+        {
+            Storage = new Mock<JobStorage>();
+            Connection = new Mock<IStorageConnection>();
+            BackgroundJob = new BackgroundJobMock();
+            CancellationToken = new Mock<IJobCancellationToken>();
+
+            _context = new Lazy<PerformContext>(
+                () => new PerformContext(Storage.Object, Connection.Object, BackgroundJob.Object, CancellationToken.Object));
+        }
+
+        public Mock<JobStorage> Storage { get; set; }
+        public Mock<IStorageConnection> Connection { get; set; }
+        public BackgroundJobMock BackgroundJob { get; set; }
+        public Mock<IJobCancellationToken> CancellationToken { get; set; }
+
+        public PerformContext Object => _context.Value;
+
+        public static void SomeMethod()
+        {
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/AddClassroomExperienceNoteJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/AddClassroomExperienceNoteJobTests.cs
@@ -1,0 +1,121 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Models.SchoolsExperience;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.Server;
+using Hangfire.States;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class AddClassroomExperienceNoteJobTests
+    {
+        private readonly Mock<IEnv> _mockEnv;
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<IAppSettings> _mockAppSettings;
+        private readonly Mock<ILogger<AddClassroomExperienceNoteJob>> _mockLogger;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        private readonly AddClassroomExperienceNoteJob _job;
+
+        public AddClassroomExperienceNoteJobTests()
+        {
+            _mockEnv = new Mock<IEnv>();
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockAppSettings = new Mock<IAppSettings>();
+            _mockLogger = new Mock<ILogger<AddClassroomExperienceNoteJob>>();
+            _mockCrm = new Mock<ICrmService>();
+            _mockJobClient = new Mock<IBackgroundJobClient>();
+
+            _job = new AddClassroomExperienceNoteJob(
+                _mockEnv.Object,
+                _mockContext.Object,
+                _mockAppSettings.Object,
+                _mockLogger.Object,
+                _mockCrm.Object,
+                _mockJobClient.Object);
+        }
+
+        [Fact]
+        public void Run_WhenCrmIntegrationPaused_ThrowsException()
+        {
+            _mockAppSettings.Setup(mock => mock.IsCrmIntegrationPaused).Returns(true);
+
+            Action job = () => _job.Run(null, new ClassroomExperienceNote(), Guid.NewGuid());
+
+            job.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("AddClassroomExperienceNoteJob - Aborting (CRM integration paused).");
+        }
+
+        [Fact]
+        public void Run_WhenCandidateReturnsNullAndLessThanThreeTries_LogsMessageAndRetries()
+        {
+            _mockCrm.Setup(mock => mock.GetCandidate(It.IsAny<Guid>())).Returns((Candidate)null);
+            _mockContext.Setup(mock => mock.GetRetryCount(null)).Returns(2);
+            var mockPerformContext = new PerformContextMock();
+            mockPerformContext.BackgroundJob.Id = "perform-context-id";
+
+            _job.Run(mockPerformContext.Object, new ClassroomExperienceNote(), Guid.NewGuid());
+
+            _mockLogger.VerifyInformationWasCalled("AddClassroomExperienceNoteJob - Candidate not found (may be in concurrent job queue)");
+            _mockJobClient.Verify(x => x.ChangeState(
+               "perform-context-id",
+               It.IsAny<EnqueuedState>(),
+               null), Times.Once);
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run"),
+                It.IsAny<EnqueuedState>()), Times.Never);
+        }
+
+        [Fact]
+        public void Run_WhenCandidateReturnsNullAndMoreThanThreeTries_ThrowsException()
+        {
+            _mockCrm.Setup(mock => mock.GetCandidate(It.IsAny<Guid>())).Returns((Candidate)null);
+            _mockContext.Setup(mock => mock.GetRetryCount(null)).Returns(3);
+
+            Action job = () => _job.Run(null, new ClassroomExperienceNote(), Guid.NewGuid());
+
+            job.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("AddClassroomExperienceNoteJob - Candidate not found");
+            _mockJobClient.Verify(x => x.Create(
+                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run"),
+                It.IsAny<EnqueuedState>()), Times.Never);
+        }
+
+        [Fact]
+        public void Run_OnSuccess_QueuesCandidateUpsertJob()
+        {
+            var note = new ClassroomExperienceNote() { Action = "REQUESTED", SchoolName = "School Name", SchoolUrn = 123456 };
+            var candidate = new Candidate() { Id = Guid.NewGuid() };
+            _mockCrm.Setup(mock => mock.GetCandidate(candidate.Id.Value)).Returns(candidate);
+
+            _job.Run(null, note, candidate.Id.Value);
+
+            candidate.AddClassroomExperienceNote(note);
+            _mockJobClient.Verify(x => x.Create(
+               It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) &&
+                                 job.Method.Name == "Run" &&
+                                 IsMatch(candidate, (string)job.Args[0])),
+               It.IsAny<EnqueuedState>()), Times.Once);
+        }
+
+        private static bool IsMatch(Candidate candidateA, string candidateBJson)
+        {
+            var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();
+            candidateA.Should().BeEquivalentTo(candidateB);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Part of the School Experience candidate sign up (in the app) attempts to add a `ClassroomExperienceNote`. This firstly fetches the candidate from the CRM. 

When the CRM integration is paused, this is not possible and we were therefore seeing 404 not found.

To fix this, add an `AddClassroomExperienceNoteJob` so that the API can queue the request until the CRM is operational again. 

The `AddClassroomExperienceNoteJob` must complete after the `UpsertCandidateJob` of the `SignUp` action. However, the Hangfire jobs run concurrently, so we silently retry the `AddClassroomExperienceNoteJob` three times to allow some time for the `UpsertCandidateJob` to complete.