### PR TITLE
Get candidates with different primary and secondary phone numbers

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -125,6 +125,25 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
             return Ok(signUps);
         }
 
+        // Temporary method. Currently, we use secondary phone number in School Experience if primary number already has a value.
+        // Going forward we want to use primary phone number only. This method is used to retrieve all School Experience candidates
+        // with primary and secondary phone numbers that are different, because these will be negatively impacted by the change (we
+        // will be assuming that their primary phone number is the most up to date, but it will actually be their secondary phone
+        // number)
+        [HttpGet]
+        [Route("different-phone-numbers")]
+        [SwaggerOperation(
+          Summary = "Find all candidates with different primary and seconary phone numbers.",
+          OperationId = "GetSchoolsExperienceDifferentPhoneNumbers",
+          Tags = new[] { "Schools Experience" })]
+        [ProducesResponseType(typeof(IEnumerable<SchoolsExperienceSignUp>), StatusCodes.Status200OK)]
+        public IActionResult GetCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(int pageNumber, int count)
+        {
+            var candidates = _crm.GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(pageNumber, count);
+
+            return Ok(candidates);
+        }
+
         [HttpPost]
         [Route("exchange_access_token/{accessToken}")]
         [SwaggerOperation(

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -197,6 +197,33 @@ namespace GetIntoTeachingApi.Services
             return entities.Select((entity) => new Candidate(entity, this, _validatorFactory));
         }
 
+        // Temporary method. Currently, we use secondary phone number in School Experience if primary number already has a value.
+        // Going forward we want to use primary phone number only. This method is used to retrieve all School Experience candidates
+        // with primary and secondary phone numbers that are different, because these will be negatively impacted by the change (we
+        // will be assuming that their primary phone number is the most up to date, but it will actually be their secondary phone
+        // number)
+        public IEnumerable<Candidate> GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(int pageNumber, int count)
+        {
+            var query = new QueryExpression("contact")
+            {
+                PageInfo = new PagingInfo
+                {
+                    PageNumber = pageNumber,
+                    Count = count
+                }
+            };
+            query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(Candidate)));
+
+            query.Criteria.AddCondition(new ConditionExpression("dfe_notesforclassroomexperience", ConditionOperator.NotNull));
+            query.Criteria.AddCondition(new ConditionExpression("telephone1", ConditionOperator.NotNull));
+            query.Criteria.AddCondition(new ConditionExpression("telephone2", ConditionOperator.NotNull));
+            query.Criteria.AddCondition(new ConditionExpression("telephone1", ConditionOperator.NotEqual, true, "telephone2"));
+
+            var entities = _service.RetrieveMultiple(query);
+
+            return entities.Select((entity) => new Candidate(entity, this, _validatorFactory));
+        }
+
         public IEnumerable<Candidate> GetCandidatesPendingMagicLinkTokenGeneration(int limit = 10)
         {
             var query = new QueryExpression("contact");

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -34,5 +34,6 @@ namespace GetIntoTeachingApi.Services
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);
         Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context);
         IEnumerable<TeachingEventBuilding> GetTeachingEventBuildings();
+        IEnumerable<Candidate> GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(int pageNumber, int count);
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -286,6 +286,23 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
                 .WithMessage("New feature under development");
         }
 
+        [Fact]
+        public void GetCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers_ReturnsCandidates()
+        {
+            var candidates = new Candidate[]
+            {
+                new Candidate() { Telephone = "07777777777", SecondaryTelephone = "07999999999" },
+                new Candidate() { Telephone = "07777777777", SecondaryTelephone = "07888888888" },
+            };
+            _mockCrm.Setup(mock => mock.GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(1, 2)).Returns(candidates);
+
+            var response = _controller.GetCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(1, 2);
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var candidatesResponse = ok.Value.Should().BeAssignableTo<IEnumerable<Candidate>>().Subject;
+            candidatesResponse.Should().BeEquivalentTo(candidates);
+        }
+
         private static bool IsMatch(Candidate candidateA, string candidateBJson)
         {
             var candidateB = candidateBJson.DeserializeChangeTracked<Candidate>();

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -764,6 +764,37 @@ namespace GetIntoTeachingApiTests.Services
                 new Relationship("msevtmgt_event_building"), _context), Times.Never);
         }
 
+        [Fact]
+        public void GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers_ReturnsCandidates()
+        {
+            const int pageNumber = 1;
+            const int count = 500;
+            _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
+                q => VerifyGetCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbersQueryExpression(q, pageNumber, count)))).Returns(MockCandidates());
+
+            var result = _crm.GetSchoolExperienceCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbers(pageNumber, count);
+
+            result.Should().NotBeNull();
+        }
+
+        private static bool VerifyGetCandidatesWithDifferentPrimaryAndSecondaryPhoneNumbersQueryExpression(QueryExpression query, int pageNumber, int count)
+        {
+            var hasEntityName = query.EntityName == "contact";
+            var hasPagination = query.PageInfo.PageNumber == pageNumber && query.PageInfo.Count == count;
+            var conditions = query.Criteria.Conditions;
+
+            var hasPhoneNotNullCondition = conditions.Any(c => c.AttributeName == "telephone1" &&
+                c.Operator == ConditionOperator.NotNull);
+            var hasSecondPhoneNotNullCondition = conditions.Any(c => c.AttributeName == "telephone2" &&
+               c.Operator == ConditionOperator.NotNull);
+            var hasSchoolExperienceNotesNotNullCondition = conditions.Any(c => c.AttributeName == "dfe_notesforclassroomexperience" &&
+               c.Operator == ConditionOperator.NotNull);
+            var hasPhoneDoesNotEqualSecondPhoneCondition = conditions.Any(c => c.AttributeName == "telephone1" &&
+               c.Operator == ConditionOperator.NotEqual && c.CompareColumns && c.Values.Contains("telephone2"));
+
+            return hasEntityName && hasSecondPhoneNotNullCondition && hasSchoolExperienceNotesNotNullCondition && hasPhoneDoesNotEqualSecondPhoneCondition && hasPagination;
+        }
+
         private static bool VerifyMatchEventWithReadableIdQueryExpression(QueryExpression query, string readableId)
         {
             var hasEntityName = query.EntityName == "msevtmgt_event";


### PR DESCRIPTION
Currently, we use secondary phone number in School Experience if primary number already has a value.  Going forward we have agreed to use primary phone number only. 

This endpoint will be used to retrieve all School Experience candidates with primary and secondary phone numbers that are different, because these will be negatively impacted by the change (we will be assuming that their primary phone number is the most up to date, but it will actually be their secondary phone number).

This endpoint will be removed once we have retrieved the candidates from production and passed them on to the CRM team.