### PR TITLE
Dynamically map recruitment cycle year

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -101,6 +101,8 @@ namespace GetIntoTeachingApi.Jobs
             {
                 var existingForm = _crm.GetApplicationForm(findApplyForm.Id.ToString());
 
+                var yearId = ((int)Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2020) + (findApplyForm.RecruitmentCycleYear - 2020);
+
                 return new Models.Crm.ApplicationForm()
                 {
                     Id = existingForm?.Id,
@@ -110,7 +112,7 @@ namespace GetIntoTeachingApi.Jobs
                     SubmittedAt = findApplyForm.SubmittedAt,
                     StatusId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Status), findApplyForm.ApplicationStatus.ToPascalCase()),
                     PhaseId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Phase), findApplyForm.ApplicationPhase.ToPascalCase()),
-                    RecruitmentCycleYearId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.RecruitmentCycleYear), $"Year{findApplyForm.RecruitmentCycleYear.ToString()}"),
+                    RecruitmentCycleYearId = yearId,
                 };
             });
         }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -34,10 +34,9 @@ namespace GetIntoTeachingApi.Models.Crm
             Apply2 = 222750001,
         }
 
-        // The keys for this enum need to mirror the
-        // Apply API naming so we can match them up.
         public enum RecruitmentCycleYear
         {
+            Year2020 = 222750000,
             Year2021 = 222750001,
             Year2022 = 222750002,
         }


### PR DESCRIPTION
Apply are sending through recruitment cycle years that are outwith the initial option set values the CRM team created. The CRM team have since updated their option set values, but we need to account for those in the API.

To make it easier to maintain going forward I'm mapping the recruitment cycle year dynamically; there should never be a year before 2020 and the option set values are guaranteed to be sequential.