### PR TITLE
Sync new Apply API fields

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -107,8 +107,10 @@ namespace GetIntoTeachingApi.Jobs
                     FindApplyId = findApplyForm.Id.ToString(),
                     CreatedAt = findApplyForm.CreatedAt,
                     UpdatedAt = findApplyForm.UpdatedAt,
+                    SubmittedAt = findApplyForm.SubmittedAt,
                     StatusId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Status), findApplyForm.ApplicationStatus.ToPascalCase()),
                     PhaseId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Phase), findApplyForm.ApplicationPhase.ToPascalCase()),
+                    RecruitmentCycleYearId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.RecruitmentCycleYear), $"Year{findApplyForm.RecruitmentCycleYear.ToString()}"),
                 };
             });
         }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -34,18 +34,30 @@ namespace GetIntoTeachingApi.Models.Crm
             Apply2 = 222750001,
         }
 
+        // The keys for this enum need to mirror the
+        // Apply API naming so we can match them up.
+        public enum RecruitmentCycleYear
+        {
+            Year2021 = 222750001,
+            Year2022 = 222750002,
+        }
+
         [EntityField("dfe_contact", typeof(EntityReference), "contact")]
         public Guid CandidateId { get; set; }
         [EntityField("dfe_applyphase", typeof(OptionSetValue))]
         public int? PhaseId { get; set; }
         [EntityField("dfe_applystatus", typeof(OptionSetValue))]
         public int? StatusId { get; set; }
+        [EntityField("dfe_recruitmentyear", typeof(OptionSetValue))]
+        public int? RecruitmentCycleYearId { get; set; }
         [EntityField("dfe_applicationformid")]
         public string FindApplyId { get; set; }
         [EntityField("dfe_createdon")]
         public DateTime CreatedAt { get; set; }
         [EntityField("dfe_modifiedon")]
         public DateTime UpdatedAt { get; set; }
+        [EntityField("dfe_submittedatdate")]
+        public DateTime? SubmittedAt { get; set; }
         [EntityField("dfe_name")]
         public string Name
         {

--- a/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/ApplicationFormValidator.cs
@@ -15,6 +15,9 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(form => form.StatusId)
                 .NotNull()
                 .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_applystatus", store));
+            RuleFor(form => form.RecruitmentCycleYearId)
+                .NotNull()
+                .SetValidator(new PickListItemIdValidator<ApplicationForm>("dfe_applyapplicationform", "dfe_recruitmentyear", store));
         }
     }
 }

--- a/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
@@ -11,9 +11,13 @@ namespace GetIntoTeachingApi.Models.FindApply
         public DateTime CreatedAt { get; set; }
         [JsonProperty("updated_at")]
         public DateTime UpdatedAt { get; set; }
+        [JsonProperty("submitted_at")]
+        public DateTime? SubmittedAt { get; set; }
         [JsonProperty("application_status")]
         public string ApplicationStatus { get; set; }
         [JsonProperty("application_phase")]
         public string ApplicationPhase { get; set; }
+        [JsonProperty("recruitment_cycle_year")]
+        public int RecruitmentCycleYear { get; set; }
     }
 }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -261,6 +261,7 @@ namespace GetIntoTeachingApi.Services
                 await SyncPickListItem("contact", "dfe_candidateapplyphase");
                 await SyncPickListItem("dfe_applyapplicationform", "dfe_applyphase");
                 await SyncPickListItem("dfe_applyapplicationform", "dfe_applystatus");
+                await SyncPickListItem("dfe_applyapplicationform", "dfe_recruitmentyear");
             }
         }
 

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -45,8 +45,10 @@ namespace GetIntoTeachingApiTests.Jobs
                     Id = 1,
                     CreatedAt = new DateTime(2021, 1, 4),
                     UpdatedAt = new DateTime(2021, 1, 5),
+                    SubmittedAt = new DateTime(2021, 1, 6),
                     ApplicationStatus = "never_signed_in",
                     ApplicationPhase = "apply_2",
+                    RecruitmentCycleYear = 2022,
                 },
                 new ApplicationForm()
                 {
@@ -54,6 +56,7 @@ namespace GetIntoTeachingApiTests.Jobs
                     CreatedAt = new DateTime(2021, 1, 3),
                     ApplicationStatus = "awaiting_candidate_response",
                     ApplicationPhase = "apply_1",
+                    RecruitmentCycleYear = 2021,
                 },
             };
             _attributes = new CandidateAttributes()
