### PR TITLE
Remove unused fields from the SchoolExperienceSignUp

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperience/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperience/SchoolsExperienceSignUp.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Services;
@@ -24,7 +22,6 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
         [SwaggerSchema(ReadOnly = true)]
         public string FullName { get; set; }
         public string Email { get; set; }
-        public string SecondaryEmail { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string AddressLine1 { get; set; }
@@ -33,10 +30,7 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
         public string AddressCity { get; set; }
         public string AddressStateOrProvince { get; set; }
         public string AddressPostcode { get; set; }
-        public string AddressTelephone { get; set; }
         public string Telephone { get; set; }
-        public string SecondaryTelephone { get; set; }
-        public string MobileTelephone { get; set; }
         public bool? HasDbsCertificate { get; set; }
         public DateTime? DbsCertificateIssuedAt { get; set; }
 
@@ -64,7 +58,6 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
             Merged = candidate.Merged;
             FullName = candidate.FullName;
             Email = candidate.Email;
-            SecondaryEmail = candidate.SecondaryEmail ?? candidate.Email;
             FirstName = candidate.FirstName;
             LastName = candidate.LastName;
             AddressLine1 = candidate.AddressLine1;
@@ -73,12 +66,7 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
             AddressCity = candidate.AddressCity;
             AddressStateOrProvince = candidate.AddressStateOrProvince;
             AddressPostcode = candidate.AddressPostcode;
-            AddressTelephone = candidate.AddressTelephone.StripExitCode();
             Telephone = candidate.Telephone.StripExitCode();
-            MobileTelephone = candidate.MobileTelephone.StripExitCode();
-
-            var secondaryTelephoneDefaults = new List<string> { MobileTelephone, AddressTelephone, Telephone };
-            SecondaryTelephone = candidate.SecondaryTelephone.StripExitCode() ?? secondaryTelephoneDefaults.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
 
             HasDbsCertificate = candidate.HasDbsCertificate;
             DbsCertificateIssuedAt = candidate.DbsCertificateIssuedAt;
@@ -91,7 +79,6 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
                 Id = CandidateId,
                 CountryId = LookupItem.UnitedKingdomCountryId,
                 Email = Email,
-                SecondaryEmail = SecondaryEmail,
                 FirstName = FirstName,
                 LastName = LastName,
                 AddressLine1 = AddressLine1,
@@ -100,10 +87,7 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
                 AddressCity = AddressCity,
                 AddressStateOrProvince = AddressStateOrProvince,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                AddressTelephone = AddressTelephone,
                 Telephone = Telephone,
-                SecondaryTelephone = SecondaryTelephone,
-                MobileTelephone = MobileTelephone,
                 HasDbsCertificate = HasDbsCertificate,
                 DbsCertificateIssuedAt = DbsCertificateIssuedAt,
             };

--- a/GetIntoTeachingApi/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidator.cs
@@ -22,10 +22,8 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience.Validators
             RuleFor(request => request.AddressCity).NotNull();
             RuleFor(request => request.AddressStateOrProvince).NotNull();
             RuleFor(request => request.AddressPostcode).NotNull();
-            RuleFor(request => request.AddressTelephone).NotNull();
             RuleFor(request => request.HasDbsCertificate).NotNull();
             RuleFor(request => request.Telephone).NotNull();
-            RuleFor(request => request.SecondaryTelephone).NotNull();
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
         }

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
@@ -20,7 +20,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
                 MasterId = Guid.NewGuid(),
                 Merged = true,
                 Email = "email@address.com",
-                SecondaryEmail = "email2@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 DateOfBirth = DateTime.UtcNow,
@@ -30,10 +29,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
                 AddressCity = "City",
                 AddressStateOrProvince = "County",
                 AddressPostcode = "KY11 9YU",
-                AddressTelephone = "00123456789",
                 Telephone = "00234567890",
-                SecondaryTelephone = "00345678901",
-                MobileTelephone = "00456789012",
                 HasDbsCertificate = true,
                 DbsCertificateIssuedAt = DateTime.UtcNow,
             };
@@ -45,7 +41,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             response.SecondaryPreferredTeachingSubjectId.Should().Be(candidate.SecondaryPreferredTeachingSubjectId);
             response.MasterId.Should().Be(candidate.MasterId);
             response.Email.Should().Be(candidate.Email);
-            response.SecondaryEmail.Should().Be(candidate.SecondaryEmail);
             response.Merged.Should().Be(candidate.Merged);
             response.FullName.Should().Be(candidate.FullName);
             response.FirstName.Should().Be(candidate.FirstName);
@@ -56,56 +51,9 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             response.AddressCity.Should().Be(candidate.AddressCity);
             response.AddressStateOrProvince.Should().Be(candidate.AddressStateOrProvince);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
-            response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
             response.Telephone.Should().Be(candidate.Telephone[2..]);
