### PR TITLE
Reduce event archive size to 4 months

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class Store : IStore
     {
-        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 9);
+        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 4);
         public static readonly HashSet<string> FailedPostcodeLookupCache = new HashSet<string>();
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;


### PR DESCRIPTION
[Trello-2675](https://trello.com/c/d6dk89B4/2675-address-why-so-many-historic-events-are-still-on-site-and-appear-in-serps)

Currently, if someone directly visits a past event on the website we allow them to view it; whilst we want to retain this for the previous 4 months of events that have an archive (Online Q&As) we don't want to let users view events that are older than that. This change makes the API consistent with the website.