### PR TITLE
Fix various linting warnings

### DIFF
--- a/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/GeocodeClientAdapter.cs
@@ -27,7 +27,7 @@ namespace GetIntoTeachingApi.Adapters
         {
             var response = await _client.GeocodeAddress($"postcode {postcode}");
 
-            _logger.LogInformation($"Google API Status [{postcode}]: {response.StatusText}");
+            _logger.LogInformation("Google API Status [{postcode}]: {statusText}", postcode, response.StatusText);
 
             if (response.Status != GeocodeStatus.Ok)
             {

--- a/GetIntoTeachingApi/AppStart/SwaggerDefinitionsFilter.cs
+++ b/GetIntoTeachingApi/AppStart/SwaggerDefinitionsFilter.cs
@@ -24,12 +24,9 @@ namespace GetIntoTeachingApi.AppStart
 
             var schemas = swaggerDoc.Components.Schemas;
 
-            foreach (var definition in schemas)
+            foreach (var schema in schemas.Where(s => swaggerIngoredTypeNames.Contains(s.Key)))
             {
-                if (swaggerIngoredTypeNames.Contains(definition.Key))
-                {
-                    schemas.Remove(definition);
-                }
+                schemas.Remove(schema);
             }
         }
     }

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -72,7 +72,7 @@ namespace GetIntoTeachingApi.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogInformation($"CandidatesController - potential duplicate (CRM exception) - {e.Message}");
+                _logger.LogInformation("CandidatesController - potential duplicate (CRM exception) - {message}", e.Message);
                 throw;
             }
 

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -73,7 +73,7 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
 
             if (request.Postcode != null)
             {
-                _logger.LogInformation($"SearchGroupedByType: {request.Postcode}");
+                _logger.LogInformation("SearchGroupedByType: {postcode}", request.Postcode);
             }
 
             var teachingEvents = await _store.SearchTeachingEventsAsync(request);

--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -25,22 +25,19 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         private readonly ICandidateUpserter _upserter;
         private readonly IBackgroundJobClient _jobClient;
         private readonly IDateTimeProvider _dateTime;
-        private readonly IEnv _env;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             ICandidateUpserter upserter,
             IBackgroundJobClient jobClient,
-            IDateTimeProvider dateTime,
-            IEnv env)
+            IDateTimeProvider dateTime)
         {
             _crm = crm;
             _upserter = upserter;
             _tokenService = tokenService;
             _jobClient = jobClient;
             _dateTime = dateTime;
-            _env = env;
         }
 
         [HttpPost]

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContextFactory.cs
@@ -30,7 +30,7 @@ namespace GetIntoTeachingApi.Database
             return new GetIntoTeachingDbContext(optionsBuilder.Options);
         }
 
-        private void MockRequiredEnvironment()
+        private static void MockRequiredEnvironment()
         {
             // We need to be able to generate a valid connection string
             // when creating migrations (even though the DB is never called).

--- a/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
+++ b/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
@@ -39,8 +39,8 @@ namespace GetIntoTeachingApi.Jobs
                 throw new InvalidOperationException("ClaimCallbackBookingSlotJob - Aborting (CRM integration paused).");
             }
 
-            _logger.LogInformation($"ClaimCallbackBookingSlotJob - Started ({AttemptInfo(context, _contextAdapter)})");
-            _logger.LogInformation($"ClaimCallbackBookingSlotJob - Payload {scheduledAt}");
+            _logger.LogInformation("ClaimCallbackBookingSlotJob - Started ({attempt})", AttemptInfo(context, _contextAdapter));
+            _logger.LogInformation("ClaimCallbackBookingSlotJob - Payload {scheduledAt}", scheduledAt);
 
             if (IsLastAttempt(context, _contextAdapter))
             {
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApi.Jobs
                     _crm.Save(quota);
                 }
 
-                _logger.LogInformation($"ClaimCallbackBookingSlotJob - Succeeded - {scheduledAt}");
+                _logger.LogInformation("ClaimCallbackBookingSlotJob - Succeeded - {scheduledAt}", scheduledAt);
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;

--- a/GetIntoTeachingApi/Jobs/FindApplyBackfillJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyBackfillJob.cs
@@ -54,7 +54,7 @@ namespace GetIntoTeachingApi.Jobs
             while (paginator.HasNext)
             {
                 var response = await paginator.NextAsync();
-                _logger.LogInformation($"FindApplyBackfillJob - Syncing {response.Data.Count()} Candidates");
+                _logger.LogInformation("FindApplyBackfillJob - Syncing {count} Candidates", response.Data.Count());
                 response.Data.ForEach(c => _jobClient.Schedule<FindApplyCandidateSyncJob>(x => x.Run(c), TimeSpan.FromMinutes(30)));
             }
         }