@@ -89,7 +92,9 @@ namespace GetIntoTeachingApiTests.Jobs
                 CreatedAt = _forms[0].CreatedAt,
                 PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
                 StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
                 UpdatedAt = _forms[0].UpdatedAt,
+                SubmittedAt = _forms[0].SubmittedAt,
             };
 
             var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
@@ -98,8 +103,10 @@ namespace GetIntoTeachingApiTests.Jobs
                 FindApplyId = _forms[1].Id.ToString(),
                 PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
                 StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
+                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
                 CreatedAt = _forms[1].CreatedAt,
                 UpdatedAt = _forms[1].UpdatedAt,
+                SubmittedAt = null,
             };
 
             var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
@@ -23,10 +23,13 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 a => a.Name == "dfe_applyphase" && a.Type == typeof(OptionSetValue));
             type.GetProperty("StatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_applystatus" && a.Type == typeof(OptionSetValue));
+            type.GetProperty("RecruitmentCycleYearId").Should().BeDecoratedWith<EntityFieldAttribute>(
+                a => a.Name == "dfe_recruitmentyear" && a.Type == typeof(OptionSetValue));
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationformid");
             type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_createdon");
             type.GetProperty("UpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_modifiedon");
+            type.GetProperty("SubmittedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_submittedatdate");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_name");
         }
 

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/ApplicationFormValidatorTests.cs
@@ -33,6 +33,9 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
             _mockStore
                 .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_applystatus"))
                 .Returns(new[] { mockPickListItem }.AsQueryable());
+            _mockStore
+                .Setup(mock => mock.GetPickListItems("dfe_applyapplicationform", "dfe_recruitmentyear"))
+                .Returns(new[] { mockPickListItem }.AsQueryable());
 
             var form = new ApplicationForm()
             {
@@ -40,6 +43,7 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 FindApplyId = "67890",
                 PhaseId = mockPickListItem.Id,
                 StatusId = mockPickListItem.Id,
+                RecruitmentCycleYearId = mockPickListItem.Id,
             };
 
             var result = _validator.TestValidate(form);
@@ -59,21 +63,23 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         [Fact]
         public void Validate_OptionSetIsNotValid_HasError()
         {
-            var form = new ApplicationForm() { PhaseId = 456, StatusId = 789 };
+            var form = new ApplicationForm() { PhaseId = 456, StatusId = 789, RecruitmentCycleYearId = 876 };
             var result = _validator.TestValidate(form);
 
             result.ShouldHaveValidationErrorFor("PhaseId");
             result.ShouldHaveValidationErrorFor("StatusId");
+            result.ShouldHaveValidationErrorFor("RecruitmentCycleYearId");
         }
 
         [Fact]
         public void Validate_RequiredAttributeIsNull_HasError()
         {
-            var form = new ApplicationForm() { PhaseId = null, StatusId = null };
+            var form = new ApplicationForm() { PhaseId = null, StatusId = null, RecruitmentCycleYearId = null };
             var result = _validator.TestValidate(form);
 
             result.ShouldHaveValidationErrorFor("PhaseId");
             result.ShouldHaveValidationErrorFor("StatusId");
+            result.ShouldHaveValidationErrorFor("RecruitmentCycleYearId");
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
@@ -18,10 +18,14 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
             type.GetProperty("UpdatedAt").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+            type.GetProperty("SubmittedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "submitted_at");
             type.GetProperty("ApplicationStatus").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_status");
             type.GetProperty("ApplicationPhase").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_phase");
+            type.GetProperty("RecruitmentCycleYear").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "recruitment_cycle_year");
         }
     }
 }


### PR DESCRIPTION
[Trello-2651](https://trello.com/c/OaNTdS9Y/2651-add-additional-fields-to-apply-sync-job)

The Apply team have added two additional fields to their application forms; `submitted_at` and `recruitment_cycle_year`. We want to sync these through to the CRM so that we can make the reporting consistent between Apply and the CRM.

- Add new fields to the `ApplicationForm` models. 
- Sync the new `dfe_recruitmentyear` option set. 
- Map fields as part of the `FindApplyCandidateSyncJob`. 

These fields are available in the test/prod CRM and Apply environments, so we should be good to push this all the way out to production.