### PR TITLE
Use address telephone instead of telephone as primary number

### DIFF
--- a/GetIntoTeachingApi/Models/SchoolsExperience/SchoolsExperienceSignUp.cs
+++ b/GetIntoTeachingApi/Models/SchoolsExperience/SchoolsExperienceSignUp.cs
@@ -70,8 +70,8 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
             // We only want to expose primary phone number to School Experience. However, there
             // are a number of records in the CRM that have School Experience but no primary number.
             // Fetch the other phone numbers for now until the issue has been resolved in the CRM.
-            var telephoneReserves = new string[] { candidate.MobileTelephone, candidate.AddressTelephone, candidate.SecondaryTelephone };
-            Telephone = candidate.Telephone.StripExitCode() ?? Array.Find(telephoneReserves, number => !string.IsNullOrWhiteSpace(number)).StripExitCode();
+            var telephoneReserves = new string[] { candidate.Telephone, candidate.MobileTelephone, candidate.SecondaryTelephone };
+            Telephone = candidate.AddressTelephone.StripExitCode() ?? Array.Find(telephoneReserves, number => !string.IsNullOrWhiteSpace(number)).StripExitCode();
 
             HasDbsCertificate = candidate.HasDbsCertificate;
             DbsCertificateIssuedAt = candidate.DbsCertificateIssuedAt;
@@ -92,7 +92,7 @@ namespace GetIntoTeachingApi.Models.SchoolsExperience
                 AddressCity = AddressCity,
                 AddressStateOrProvince = AddressStateOrProvince,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
-                Telephone = Telephone,
+                AddressTelephone = Telephone,
                 HasDbsCertificate = HasDbsCertificate,
                 DbsCertificateIssuedAt = DbsCertificateIssuedAt,
             };

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
@@ -95,7 +95,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
             candidate.AddressCity.Should().Be(request.AddressCity);
             candidate.AddressStateOrProvince.Should().Be(request.AddressStateOrProvince);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
-            candidate.Telephone.Should().Be(request.Telephone);
+            candidate.AddressTelephone.Should().Be(request.Telephone);
             candidate.HasDbsCertificate.Should().Be(request.HasDbsCertificate);
             candidate.DbsCertificateIssuedAt.Should().Be(request.DbsCertificateIssuedAt);
 
@@ -104,8 +104,8 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
         }
 
         [Theory]
+        [InlineData(nameof(Candidate.Telephone))]
         [InlineData(nameof(Candidate.MobileTelephone))]
-        [InlineData(nameof(Candidate.AddressTelephone))]
         [InlineData(nameof(Candidate.SecondaryTelephone))]
         public void Constructor_WhenCandidateHasNoPrimaryTelephone_UsesReserveNumbers(string reserveNumber)
         {

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/Validators/SchoolsExperienceSignUpValidatorTests.cs
@@ -65,7 +65,7 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor("Candidate.Telephone");
+            result.ShouldHaveValidationErrorFor("Candidate.AddressTelephone");
         }
 
         [Fact]


### PR DESCRIPTION
It is `address1_telephone1` that is used by the call centres, so this is the field that should be used as primary phone number (not `telephone1`).