--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -37,9 +37,9 @@ namespace GetIntoTeachingApi.Jobs
                 throw new InvalidOperationException("FindApplyCandidateSyncJob - Aborting (CRM integration paused).");
             }
 
-            _logger.LogInformation($"FindApplyCandidateSyncJob - Started - {findApplyCandidate.Id}");
+            _logger.LogInformation("FindApplyCandidateSyncJob - Started - {id}", findApplyCandidate.Id);
             SyncCandidate(findApplyCandidate);
-            _logger.LogInformation($"FindApplyCandidateSyncJob - Succeeded - {findApplyCandidate.Id}");
+            _logger.LogInformation("FindApplyCandidateSyncJob - Succeeded - {id}", findApplyCandidate.Id);
         }
 
         public void SyncCandidate(Candidate findApplyCandidate)
@@ -56,8 +56,9 @@ namespace GetIntoTeachingApi.Jobs
         private Models.Crm.Candidate Candidate(Candidate findApplyCandidate, IEnumerable<ApplicationForm> findApplyApplicationForms)
         {
             var match = _crm.MatchCandidate(findApplyCandidate.Attributes.Email);
+            var status = match == null ? "Miss" : "Hit";
 
-            _logger.LogInformation($"FindApplyCandidateSyncJob - {(match == null ? "Miss" : "Hit")} - {findApplyCandidate.Id}");
+            _logger.LogInformation("FindApplyCandidateSyncJob - {status} - {id}", status, findApplyCandidate.Id);
 
             // We persist a new Candidate to ensure we only write the find/apply
             // attributes back to the CRM and not existing attributes on the match.

--- a/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
@@ -62,7 +62,7 @@ namespace GetIntoTeachingApi.Jobs
             while (paginator.HasNext)
             {
                 var response = await paginator.NextAsync();
-                _logger.LogInformation($"FindApplySyncJob - Syncing {response.Data.Count()} Candidates");
+                _logger.LogInformation("FindApplySyncJob - Syncing {count} Candidates", response.Data.Count());
                 response.Data.ForEach(c => _jobClient.Enqueue<FindApplyCandidateSyncJob>(x => x.Run(c)));
             }
         }

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -57,7 +57,7 @@ namespace GetIntoTeachingApi.Jobs
         private void GenerateTokens()
         {
             var candidates = _crm.GetCandidatesPendingMagicLinkTokenGeneration(BatchSize);
-            _logger.LogInformation($"MagicLinkTokenGenerationJob - Processing ({candidates.Count()})");
+            _logger.LogInformation("MagicLinkTokenGenerationJob - Processing ({count})", candidates.Count());
 
             foreach (var match in candidates)
             {

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -44,8 +44,8 @@ namespace GetIntoTeachingApi.Jobs
                 throw new InvalidOperationException("UpsertCandidateJob - Aborting (CRM integration paused).");
             }
 
-            _logger.LogInformation($"UpsertCandidateJob - Started ({AttemptInfo(context, _contextAdapter)})");
-            _logger.LogInformation($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
+            _logger.LogInformation("UpsertCandidateJob - Started ({attempt})", AttemptInfo(context, _contextAdapter));
+            _logger.LogInformation("UpsertCandidateJob - Payload {payload}", Redactor.RedactJson(json));
 
             var candidate = json.DeserializeChangeTracked<Candidate>();
 
@@ -64,7 +64,7 @@ namespace GetIntoTeachingApi.Jobs
             {
                 _upserter.Upsert(candidate);
 
-                _logger.LogInformation($"UpsertCandidateJob - Succeeded - {candidate.Id}");
+                _logger.LogInformation("UpsertCandidateJob - Succeeded - {id}", candidate.Id);
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;

--- a/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
@@ -47,8 +47,8 @@ namespace GetIntoTeachingApi.Jobs
                 throw new InvalidOperationException($"UpsertModelJob<{typeName}> - Aborting (CRM integration paused).");
             }
 
-            _logger.LogInformation($"UpsertModelJob<{typeName}> - Started ({AttemptInfo(context, _contextAdapter)})");
-            _logger.LogInformation($"UpsertModelJob<{typeName}> - Payload {Redactor.RedactJson(json)}");
+            _logger.LogInformation("UpsertModelJob<{typeName}> - Started ({attempt})", typeName, AttemptInfo(context, _contextAdapter));
+            _logger.LogInformation("UpsertModelJob<{typeName}> - Payload {payload}", typeName, Redactor.RedactJson(json));
 
             var model = json.DeserializeChangeTracked<T>();
 
@@ -67,13 +67,13 @@ namespace GetIntoTeachingApi.Jobs
                         personalisation);
                 }
 
