### PR TITLE
Add JsonIgnore attribute to `HasUpfrontId` property

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/Crm/BaseModel.cs
@@ -23,6 +23,7 @@ namespace GetIntoTeachingApi.Models.Crm
 
         [NotMapped]
         [JsonProperty]
+        [System.Text.Json.Serialization.JsonIgnore]
         public bool HasUpfrontId { get; private set; }
         [NotMapped]
         [System.Text.Json.Serialization.JsonIgnore]


### PR DESCRIPTION
The `HasUpfrontId` property was being exposed via Swagger, adding the `JsonIgnore` attribute will prevent this.

Using the `internal` modifier seems to do the same thing, is it worth going through the project replacing all of the `JsonIgnore`s with `internal`?