### PR TITLE
Add field to track which welcome guide variant was served

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -231,6 +231,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public string MagicLinkToken { get; set; }
         [EntityField("dfe_websitemltokenexpirydate")]
         public DateTime? MagicLinkTokenExpiresAt { get; set; }
+        [EntityField("dfe_welcomeguidestring", null, null, new[] { "WELCOME_GUIDE_VARIANT" })]
+        public string WelcomeGuideVariant { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]
         public bool? HasTeacherTrainingAdviserSubscription { get; set; }

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressPostcode { get; set; }
+        public string WelcomeGuideVariant { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool AlreadySubscribedToEvents { get; set; }
         [SwaggerSchema(ReadOnly = true)]
@@ -65,6 +66,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressPostcode = candidate.AddressPostcode;
+            WelcomeGuideVariant = candidate.WelcomeGuideVariant;
 
             AlreadySubscribedToMailingList = candidate.HasMailingListSubscription == true;
             AlreadySubscribedToEvents = candidate.HasEventsSubscription == true;
@@ -82,6 +84,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
+                WelcomeGuideVariant = WelcomeGuideVariant,
                 EligibilityRulesPassed = "false",
                 PreferredPhoneNumberTypeId = (int)Candidate.PhoneNumberType.Home,
                 PreferredContactMethodId = (int)Candidate.ContactMethod.Any,

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -33,7 +33,8 @@
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
         "TOTP_SECRET_KEY": "def456",
-        "APPLY_API_FEATURE": "on"
+        "APPLY_API_FEATURE": "on",
+        "WELCOME_GUIDE_VARIANT_FEATURE": "on"
       }
     }
   }

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -123,6 +123,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
             type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken");
             type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate");
+            type.GetProperty("WelcomeGuideVariant").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_welcomeguidestring" && a.Features.Contains("WELCOME_GUIDE_VARIANT"));
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
@@ -36,6 +36,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
                 FirstName = "John",
                 LastName = "Doe",
                 AddressPostcode = "KY11 9YU",
+                WelcomeGuideVariant = "variant1",
                 Qualifications = qualifications,
                 HasEventsSubscription = true,
                 HasTeacherTrainingAdviserSubscription = true,
@@ -50,6 +51,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
+            response.WelcomeGuideVariant.Should().Be(candidate.WelcomeGuideVariant);
 
             response.QualificationId.Should().Be(latestQualification.Id);
             response.DegreeStatusId.Should().Be(latestQualification.DegreeStatusId);
@@ -74,6 +76,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
                 FirstName = "John",
                 LastName = "Doe",
                 AddressPostcode = "KY11 9YU",
+                WelcomeGuideVariant = "variant1"
             };
 
             var candidate = request.Candidate;
@@ -98,6 +101,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.PreferredContactMethodId.Should().Be((int)Candidate.ContactMethod.Any);
             candidate.GdprConsentId.Should().Be((int)Candidate.GdprConsent.Consent);
             candidate.OptOutOfGdpr.Should().BeFalse();
+            candidate.WelcomeGuideVariant.Should().Be(request.WelcomeGuideVariant);
 
             candidate.PrivacyPolicy.AcceptedPolicyId.Should().Be((Guid)request.AcceptedPolicyId);
             candidate.PrivacyPolicy.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));


### PR DESCRIPTION
[Trello-2661](https://trello.com/c/catUOcuk/2661-update-api-to-include-welcome-guide-query-parameters)

If we serve a welcome guide to the user we want to be able to track which version was served to them at the time of sign up (the fields to determine this can change over time on the candidate record).

The field is not required and is left as plain text for the client to define.