-                _logger.LogInformation($"UpsertModelJob<{typeName}> - Deleted");
+                _logger.LogInformation("UpsertModelJob<{typeName}> - Deleted", typeName);
             }
             else
             {
                 _crm.Save(model);
 
-                _logger.LogInformation($"UpsertModelJob<{typeName}> - Succeeded - {model.Id}");
+                _logger.LogInformation("UpsertModelJob<{typeName}> - Succeeded - {id}", typeName, model.Id);
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;

--- a/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
@@ -64,7 +64,7 @@ namespace GetIntoTeachingApi.Middleware
                 Payload = ConstructPayload(request, payload),
             };
 
-            _logger.LogInformation($"{identifier}: {info}");
+            _logger.LogInformation("{identifier}: {info}", identifier, info);
         }
 
         private string ConstructPayload(HttpRequest request, string payload)

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -61,9 +61,7 @@ namespace GetIntoTeachingApi.Models.Crm
 
         public enum SubscriptionChannel
         {
-            TeacherTrainingAdviser = 222750000,
-            MailingList = 222750000,
-            Events = 222750000,
+            Subscribed = 222750000,
         }
 
         public enum SubscriptionType

--- a/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
+++ b/GetIntoTeachingApi/Models/ExistingCandidateRequest.cs
@@ -35,12 +35,7 @@ namespace GetIntoTeachingApi.Models
             return string.Join("-", attributes).ToLower();
         }
 
