### PR TITLE
Grafana directory traversal

### DIFF
--- a/terraform/paas/monitoring.tf
+++ b/terraform/paas/monitoring.tf
@@ -36,7 +36,7 @@ module "prometheus" {
   grafana_json_dashboards           = [for f in local.dashboard_list : file(f)]
   grafana_extra_datasources         = [for f in local.datasource_list : templatefile(f, local.template_variable_map)]
   grafana_google_jwt                = lookup( local.monitoring_secrets , "GOOGLE_JWT" , "" )
-  grafana_runtime_version           = "7.2.2"
+  grafana_runtime_version           = "8.3.2"
   prometheus_memory                 = 5120
   prometheus_disk_quota             = 5120
   internal_apps                     = var.monitor_scrape_applications


### PR DESCRIPTION
CVE-2021-43798 - Update Grafana to 8.3.2

Grafana versions 8.0.0-beta1 through 8.3.0 (except for patched versions) iss vulnerable to directory traversal, allowing access to local files. The vulnerable URL path is: `<grafana_host_url>/public/plugins//`, where is the plugin ID for any installed plugin.  Users are advised to upgrade to patched versions 8.0.7, 8.1.8, 8.2.7, or 8.3.1. 

This is a low risk to us as we are containerised and there is no secure data available.However, it has been decided to bring Grafana into line with the latest version.