### PR TITLE
Update `NewEntity` to handle when the model has an upfront ID

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApi.Adapters
         IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
         OrganizationServiceContext Context();
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
-        Entity NewEntity(string entityName, OrganizationServiceContext context);
+        Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context);
         void SaveChanges(OrganizationServiceContext context);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -86,9 +86,9 @@ namespace GetIntoTeachingApi.Adapters
             return existingEntity;
         }
 
-        public Entity NewEntity(string entityName, OrganizationServiceContext context)
+        public Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
         {
-            var newEntity = new Entity(entityName);
+            var newEntity = id.HasValue ? new Entity(entityName, id.Value) : new Entity(entityName);
             context.AddObject(newEntity);
             return newEntity;
         }

--- a/GetIntoTeachingApi/Models/Crm/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/Crm/BaseModel.cs
@@ -166,7 +166,7 @@ namespace GetIntoTeachingApi.Models.Crm
         {
             return Id.HasValue && !HasUpfrontId
                 ? crm.BlankExistingEntity(entityName, Id.Value, context)
-                : crm.NewEntity(entityName, context);
+                : crm.NewEntity(entityName, Id, context);
         }
 
         [OnDeserializing]

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -266,9 +266,9 @@ namespace GetIntoTeachingApi.Services
             return _service.BlankExistingEntity(entityName, id, context);
         }
 
-        public Entity NewEntity(string entityName, OrganizationServiceContext context)
+        public Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
         {
-            return _service.NewEntity(entityName, context);
+            return _service.NewEntity(entityName, id, context);
         }
 
         public void Save(BaseModel model)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -32,7 +32,7 @@ namespace GetIntoTeachingApi.Services
         void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         IEnumerable<Entity> RelatedEntities(Entity entity, string relationshipName, string logicalName);
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
-        Entity NewEntity(string entityName, OrganizationServiceContext context);
+        Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();
     }
 }

--- a/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
@@ -56,9 +56,9 @@ namespace GetIntoTeachingApiTests.Helpers
             return existingEntity;
         }
 
-        public Entity NewEntity(string entityName, OrganizationServiceContext context)
+        public Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
         {
-            var newEntity = new Entity(entityName);
+            var newEntity = id.HasValue ? new Entity(entityName, id.Value) : new Entity(entityName);
             newEntity.EntityState = EntityState.Created;
             TrackedEntities.Add(newEntity);
             return newEntity;

--- a/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
@@ -323,7 +323,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
 
             var mockEntity = new Entity("mock");
 
-            _mockService.Setup(m => m.NewEntity("mock", _context)).Returns(mockEntity);
+            _mockService.Setup(m => m.NewEntity("mock", null, _context)).Returns(mockEntity);
 
             mock.ToEntity(_crm, _context);
 
@@ -334,14 +334,14 @@ namespace GetIntoTeachingApiTests.Models.Crm
         }
 
         [Fact]
-        public void ToEntity_WhenIdIsGeneratedUpfront_CallsNewEntity()
+        public void ToEntity_WhenIdIsGeneratedUpfront_CallsNewEntityWithId()
         {
             var mock = new MockModel();
 
             mock.GenerateUpfrontId();
             mock.ToEntity(_crm, _context);
 
-            _mockService.Verify(m => m.NewEntity("mock", _context));
+            _mockService.Verify(m => m.NewEntity("mock", mock.Id, _context));
         }
 
         [Fact]
@@ -392,7 +392,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockEntity = new Entity("mock", (Guid)mock.Id);
 
             _mockService.Setup(m => m.BlankExistingEntity("mock", mockEntity.Id, _context)).Returns(mockEntity);
-            _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns<Entity>(null);
+            _mockService.Setup(m => m.NewEntity("relatedMock", null, _context)).Returns<Entity>(null);
 
             mock.ToEntity(_crm, _context);
 
@@ -411,8 +411,8 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockEntity = new Entity("mock");
             var relatedMockEntity = new Entity("mock");
 
-            _mockService.Setup(m => m.NewEntity("mock", _context)).Returns(mockEntity);
-            _mockService.Setup(m => m.NewEntity("relatedMock", _context)).Returns(relatedMockEntity);
+            _mockService.Setup(m => m.NewEntity("mock", null, _context)).Returns(mockEntity);
+            _mockService.Setup(m => m.NewEntity("relatedMock", null, _context)).Returns(relatedMockEntity);
             relatedMock.Setup(m => m.ToEntity(_crm, _context)).Returns<Entity>(null);
 
             mock.ToEntity(_crm, _context);

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -220,7 +220,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
 
             candidate.ToEntity(mockCrm.Object, context);
 