-        private bool EmailMatchesCandidate(Entity entity)
-        {
-            return entity.GetAttributeValue<string>("emailaddress1").Trim().Equals(Email, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private string[] AdditionalAttributeValues(string firstName, string lastName, DateTime? dateOfBirth)
+        private static string[] AdditionalAttributeValues(string firstName, string lastName, DateTime? dateOfBirth)
         {
             return new[]
                 {
@@ -50,6 +45,11 @@ namespace GetIntoTeachingApi.Models
                 }
                 .Where(s => s != null)
                 .ToArray();
+        }
+
+        private bool EmailMatchesCandidate(Entity entity)
+        {
+            return entity.GetAttributeValue<string>("emailaddress1").Trim().Equals(Email, StringComparison.OrdinalIgnoreCase);
         }
 
         private bool MinimumAdditionalAttributesMatch(Entity entity)

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -114,6 +114,22 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             return Enum.IsDefined(typeof(ResubscribableAdviserStatus), candidate.AdviserStatusId);
         }
 
+        private static void DefaultPreferredEducationPhase(Candidate candidate)
+        {
+            if (candidate.IsReturningToTeaching())
+            {
+                candidate.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
+            }
+        }
+
+        private static void DefaultPreferredTeachingSubjectId(Candidate candidate)
+        {
+            if (candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
+            {
+                candidate.PreferredTeachingSubjectId = LookupItem.PrimaryTeachingSubjectId;
+            }
+        }
+
         private void PopulateWithCandidate(Candidate candidate)
         {
             CandidateId = candidate.Id;
@@ -240,22 +256,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             if (CandidateId == null)
             {
                 candidate.ChannelId = ChannelId ?? (int?)Candidate.Channel.TeacherTrainingAdviser;
-            }
-        }
-
-        private void DefaultPreferredEducationPhase(Candidate candidate)
-        {
-            if (candidate.IsReturningToTeaching())
-            {
-                candidate.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
-            }
-        }
-
-        private void DefaultPreferredTeachingSubjectId(Candidate candidate)
-        {
-            if (candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Primary)
-            {
-                candidate.PreferredTeachingSubjectId = LookupItem.PrimaryTeachingSubjectId;
             }
         }
 

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -117,7 +117,8 @@ namespace GetIntoTeachingApi.Services
             {
                 entity = entities.FirstOrDefault(request.IsEmailMatch);
 
-                _logger.LogInformation($"MatchCandidate - EmailMatch - {(entity == null ? "Miss" : "Hit")}");
+                var status = entity == null ? "Miss" : "Hit";
+                _logger.LogInformation("MatchCandidate - EmailMatch - {status}", status);
             }
 
             if (entity == null)
@@ -154,7 +155,7 @@ namespace GetIntoTeachingApi.Services
             // Avoids a potentially very expensive query.
             if (string.IsNullOrEmpty(magicLinkToken))
             {
-                return new Candidate[0];
+                return Array.Empty<Candidate>();
             }
 
             var query = new QueryExpression("contact");

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApi.Services
 
         public Task SendEmailAsync(string email, string templateId, Dictionary<string, dynamic> personalisation)
         {
-            _logger.LogInformation($"NotifyService - Sending Email ({TemplateDescription(templateId)})");
+            _logger.LogInformation("NotifyService - Sending Email ({template})", TemplateDescription(templateId));
 
             return _client.SendEmailAsync(
                 ApiKey(),
@@ -39,7 +39,7 @@ namespace GetIntoTeachingApi.Services
                 templateId,
                 personalisation)
             .ContinueWith(
-                task => _logger.LogWarning($"NotifyService - Failed to send email: {task.Exception?.Message}"),
+                task => _logger.LogWarning("NotifyService - Failed to send email: {message}", task.Exception?.Message),
                 TaskContinuationOptions.OnlyOnFaulted);
         }
 

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -18,7 +18,7 @@ namespace GetIntoTeachingApi.Services
     public class Store : IStore
     {
         public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 4);
-        public static readonly HashSet<string> FailedPostcodeLookupCache = new HashSet<string>();
+        private static readonly HashSet<string> FailedPostcodeLookupCache = new HashSet<string>();
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;
         private readonly ICrmService _crm;
@@ -37,6 +37,11 @@ namespace GetIntoTeachingApi.Services
             _crm = crm;
             _dateTime = dateTime;
             _env = env;
+        }
+
+        public static void ClearFailedPostcodeLookupCache()
+        {
+            FailedPostcodeLookupCache.Clear();
         }
 
         public async Task<string> CheckStatusAsync()

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -8,7 +8,7 @@ namespace GetIntoTeachingApi.Services
         public static void SubscribeToMailingList(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasMailingListSubscription = true;
-            candidate.MailingListSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.MailingList;
+            candidate.MailingListSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.MailingListSubscriptionStartAt = utcNow;
             candidate.MailingListSubscriptionDoNotEmail = false;
             candidate.MailingListSubscriptionDoNotBulkEmail = false;
@@ -27,7 +27,7 @@ namespace GetIntoTeachingApi.Services
         public static void SubscribeToEvents(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasEventsSubscription = true;
-            candidate.EventsSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Events;
+            candidate.EventsSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.EventsSubscriptionStartAt = utcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
             candidate.EventsSubscriptionDoNotBulkEmail = false;
@@ -55,7 +55,7 @@ namespace GetIntoTeachingApi.Services
         public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow, int? channelId = null)
         {
             candidate.HasTeacherTrainingAdviserSubscription = true;
-            candidate.TeacherTrainingAdviserSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.TeacherTrainingAdviser;
+            candidate.TeacherTrainingAdviserSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.TeacherTrainingAdviserSubscriptionStartAt = utcNow;
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();

--- a/GetIntoTeachingApi/Utils/BombFoundException.cs
+++ b/GetIntoTeachingApi/Utils/BombFoundException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace GetIntoTeachingApi.Utils
 {
+    [Serializable]
     public class BombFoundException : Exception
     {
         public BombFoundException()
@@ -15,6 +17,11 @@ namespace GetIntoTeachingApi.Utils
 
         public BombFoundException(string message, Exception inner)
             : base(message, inner)
+        {
+        }
+
+        protected BombFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -67,7 +67,7 @@ namespace GetIntoTeachingApi.Utils
             return Environment.GetEnvironmentVariable(variable);
         }
 
-        private ApplicationServices AppServices
+        private static ApplicationServices AppServices
         {
             get
             {
@@ -76,7 +76,7 @@ namespace GetIntoTeachingApi.Utils
             }
         }
 
-        private class ApplicationServices
+        private sealed class ApplicationServices
         {
             [JsonPropertyName("application_name")]
             public string ApplicationName { get; set; }

--- a/GetIntoTeachingApi/Utils/GeometryExtensions.cs
+++ b/GetIntoTeachingApi/Utils/GeometryExtensions.cs
@@ -50,7 +50,7 @@ namespace GetIntoTeachingApi.Utils
             return result;
         }
 
-        private class MathTransformFilter : ICoordinateSequenceFilter
+        private sealed class MathTransformFilter : ICoordinateSequenceFilter
         {
             private readonly MathTransform _transform;
 

--- a/GetIntoTeachingApiTests/Contracts/TeacherTrainingAdviserTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/TeacherTrainingAdviserTests.cs
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApiTests.Contracts
 
             var snapshot = SortEntities(JArray.Parse(File.ReadAllText(outputFile)));
 
-            request.Should().HaveCount(snapshot.Count());
+            request.Should().HaveCount(snapshot.Count);
             request.Should().BeEquivalentTo(snapshot);
         }
 
@@ -97,6 +97,12 @@ namespace GetIntoTeachingApiTests.Contracts
             return Path.Combine(Directory.GetCurrentDirectory(), relativePath);
         }
 
+        private static ContractTestState GetContractTestState()
+        {
+            var json = File.ReadAllText("./Contracts/Data/state.json");
+            return JsonConvert.DeserializeObject<ContractTestState>(json);
+        }
+
         private string RequestJson()
         {
             var trackedEntities = _factory.ContractOrganizationServiceAdapter.TrackedEntities;
@@ -108,12 +114,6 @@ namespace GetIntoTeachingApiTests.Contracts
             await SeedPickListItems();
             await SeedLookupItems();
             await SeedPrivacyPolicy();
-        }
-
-        private ContractTestState GetContractTestState()
-        {
-            var json = File.ReadAllText("./Contracts/Data/state.json");
-            return JsonConvert.DeserializeObject<ContractTestState>(json);
         }
 
         private async Task SeedPickListItems()

--- a/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/OperationsControllerTests.cs
@@ -58,7 +58,7 @@ namespace GetIntoTeachingApiTests.Controllers
 
             var ok = response.Should().BeOfType<OkObjectResult>().Subject;
             var mappings = ok.Value.Should().BeOfType<List<MappingInfo>>().Subject;
-            mappings.Count().Should().Be(13);
+            mappings.Count.Should().Be(13);
             mappings.Any(m => m.LogicalName == "contact" &&
                               m.Class == "GetIntoTeachingApi.Models.Crm.Candidate"
             ).Should().BeTrue();

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -27,7 +27,6 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<ICandidateUpserter> _mockUpserter;
         private readonly Mock<IDateTimeProvider> _mockDateTime;
-        private readonly Mock<IEnv> _mockEnv;
         private readonly CandidatesController _controller;
         private readonly ExistingCandidateRequest _request;
 
@@ -38,15 +37,13 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockUpserter = new Mock<ICandidateUpserter>();
             _mockDateTime = new Mock<IDateTimeProvider>();
-            _mockEnv = new Mock<IEnv>();
             _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
             _controller = new CandidatesController(
                 _mockTokenService.Object,
                 _mockCrm.Object,
                 _mockUpserter.Object,
                 _mockJobClient.Object,
-                _mockDateTime.Object,
-                _mockEnv.Object);
+                _mockDateTime.Object);
             _controller.MockUser("SE");
         }
 
@@ -192,7 +189,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         [Fact]
         public void Get_WhenNotFound_ReturnsEmpty()
         {
-            _mockCrm.Setup(mock => mock.GetCandidates(It.IsAny<IEnumerable<Guid>>())).Returns(new Candidate[0]);
+            _mockCrm.Setup(mock => mock.GetCandidates(It.IsAny<IEnumerable<Guid>>())).Returns(Array.Empty<Candidate>());
 
             var response = _controller.GetMultiple(new Guid[] { Guid.NewGuid() });
 

--- a/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
+++ b/GetIntoTeachingApiTests/Helpers/DatabaseTests.cs
@@ -29,6 +29,8 @@ namespace GetIntoTeachingApiTests.Helpers
                 // StoreTests.CheckStatusAsync_WhenUnhealthy_ReturnsError
                 // disposes of the connection prematurely as part of the test.
             }
+
+            GC.SuppressFinalize(this);
         }
 
         private void SetupDbContext(string databaseName)

