### PR TITLE
Ensure correct method is called when the ID is API generated

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
-using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.SchoolsExperience;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -76,7 +75,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 // Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better
                 // SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front
                 // because the School Experience app needs the Candidate ID immediately.
-                candidate.Id = Guid.NewGuid();
+                candidate.GenerateUpfrontId();
 
                 // This is the only way we can mock/freeze the current date/time
                 // in contract tests (there's no other way to inject it into this class).

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -261,9 +261,14 @@ namespace GetIntoTeachingApi.Services
             return new List<Entity>() { relatedEntity };
         }
 
-        public Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context)
+        public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context)
         {
-            return id != null ? _service.BlankExistingEntity(entityName, (Guid)id, context) : _service.NewEntity(entityName, context);
+            return _service.BlankExistingEntity(entityName, id, context);
+        }
+
+        public Entity NewEntity(string entityName, OrganizationServiceContext context)
+        {
+            return _service.NewEntity(entityName, context);
         }
 
         public void Save(BaseModel model)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -31,7 +31,8 @@ namespace GetIntoTeachingApi.Services
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
-        Entity MappableEntity(string entityName, Guid? id, OrganizationServiceContext context);
+        Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
+        Entity NewEntity(string entityName, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -139,7 +139,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             signUp.CandidateId.Should().NotBeNull();
             _mockJobClient.Verify(x => x.Create(
                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-               IsRequestPlusId(request.Candidate, (string)job.Args[0], signUp.CandidateId.Value)),
+               MatchesCandidateWithUpfrontId(request.Candidate, (string)job.Args[0], signUp.CandidateId.Value)),
                It.IsAny<EnqueuedState>()));
         }
 
@@ -240,12 +240,14 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
                 It.IsAny<EnqueuedState>()));
         }
 
-        private static bool IsRequestPlusId(Candidate requestCandidate, string candidateSentToJobJson, Guid expectedId)
+        private static bool MatchesCandidateWithUpfrontId(Candidate requestCandidate, string candidateSentToJobJson, Guid expectedId)
         {
             var candidateSentToJob = candidateSentToJobJson.DeserializeChangeTracked<Candidate>();
             requestCandidate.Should().BeEquivalentTo(candidateSentToJob, option => option
-                .Excluding(candidate => candidate.Id));
+                .Excluding(candidate => candidate.Id)
+                .Excluding(candidate => candidate.HasUpfrontId));
             candidateSentToJob.Id.Should().Be(expectedId);
+            candidateSentToJob.HasUpfrontId.Should().Be(true);
             return true;
         }
     }

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -213,7 +213,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
                 PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
             };
 
-            mockCrm.Setup(m => m.MappableEntity("contact", (Guid)candidate.Id, context)).Returns(new Entity("contact"));
+            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(new Entity("contact"));
             mockCrm.Setup(m => m.CandidateYetToAcceptPrivacyPolicy((Guid)candidate.Id,
                 candidate.PrivacyPolicy.AcceptedPolicyId)).Returns(false);
 
@@ -230,7 +230,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate() { Id = Guid.NewGuid(), PrivacyPolicy = null };
 
-            mockCrm.Setup(m => m.MappableEntity("contact", (Guid)candidate.Id, context)).Returns(new Entity("contact"));
+            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(new Entity("contact"));
 
             candidate.ToEntity(mockCrm.Object, context);
 
@@ -247,7 +247,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate() { Id = Guid.NewGuid(), EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent };
             var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.MappableEntity("contact", candidate.Id, context)).Returns(candidateEntity);
+            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(candidateEntity);
             mockCrm.Setup(m => m.CandidateAlreadyHasLocalEventSubscriptionType((Guid)candidate.Id)).Returns(true);
 
             candidate.ToEntity(mockCrm.Object, context);
@@ -266,7 +266,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate() { Id = null };
             var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.MappableEntity("contact", null, context)).Returns(candidateEntity);
+            mockCrm.Setup(m => m.NewEntity("contact", context)).Returns(candidateEntity);
 
             candidate.ToEntity(mockCrm.Object, context);
 
@@ -281,7 +281,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate() { Id = Guid.NewGuid() };
             var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.MappableEntity("contact", candidate.Id, context)).Returns(candidateEntity);
+            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(candidateEntity);
 
             candidate.ToEntity(mockCrm.Object, context);
 

--- a/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
@@ -58,12 +58,12 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var registration = new TeachingEventRegistration() { CandidateId = Guid.NewGuid(), EventId = Guid.NewGuid() };
 
-            mockCrm.Setup(m => m.MappableEntity("msevtmgt_eventregistration", null, context)).Returns(new Entity("msevtmgt_eventregistration"));
+            mockCrm.Setup(m => m.NewEntity("msevtmgt_eventregistration", context)).Returns(new Entity("msevtmgt_eventregistration"));
             mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent(registration.CandidateId, registration.EventId)).Returns(true);
 
             registration.ToEntity(mockCrm.Object, context);
 
-            mockCrm.Verify(m => m.MappableEntity("msevtmgt_eventregistration", null, context), Times.Once);
+            mockCrm.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Once);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/TeachingEventTests.cs
@@ -116,7 +116,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenBuildingIsRemoved_DeletesLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.MappableEntity("msevtmgt_event", null, _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {
@@ -140,7 +140,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenEventIsNew_ReturnsEntity()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.MappableEntity("msevtmgt_event", null, _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns<TeachingEvent>(null);
 
@@ -160,7 +160,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenBuildingIsNotRemoved_DoesNotDeleteLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.MappableEntity("msevtmgt_event", null, _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event",  _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {
@@ -184,7 +184,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenThereIsNoPreexistingRelationship_DoesNotDeleteLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.MappableEntity("msevtmgt_event", null, _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -690,19 +690,7 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void MappableEntity_CallsNewEntityOnServiceWhenIdNull()
-        {
-            const string entityName = "entity";
-            var newEntity = new Entity("mock");
-            _mockService.Setup(mock => mock.NewEntity(entityName, _context)).Returns(newEntity);
-
-            var result = _crm.MappableEntity(entityName, null, _context);
-
-            result.Should().Be(newEntity);
-        }
-
-        [Fact]
-        public void MappableEntity_CallsBlankExistingEntityOnServiceWhenIdNotNull()
+        public void BlankExistingEntity_CallsBlankExistingEntityOnService()
         {
             const string entityName = "entity";
             var id = Guid.NewGuid();
@@ -710,9 +698,21 @@ namespace GetIntoTeachingApiTests.Services
             _mockService.Setup(mock => mock.BlankExistingEntity(entityName, id, _context))
                 .Returns(existingEntity);
 
-            var result = _crm.MappableEntity(entityName, id, _context);
+            var result = _crm.BlankExistingEntity(entityName, id, _context);
 
             result.Should().Be(existingEntity);
+        }
+
+        [Fact]
+        public void NewEntity_CallsNewEntityOnService()
+        {
+            const string entityName = "entity";
+            var newEntity = new Entity("mock");
+            _mockService.Setup(mock => mock.NewEntity(entityName, _context)).Returns(newEntity);
+
+            var result = _crm.NewEntity(entityName, _context);
+
+            result.Should().Be(newEntity);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, the `CrmService` chooses the which `OrganisationService` method to call based on whether the model has an existing ID.

However, in certain circumstances, we need to allow to API to generate an ID up-front. 

Add a `GeneratedUpfrontId` method to the `BaseModel`, which sets a flag of `HasUpfrontId` on the model to true. The `BaseModel` can then choose which `OrganisationService` method to call based on the value of the flag.