### PR TITLE
Label TOTP metrics with service reference

### DIFF
--- a/GetIntoTeachingApi/Auth/ApiClientHandler.cs
+++ b/GetIntoTeachingApi/Auth/ApiClientHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
@@ -57,10 +58,15 @@ namespace GetIntoTeachingApi.Auth
 
             if (client == null)
             {
-                return new Claim[0];
+                return Array.Empty<Claim>();
             }
 
-            return new[] { new Claim("token", token), new Claim(ClaimTypes.Role, client.Role) };
+            return new[]
+            {
+                new Claim("token", token),
+                new Claim(ClaimTypes.Role, client.Role),
+                new Claim(ClaimTypes.Name, client.Name),
+            };
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Sentry;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace GetIntoTeachingApi.Controllers
@@ -52,9 +51,11 @@ namespace GetIntoTeachingApi.Controllers
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult CreateAccessToken([FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             if (!ModelState.IsValid)
             {
-                return BadRequest(this.ModelState);
+                return BadRequest(ModelState);
             }
 
             if (_appSettings.IsCrmIntegrationPaused)

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/CallbacksController.cs
@@ -75,6 +75,8 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/MailingListController.cs
@@ -82,6 +82,8 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null || !_accessTokenService.IsValid(accessToken, request, (Guid)candidate.Id))

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -156,6 +156,8 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
         public IActionResult ExchangeUnverifiedRequestForAttendee(
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null)
@@ -189,6 +191,8 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))

--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -139,6 +139,8 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -76,6 +76,8 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
             [FromRoute, SwaggerParameter("Access token (PIN code).", Required = true)] string accessToken,
             [FromBody, SwaggerRequestBody("Candidate access token request (must match an existing candidate).", Required = true)] ExistingCandidateRequest request)
         {
+            request.Reference ??= User.Identity.Name;
+
             var candidate = _crm.MatchCandidate(request);
 
             if (candidate == null || !_tokenService.IsValid(accessToken, request, (Guid)candidate.Id))

--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Models
         public string LastName { get; set; }
         public string Email { get; set; }
         public DateTime? DateOfBirth { get; set; }
+        public string Reference { get; set; }
 
         public bool IsFullMatch(Entity entity)
         {

--- a/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
+++ b/GetIntoTeachingApi/Services/CandidateAccessTokenService.cs
@@ -13,6 +13,7 @@ namespace GetIntoTeachingApi.Services
         public static readonly int VerificationWindow = 30;
         public static readonly int StepInSeconds = 30;
         private const int Length = 6;
+        private static readonly string NoReference = "None";
         private readonly IEnv _env;
         private readonly IMetricService _metrics;
         private readonly IDateTimeProvider _dateTime;
@@ -28,7 +29,7 @@ namespace GetIntoTeachingApi.Services
         {
             var totp = CreateTotp(request).ComputeTotp();
 
-            _metrics.GeneratedTotps.Inc();
+            _metrics.GeneratedTotps.WithLabels(request.Reference ?? NoReference).Inc();
 
             return totp;
         }
@@ -53,7 +54,7 @@ namespace GetIntoTeachingApi.Services
                 out _,
                 new VerificationWindow(previous: VerificationWindow, future: 0));
 
-            _metrics.VerifiedTotps.WithLabels(valid.ToString()).Inc();
+            _metrics.VerifiedTotps.WithLabels(valid.ToString(), request.Reference ?? NoReference).Inc();
 
             return valid;
         }

--- a/GetIntoTeachingApi/Services/MetricService.cs
+++ b/GetIntoTeachingApi/Services/MetricService.cs
@@ -40,11 +40,14 @@ namespace GetIntoTeachingApi.Services
                 LabelNames = new[] { "outcome" },
             });
         private static readonly Counter _generatedTotps = Metrics
-            .CreateCounter("api_generated_totps", "Number of generated timed one time passwords.");
+            .CreateCounter("api_generated_totps", "Number of generated timed one time passwords.", new CounterConfiguration
+            {
+                LabelNames = new[] { "reference" },
+            });
         private static readonly Counter _verifiedTotps = Metrics
             .CreateCounter("api_verified_totps", "Number of verified timed one time passwords.", new CounterConfiguration
             {
-                LabelNames = new[] { "valid" },
+                LabelNames = new[] { "valid", "reference" },
             });
 
         public Histogram FindApplySyncDuration => _findApplySyncDuration;