--- a/GetIntoTeachingApiTests/Helpers/QueryableExtensions.cs
+++ b/GetIntoTeachingApiTests/Helpers/QueryableExtensions.cs
@@ -53,6 +53,8 @@ namespace GetIntoTeachingApiTests.Helpers
 
             public ValueTask DisposeAsync()
             {
+                GC.SuppressFinalize(this);
+
                 return new ValueTask();
             }
 

--- a/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
@@ -95,7 +95,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 .WithMessage("ClaimCallbackBookingSlotJob - Aborting (CRM integration paused).");
         }
 
-        private bool IsMatch(object objectA, object objectB)
+        private static bool IsMatch(object objectA, object objectB)
         {
             objectA.Should().BeEquivalentTo(objectB);
             return true;

--- a/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
@@ -78,7 +78,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockJobClient.Verify(x => x.Create(
                It.Is<Job>(job => job.Type == typeof(FindApplyCandidateSyncJob) && job.Method.Name == "Run"),
-               It.IsAny<EnqueuedState>()), Times.Exactly(candidates.Count()));
+               It.IsAny<EnqueuedState>()), Times.Exactly(candidates.Length));
 
             _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Started");
             _mockLogger.VerifyInformationWasCalled("FindApplySyncJob - Syncing 2 Candidates");
