### PR TITLE
Enable welcome guide variant field in test/prod

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -231,7 +231,7 @@ namespace GetIntoTeachingApi.Models.Crm
         public string MagicLinkToken { get; set; }
         [EntityField("dfe_websitemltokenexpirydate")]
         public DateTime? MagicLinkTokenExpiresAt { get; set; }
-        [EntityField("dfe_welcomeguidestring", null, null, new[] { "WELCOME_GUIDE_VARIANT" })]
+        [EntityField("dfe_welcomeguidestring")]
         public string WelcomeGuideVariant { get; set; }
 
         [EntityField("dfe_gitisttaserviceissubscriber")]

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -33,8 +33,7 @@
         "TTA_API_KEY": "secret-tta",
         "SE_API_KEY": "secret-se",
         "TOTP_SECRET_KEY": "def456",
-        "APPLY_API_FEATURE": "on",
-        "WELCOME_GUIDE_VARIANT_FEATURE": "on"
+        "APPLY_API_FEATURE": "on"
       }
     }
   }

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -123,7 +123,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("OptOutOfGdpr").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "msdyn_gdproptout");
             type.GetProperty("MagicLinkToken").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltoken");
             type.GetProperty("MagicLinkTokenExpiresAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_websitemltokenexpirydate");
-            type.GetProperty("WelcomeGuideVariant").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_welcomeguidestring" && a.Features.Contains("WELCOME_GUIDE_VARIANT"));
+            type.GetProperty("WelcomeGuideVariant").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_welcomeguidestring");
 
             type.GetProperty("TeacherTrainingAdviserSubscriptionChannelId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_gitisttaservicesubscriptionchannel" && a.Type == typeof(OptionSetValue));


### PR DESCRIPTION
This was available in dev and has since been shipped to test/prod CRM instances, so we can enable it there too.