-            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", context), Times.Never);
+            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", null, context), Times.Never);
         }
 
         [Fact]
@@ -237,7 +237,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
 
             mockCrm.Verify(m => m.CandidateYetToAcceptPrivacyPolicy(
                 It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
-            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", context), Times.Never);
+            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", null, context), Times.Never);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var candidate = new Candidate() { Id = null };
             var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.NewEntity("contact", context)).Returns(candidateEntity);
+            mockCrm.Setup(m => m.NewEntity("contact", null, context)).Returns(candidateEntity);
 
             candidate.ToEntity(mockCrm.Object, context);
 

--- a/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
@@ -47,7 +47,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var entity = registration.ToEntity(mockCrm.Object, context);
 
             entity.Should().BeNull();
-            mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Never);
+            mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", null, context), Times.Never);
         }
 
         [Fact]
@@ -58,12 +58,12 @@ namespace GetIntoTeachingApiTests.Models.Crm
             var mockCrm = new Mock<ICrmService>();
             var registration = new TeachingEventRegistration() { CandidateId = Guid.NewGuid(), EventId = Guid.NewGuid() };
 
-            mockCrm.Setup(m => m.NewEntity("msevtmgt_eventregistration", context)).Returns(new Entity("msevtmgt_eventregistration"));
+            mockCrm.Setup(m => m.NewEntity("msevtmgt_eventregistration", null, context)).Returns(new Entity("msevtmgt_eventregistration"));
             mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent(registration.CandidateId, registration.EventId)).Returns(true);
 
             registration.ToEntity(mockCrm.Object, context);
 
-            mockCrm.Verify(m => m.NewEntity("msevtmgt_eventregistration", context), Times.Once);
+            mockCrm.Verify(m => m.NewEntity("msevtmgt_eventregistration", null, context), Times.Once);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/TeachingEventTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/TeachingEventTests.cs
@@ -116,7 +116,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenBuildingIsRemoved_DeletesLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", null, _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {
@@ -140,7 +140,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenEventIsNew_ReturnsEntity()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", null, _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns<TeachingEvent>(null);
 
@@ -160,7 +160,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenBuildingIsNotRemoved_DoesNotDeleteLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event",  _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", null,  _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {
@@ -184,7 +184,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
         public void ToEntity_WhenThereIsNoPreexistingRelationship_DoesNotDeleteLink()
         {
             _mockBuilding.Setup(mock => mock.ToEntity(It.IsAny<ICrmService>(), _context)).Returns(new Entity());
-            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", _context)).Returns(new Entity());
+            _mockCrm.Setup(m => m.NewEntity("msevtmgt_event", null, _context)).Returns(new Entity());
             _mockCrm.Setup(mock => mock.GetTeachingEvent("readableId"))
                 .Returns(new TeachingEvent
                 {

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -707,12 +707,21 @@ namespace GetIntoTeachingApiTests.Services
         public void NewEntity_CallsNewEntityOnService()
         {
             const string entityName = "entity";
-            var newEntity = new Entity("mock");
-            _mockService.Setup(mock => mock.NewEntity(entityName, _context)).Returns(newEntity);
 
-            var result = _crm.NewEntity(entityName, _context);
+            var result = _crm.NewEntity(entityName, null, _context);
 
-            result.Should().Be(newEntity);
+            _mockService.Verify(mock => mock.NewEntity(entityName, null, _context), Times.Once);
+        }
+
+        [Fact]
+        public void NewEntity_WithId_CallsNewEntityOnService()
+        {
+            const string entityName = "entity";
+            var id = Guid.NewGuid();
+
+            var result = _crm.NewEntity(entityName, id, _context);
+
+            _mockService.Verify(mock => mock.NewEntity(entityName, id, _context), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, when an upfront ID is generated for a model, and it is saved in the CRM, it is returned with a different ID.

We may need to create the `Entity` object with an ID in the first place before adding it to the context. :anguished:

Add an optional ID parameter that is passed down to the `OrganizationServiceAdapter`, we can pass this to the new `Entity` object.