@@ -121,7 +121,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             using (var httpTest = new HttpTest())
             {
-                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                var response = new Response<IEnumerable<Candidate>>() { Data = Array.Empty<Candidate>() };
                 MockResponse(httpTest, lastSyncAt, response);
                 await _job.RunAsync();
             }
@@ -145,7 +145,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             using (var httpTest = new HttpTest())
             {
-                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                var response = new Response<IEnumerable<Candidate>>() { Data = Array.Empty<Candidate>() };
                 MockResponse(httpTest, now, response);
                 await _job.RunAsync();
             }
@@ -165,7 +165,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             using (var httpTest = new HttpTest())
             {
-                var response = new Response<IEnumerable<Candidate>>() { Data = new Candidate[0] };
+                var response = new Response<IEnumerable<Candidate>>() { Data = Array.Empty<Candidate>() };
                 MockResponse(httpTest, lastSyncAt, response);
                 await _job.RunAsync();
             }

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -85,7 +85,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 .WithMessage("UpsertCandidateJob - Aborting (CRM integration paused).");
         }
 
-        private bool IsMatch(object objectA, object objectB)
+        private static bool IsMatch(object objectA, object objectB)
         {
             objectA.Should().BeEquivalentTo(objectB);
             return true;

--- a/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 .WithMessage("UpsertModelJob<CandidatePrivacyPolicy> - Aborting (CRM integration paused).");
         }
 
-        private bool IsMatch(object objectA, object objectB)
+        private static bool IsMatch(object objectA, object objectB)
         {
             objectA.Should().BeEquivalentTo(objectB);
             return true;

--- a/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
+++ b/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -22,7 +23,7 @@ namespace GetIntoTeachingApiTests.Middleware
         {
             _mockLogger = new Mock<ILogger<RequestResponseLoggingMiddleware>>();
             _mockConfig = new Mock<IRequestResponseLoggingConfiguration>();
-            _mockConfig.Setup(m => m.CompactLoggingPatterns).Returns(new Regex[0]);
+            _mockConfig.Setup(m => m.CompactLoggingPatterns).Returns(Array.Empty<Regex>());
             _context = new DefaultHttpContext();
 
             _context.Request.Scheme = "https";

--- a/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/BaseModelTests.cs
@@ -365,7 +365,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             mockEntity.GetAttributeValue<OptionSetValue>("dfe_field2").Should().BeNull();
             mockEntity.GetAttributeValue<string>("dfe_field3").Should().BeNull();
 
-            var numberOfChangedAttributes = mockEntity.Attributes.Count();
+            var numberOfChangedAttributes = mockEntity.Attributes.Count;
             numberOfChangedAttributes.Should().Be(3);
         }
 
@@ -380,7 +380,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
 
             mock.ToEntity(_crm, _context);
 
-            var numberOfChangedAttributes = mockEntity.Attributes.Count();
+            var numberOfChangedAttributes = mockEntity.Attributes.Count;
             numberOfChangedAttributes.Should().Be(2);
         }
 

