### PR TITLE
Add candidate ID parameter to add school experience action

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -185,6 +185,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
         public IActionResult AddSchoolExperience(
+            [FromRoute, SwaggerParameter("The `id` of the `Candidate`.", Required = true)] Guid id,
             [FromBody, SwaggerRequestBody("School experience.", Required = true)] CandidateSchoolExperience candidateSchoolExperience)
         {
             if (_env.IsProduction)
@@ -192,7 +193,7 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
                 throw new InvalidOperationException("New feature under development");
             }
 
-            var candidate = new Candidate { Id = candidateSchoolExperience.CandidateId };
+            var candidate = new Candidate { Id = id };
             candidate.SchoolExperiences.Add(candidateSchoolExperience);
 
             if (!ModelState.IsValid)

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -236,10 +236,11 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         [Fact]
         public void AddSchoolExperience_InvalidRequest_RespondsWithValidationErrors()
         {
+            var candidateId = Guid.NewGuid();
             var schoolExperience = new CandidateSchoolExperience { SchoolName = null };
             _controller.ModelState.AddModelError("SchoolName", "SchoolName must be set.");
 
-            var response = _controller.AddSchoolExperience(schoolExperience);
+            var response = _controller.AddSchoolExperience(candidateId, schoolExperience);
 
             var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
             var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
@@ -249,9 +250,9 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         [Fact]
         public void AddSchoolExperience_ValidRequest_EnqueuesUpsertCandidateJobAndRespondsWithNoContent()
         {
+            var candidateId = Guid.NewGuid();
             var schoolExperience = new CandidateSchoolExperience()
             {
-                CandidateId = Guid.NewGuid(),
                 SchoolUrn = "123456",
                 DurationOfPlacementInDays = 1,
                 TeachingSubjectId = Guid.NewGuid(),
@@ -260,11 +261,11 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             };
             var candidate = new Candidate
             {
-                Id = schoolExperience.CandidateId,
+                Id = candidateId,
                 SchoolExperiences = new List<CandidateSchoolExperience> { schoolExperience }
             };
 
-            var response = _controller.AddSchoolExperience(schoolExperience);
+            var response = _controller.AddSchoolExperience(candidateId, schoolExperience);
 
             response.Should().BeOfType<NoContentResult>();
             _mockJobClient.Verify(x => x.Create(
@@ -277,9 +278,10 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         [Fact]
         public void AddSchoolExperience_InProduction_ThrowsFeatureUnderDevelopmentException()
         {
+            var candidateId = Guid.NewGuid();
             _mockEnv.Setup(mock => mock.IsProduction).Returns(true);
 
-            Action request = () => _controller.AddSchoolExperience(new CandidateSchoolExperience());
+            Action request = () => _controller.AddSchoolExperience(candidateId, new CandidateSchoolExperience());
 
             request.Should()
                 .Throw<InvalidOperationException>()


### PR DESCRIPTION
We have seen some failed UpsertCandidateJobs in Prometheus while testing this new endpoint where the Guid is set to the default value of `00000000-0000-0000-0000-000000000000`.

I was accidentally setting candidate ID from the CandidateSchoolExperience model instead of the 'Id' request parameter.