-            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone[2..]);
-            response.MobileTelephone.Should().Be(candidate.MobileTelephone[2..]);
             response.HasDbsCertificate.Should().Be(candidate.HasDbsCertificate);
             response.DbsCertificateIssuedAt.Should().Be(candidate.DbsCertificateIssuedAt);
-        }
-
-        [Fact]
-        public void Constructor_CandidateSecondaryEmail_SetsCorrectly()
-        {
-            var candidate = new Candidate() { Email = "email@address.com" };
-
-            var response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryEmail.Should().Be(candidate.Email);
-
-            candidate.SecondaryEmail = "email2@address.com";
-
-            response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
-        }
-
-        [Fact]
-        public void Constructor_SecondaryTelephone_SetsCorrectly()
-        {
-            var candidate = new Candidate() { Telephone = "111111" };
-
-            var response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryTelephone.Should().Be(candidate.Telephone);
-
-            candidate.AddressTelephone = "222222";
-
-            response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryTelephone.Should().Be(candidate.AddressTelephone);
-
-            candidate.MobileTelephone = "333333";
-
-            response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryTelephone.Should().Be(candidate.MobileTelephone);
-
-            candidate.SecondaryTelephone = "444444";
-
-            response = new SchoolsExperienceSignUp(candidate);
-
-            response.SecondaryTelephone.Should().Be(candidate.SecondaryTelephone);
         }
 
         [Fact]
@@ -118,7 +66,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
                 SecondaryPreferredTeachingSubjectId = Guid.NewGuid(),
                 AcceptedPolicyId = Guid.NewGuid(),
                 Email = "email@address.com",
-                SecondaryEmail = "email2@address.com",
                 FirstName = "John",
                 LastName = "Doe",
                 AddressLine1 = "Address 1",
@@ -127,10 +74,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
                 AddressCity = "City",
                 AddressStateOrProvince = "County",
                 AddressPostcode = "KY11 9YU",
-                AddressTelephone = "123456789",
                 Telephone = "234567890",
-                SecondaryTelephone = "345678901",
-                MobileTelephone = "456789012",
                 HasDbsCertificate = true,
                 DbsCertificateIssuedAt = DateTime.UtcNow,
             };
@@ -142,7 +86,6 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             candidate.SecondaryPreferredTeachingSubjectId.Should().Equals(request.SecondaryPreferredTeachingSubjectId);
             candidate.CountryId.Should().Equals(LookupItem.UnitedKingdomCountryId);
             candidate.Email.Should().Be(request.Email);
-            candidate.SecondaryEmail.Should().Be(request.SecondaryEmail);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);
             candidate.AddressLine1.Should().Be(request.AddressLine1);
@@ -151,10 +94,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             candidate.AddressCity.Should().Be(request.AddressCity);
             candidate.AddressStateOrProvince.Should().Be(request.AddressStateOrProvince);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.AddressTelephone.Should().Be(request.AddressTelephone);
             candidate.Telephone.Should().Be(request.Telephone);
-            candidate.SecondaryTelephone.Should().Be(request.SecondaryTelephone);
-            candidate.MobileTelephone.Should().Be(request.MobileTelephone);
             candidate.HasDbsCertificate.Should().Be(request.HasDbsCertificate);
             candidate.DbsCertificateIssuedAt.Should().Be(request.DbsCertificateIssuedAt);
 

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -43,9 +43,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
                 AddressCity = "City",
                 AddressStateOrProvince = "County",
                 AddressPostcode = "KY11 9YU",
-                AddressTelephone = "123456789",
                 Telephone = "123456789",
-                SecondaryTelephone = "123456789",
                 HasDbsCertificate = false,
             };
 
@@ -82,9 +80,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
                 AddressCity = null,
                 AddressStateOrProvince = null,
                 AddressPostcode = null,
-                AddressTelephone = null,
                 Telephone = null,
-                SecondaryTelephone = null,
                 HasDbsCertificate = null,
                 AcceptedPolicyId = null,
                 PreferredTeachingSubjectId = null,
@@ -99,9 +95,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
             result.ShouldHaveValidationErrorFor(s => s.AddressCity);
             result.ShouldHaveValidationErrorFor(s => s.AddressStateOrProvince);
             result.ShouldHaveValidationErrorFor(s => s.AddressPostcode);
-            result.ShouldHaveValidationErrorFor(s => s.AddressTelephone);
             result.ShouldHaveValidationErrorFor(s => s.Telephone);
-            result.ShouldHaveValidationErrorFor(s => s.SecondaryTelephone);
             result.ShouldHaveValidationErrorFor(s => s.HasDbsCertificate);
             result.ShouldHaveValidationErrorFor(s => s.AcceptedPolicyId);
             result.ShouldHaveValidationErrorFor(s => s.PreferredTeachingSubjectId);


### PR DESCRIPTION
We only collect primary email address and phone number in School Experience as part of the sign up. Remove the following unused fields: AddressTelephone, MobileTelephone, SecondaryTelephone, SecondaryEmail, 