--- a/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateMagicLinkTokenServiceTests.cs
@@ -110,7 +110,7 @@ namespace GetIntoTeachingApiTests.Services
         public void Exchange_WhenTokenDoesNotMatch_ReturnsFailure()
         {
             var token = Guid.NewGuid().ToString();
-            _mockCrm.Setup(m => m.MatchCandidates(token)).Returns(new Candidate[0]);
+            _mockCrm.Setup(m => m.MatchCandidates(token)).Returns(Array.Empty<Candidate>());
 
             var result = _service.Exchange(token);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -370,7 +370,7 @@ namespace GetIntoTeachingApiTests.Services
         {
             var ids = new Guid[] { Guid.NewGuid() };
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyGetCandidatesQueryExpression(q, ids)))).Returns(new Entity[0]);
+                q => VerifyGetCandidatesQueryExpression(q, ids)))).Returns(Array.Empty<Entity>());
 
             var result = _crm.GetCandidate(ids.First());
 
@@ -414,9 +414,9 @@ namespace GetIntoTeachingApiTests.Services
         [Fact]
         public void GetCandidates_WithEmptyArray_ReturnsEmpty()
         {
-            var ids = new Guid[0];
+            var ids = Array.Empty<Guid>();
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyGetCandidatesQueryExpression(q, ids)))).Returns(new Entity[0]);
+                q => VerifyGetCandidatesQueryExpression(q, ids)))).Returns(Array.Empty<Entity>());
 
             var result = _crm.GetCandidates(ids);
 

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -36,7 +36,7 @@ namespace GetIntoTeachingApiTests.Services
             _mockEnv = new Mock<IEnv>();
             _store = new Store(DbContext, _mockGeocodeClient.Object, _mockCrm.Object, new DateTimeProvider(), _mockEnv.Object);
 
-            Store.FailedPostcodeLookupCache.Clear();
+            Store.ClearFailedPostcodeLookupCache();
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace GetIntoTeachingApiTests.Services
             await SeedMockTeachingEventBuildingsAsync();
             SeedMockLocations();
 
-            Store.FailedPostcodeLookupCache.Clear();
+            Store.ClearFailedPostcodeLookupCache();
 
             _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(MockTeachingEvents);
 
@@ -181,7 +181,7 @@ namespace GetIntoTeachingApiTests.Services
             await SeedMockTeachingEventBuildingsAsync();
             SeedMockLocations();
 
-            Store.FailedPostcodeLookupCache.Clear();
+            Store.ClearFailedPostcodeLookupCache();
 
             _mockCrm.Setup(m => m.GetTeachingEvents(It.Is<DateTime>(d => CheckGetTeachingEventsAfterDate(d)))).Returns(MockTeachingEvents);
             var postcode = "TE7 9IN";

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -16,7 +16,7 @@ namespace GetIntoTeachingApiTests.Services
             SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow);
 
             candidate.HasMailingListSubscription.Should().BeTrue();
-            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.MailingList);
+            candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
             candidate.MailingListSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
             candidate.MailingListSubscriptionDoNotBulkEmail.Should().BeFalse();
             candidate.MailingListSubscriptionDoNotBulkPostalMail.Should().BeTrue();
@@ -69,7 +69,7 @@ namespace GetIntoTeachingApiTests.Services
             SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow);
 
             candidate.HasEventsSubscription.Should().BeTrue();
-            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Events);
+            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
             candidate.EventsSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
             candidate.EventsSubscriptionDoNotBulkEmail.Should().BeFalse();
             candidate.EventsSubscriptionDoNotBulkPostalMail.Should().BeTrue();
@@ -138,7 +138,7 @@ namespace GetIntoTeachingApiTests.Services
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
             candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeFalse();
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeTrue();
@@ -158,7 +158,7 @@ namespace GetIntoTeachingApiTests.Services
             SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
             candidate.HasTeacherTrainingAdviserSubscription.Should().BeTrue();
-            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.TeacherTrainingAdviser);
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
             candidate.TeacherTrainingAdviserSubscriptionStartAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail.Should().BeTrue();
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkPostalMail.Should().BeTrue();


### PR DESCRIPTION
[Trello-2742](https://trello.com/c/WMMOuQeh/2742-improve-linting-in-the-api)

SonarCloud has highlighted a number of code issues, namely:

- Methods that could be static
- Private classes that should be `sealed`
- Use of Array.Empty
- Logging message template varying between calls
- LINQ tweaks/avoiding unnecessary `Count()`
- An enum with the same values
- Exceptions adhearing to `ISerializable`
- Calling `GC.SuppressFinalize` on `Dispose`

There are a few more to look at but I'll address those separately.