### PR TITLE
Remove feature flag for candidate sign up when CRM integration paused

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -66,12 +66,6 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
 
             if (appSettings.IsCrmIntegrationPaused)
             {
-                // Temporary. To be removed once feature is verified in other environments.
-                if (_env.IsProduction)
-                {
-                    throw new InvalidOperationException("CandidatesController#SignUp - Aborting (CRM integration paused).");
-                }
-
                 // Usually, it is best practice to allow the CRM to generate sequential GUIDs which provide better
                 // SQL performance. However, in this scenario we have agreed it is beneficial to provide the GUID up-front
                 // because the School Experience app needs the Candidate ID immediately.

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -144,19 +144,6 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         }
 
         [Fact]
-        public void SignUp_WhenProductionAndCrmIntegrationPaused_ThrowsException()
-        {
-            var request = new SchoolsExperienceSignUp { FirstName = "first" };
-            var mockAppSettings = new Mock<IAppSettings>();
-            mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
-            _mockEnv.Setup(m => m.IsProduction).Returns(true);
-
-            _controller.Invoking(c => c.SignUp(request, mockAppSettings.Object))
-               .Should().Throw<InvalidOperationException>()
-               .WithMessage("CandidatesController#SignUp - Aborting (CRM integration paused).");
-        }
-
-        [Fact]
         public void Get_WhenFound_ReturnsSchoolsExperienceSignUp()
         {
             var candidate = new Candidate() { Id = Guid.NewGuid() };


### PR DESCRIPTION
This has been tested by performing an end-to-end sign up in the test environment. The flag can now be removed.