### PR TITLE
Fix candidate Id not being set before being sent to job

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -81,7 +81,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 // This is the only way we can mock/freeze the current date/time
                 // in contract tests (there's no other way to inject it into this class).
                 request.DateTimeProvider = _dateTime;
-                string json = request.Candidate.SerializeChangeTracked();
+                string json = candidate.SerializeChangeTracked();
                 _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
             }
             else

--- a/GetIntoTeachingApi/Jobs/AddClassroomExperienceNoteJob.cs
+++ b/GetIntoTeachingApi/Jobs/AddClassroomExperienceNoteJob.cs
@@ -71,7 +71,7 @@ namespace GetIntoTeachingApi.Jobs
             var baseMessage = $"{GetType().Name} - Candidate not found";
 
             return numberOfRetries <= NumberOfRetriesAllowingForJobQueue
-                ? baseMessage += " (may be in concurrent job queue)"
+                ? baseMessage + " (may be in concurrent job queue)"
                 : baseMessage;
         }
     }


### PR DESCRIPTION
I hadn't updated the candidate sent to the `UpsertCandidateJob`. The candidate was being sent to the CRM with a `null` ID and the CRM was generating one.

Also fix SonarCloud code smell that was left in from refactoring.