### PR TITLE
Update dependencies ahead of .NET Core 6

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -6,14 +6,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
-		<PackageReference Include="CsvHelper" Version="27.1.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
+		<PackageReference Include="CsvHelper" Version="27.2.0" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.25" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.25" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.27" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.27" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.3" />
-		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.3.0" />
+		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.4" />
+		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
 		  <PrivateAssets>all</PrivateAssets>
@@ -30,37 +30,37 @@
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.11.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-		<PackageReference Include="dotenv.net" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+		<PackageReference Include="dotenv.net" Version="3.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
-		<PackageReference Include="Fody" Version="6.5.2">
+		<PackageReference Include="Fody" Version="6.6.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="4.0.1" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.4.21" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.10" />
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.0" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Castle.Core" Version="4.4.1" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.9" />
 	</ItemGroup>
 

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -21,12 +21,12 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.1.0" />
+	<PackageReference Include="FluentAssertions" Version="6.2.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 	<PackageReference Include="Moq" Version="4.16.1" />
-	<PackageReference Include="WireMock.Net" Version="1.4.20" />
+	<PackageReference Include="WireMock.Net" Version="1.4.27" />
 	<PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
[Trello-2649](https://trello.com/c/gckG3orM/2649-update-to-aspnet-core-6)

Update all dependencies that we can ahead of the ASP.NET Core v6 bump. A couple fail to update, I think because they require ASP.NET Core 6.