--- a/GetIntoTeachingApiTests/Auth/ApiClientHandlerTests.cs
+++ b/GetIntoTeachingApiTests/Auth/ApiClientHandlerTests.cs
@@ -61,6 +61,7 @@ namespace GetIntoTeachingApiTests.Auth
             {
                 result.Principal.HasClaim("token", "api_key").Should().BeTrue();
                 result.Principal.HasClaim(ClaimTypes.Role, "Service").Should().BeTrue();
+                result.Principal.HasClaim(ClaimTypes.Name, "Admin").Should().BeTrue();
             }
         }
 

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -36,6 +36,7 @@ namespace GetIntoTeachingApiTests.Controllers
                 _mockCrm.Object,
                 _mockAppSettings.Object,
                 _mockLogger.Object);
+            _controller.MockUser();
         }
 
         [Fact]
@@ -47,11 +48,12 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void CreateAccessToken_InvalidRequest_RespondsWithValidationErrors()
         {
-            var request = new ExistingCandidateRequest { Email = "invalid-email@" };
+            var request = new ExistingCandidateRequest { Email = "invalid-email@", Reference = "Ref" };
             _controller.ModelState.AddModelError("Email", "Email is invalid.");
 
             var response = _controller.CreateAccessToken(request);
 
+            request.Reference.Should().Be("Ref");
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
             errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
@@ -68,6 +70,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var response = _controller.CreateAccessToken(request);
 
+            request.Reference.Should().Be("Client");
             response.Should().BeOfType<NoContentResult>();
             _mockNotifyService.Verify(
                 mock => mock.SendEmailAsync(

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/CallbacksControllerTests.cs
@@ -14,6 +14,7 @@ using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApi.Controllers.GetIntoTeaching;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.GetIntoTeaching;
+using GetIntoTeachingApiTests.Helpers;
 
 namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 {
@@ -34,6 +35,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
             _mockDateTime = new Mock<IDateTimeProvider>();
             _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             _controller = new CallbacksController(_mockTokenService.Object, _mockCrm.Object, _mockDateTime.Object, _mockJobClient.Object);
+            _controller.MockUser("GIT");
 
             // Freeze time.
             _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
@@ -48,12 +50,14 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         [Fact]
         public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
         {
+            _request.Reference = "Ref";
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
             _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.ExchangeAccessToken("000000", _request);
 
+            _request.Reference.Should().Be("Ref");
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
@@ -66,6 +70,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var response = _controller.ExchangeAccessToken("000000", _request);
 
+            _request.Reference.Should().Be("GIT");
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as GetIntoTeachingCallback;
             responseModel.CandidateId.Should().Be(candidate.Id);

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/MailingListControllerTests.cs
@@ -14,6 +14,7 @@ using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApi.Controllers.GetIntoTeaching;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.GetIntoTeaching;
+using GetIntoTeachingApiTests.Helpers;
 
 namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 {
@@ -41,6 +42,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
                 _mockCrm.Object,
                 _mockJobClient.Object,
                 _mockDateTime.Object);
+            _controller.MockUser("GIT");
 
             // Freeze time.
             _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
@@ -65,12 +67,14 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         [Fact]
         public void ExchangeAccessTokenForMember_InvalidAccessToken_RespondsWithUnauthorized()
         {
+            _request.Reference = "Ref";
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
             _mockAccessTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.ExchangeAccessTokenForMember("000000", _request);
 
+            _request.Reference.Should().Be("Ref");
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
@@ -83,6 +87,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var response = _controller.ExchangeAccessTokenForMember("000000", _request);
 
+            _request.Reference.Should().Be("GIT");
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as MailingListAddMember;
             responseModel.CandidateId.Should().Be(candidate.Id);

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/TeachingEventsControllerTests.cs
@@ -49,6 +49,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
             _metrics = new MetricService();
             _controller = new TeachingEventsController(_mockStore.Object, _mockJobClient.Object,
                 _mockTokenService.Object, _mockCrm.Object, _mockLogger.Object, _metrics, _mockDateTime.Object);
+            _controller.MockUser("GIT");
 
             // Freeze time.
             _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
@@ -171,12 +172,14 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         [Fact]
         public void ExchangeAccessTokenForAttendee_InvalidAccessToken_RespondsWithUnauthorized()
         {
+            _request.Reference = "Ref";
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
             _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
 
+            _request.Reference.Should().Be("Ref");
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
@@ -189,6 +192,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var response = _controller.ExchangeAccessTokenForAttendee("000000", _request);
 
+            _request.Reference.Should().Be("GIT");
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as TeachingEventAddAttendee;
             responseModel.CandidateId.Should().Be(candidate.Id);
@@ -212,6 +216,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
 
             var response = _controller.ExchangeUnverifiedRequestForAttendee(_request);
 
+            _request.Reference.Should().Be("GIT");
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as TeachingEventAddAttendee;
             responseModel.CandidateId.Should().Be(candidate.Id);
@@ -222,10 +227,12 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching
         [Fact]
         public void ExchangeUnverifiedRequestForAttendee_MissingCandidate_RespondsWithNotFound()
         {
+            _request.Reference = "Ref";
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns<Candidate>(null);
 
             var response = _controller.ExchangeUnverifiedRequestForAttendee(_request);
 
+            _request.Reference.Should().Be("Ref");
             response.Should().BeOfType<NotFoundResult>();
         }
 

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Collections.Generic;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.SchoolsExperience;
+using GetIntoTeachingApiTests.Helpers;
 
 namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
 {
@@ -46,6 +47,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
                 _mockJobClient.Object,
                 _mockDateTime.Object,
                 _mockEnv.Object);
+            _controller.MockUser("SE");
         }
 
         [Fact]
@@ -57,12 +59,14 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         [Fact]
         public void ExchangeAccessToken_InvalidAccessToken_RespondsWithUnauthorized()
         {
+            _request.Reference = "Ref";
             var candidate = new Candidate { Id = Guid.NewGuid() };
             _mockCrm.Setup(mock => mock.MatchCandidate(_request)).Returns(candidate);
             _mockTokenService.Setup(mock => mock.IsValid("000000", _request, (Guid)candidate.Id)).Returns(false);
 
             var response = _controller.ExchangeAccessToken("000000", _request);
 
+            _request.Reference.Should().Be("Ref");
             response.Should().BeOfType<UnauthorizedResult>();
         }
 
@@ -75,6 +79,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
 
             var response = _controller.ExchangeAccessToken("000000", _request);
 
+            _request.Reference.Should().Be("SE");
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var responseModel = ok.Value as SchoolsExperienceSignUp;
             responseModel.CandidateId.Should().Be(candidate.Id);

--- a/GetIntoTeachingApiTests/Helpers/ControllerBaseExtensions.cs
+++ b/GetIntoTeachingApiTests/Helpers/ControllerBaseExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public static class ControllerBaseExtensions
+    {
+        public static void MockUser(this ControllerBase controller, string name = "Client")
+        {
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.Name, name),
+
+            }, "mock"));
+
+            controller.ControllerContext.HttpContext = new DefaultHttpContext() { User = user };
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/MetricServiceTests.cs
@@ -68,13 +68,14 @@ namespace GetIntoTeachingApiTests.Services
         public void GeneratedTotps_ReturnsMetric()
         {
             _metrics.GeneratedTotps.Name.Should().Be("api_generated_totps");
+            _metrics.GeneratedTotps.LabelNames.Should().BeEquivalentTo(new[] { "reference" });
         }
 
         [Fact]
         public void VerifiedTotps_ReturnsMetric()
         {
             _metrics.VerifiedTotps.Name.Should().Be("api_verified_totps");
-            _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "valid" });
+            _metrics.VerifiedTotps.LabelNames.Should().BeEquivalentTo(new[] { "valid", "reference" });
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-2692](https://trello.com/c/HYJoDiVp/2692-investigate-if-authentication-is-causing-significant-drop-off-on-event-sign-ups)

We want to be able to attribute TOTP-related metrics to individual services (and perhaps later to individual transactions within a service).

- Add Reference attribute to ExistingCandidateRequest

We want to be able to attribute authentication actions (generate TOTP/verify TOTP) to specific transactions; in order to do this we will get the clients to pass a reference (e.g. "Mailing List", "Event", etc).

- Add reference label to TOTP metrics

We currently track the generated/verified TOTPs; we now want to break this down by service transaction.

Add a label that can store a reference for the TOTP action and populate it in the token generation service.

- Add a new claim to store the client name

We can currently only retrieve the token/role of the authenticated client, however we need to be able to retrieve the name of the client so that we can later use it when attributing TOTP actions that occur. This will enable us to break down the TOTP actions by service (we can later make this more granular by passing the transaction name from the clients).

- Populate ExistingCandidateRequest reference

As the clients do not yet send a reference explicitly we are going to default them to the client name (which will give us a reasonable breakdown without having to update each client). If we find this is not granular enough we can update the clients to provide a reference relative to the individual transactions.