### PR TITLE
Ignore assets in HighNotFound app alert

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -49,7 +49,7 @@ groups:
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2156036281/App+TTA+Runbook#TooManyRequests-HIGH
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/0PRnzc2Mk/get-into-teaching-apps?viewPanel=27&orgId=1
       - alert: HighNotFound
-        expr: 'sum(increase(app_requests_total{path!~"(apple|logo.svg|login|sites|user|wp|node)",status=~"404"}[10m])) > 120'
+        expr: 'sum(increase(app_requests_total{path!~"(apple|logo.svg|login|sites|user|wp|node|.jpg|.jpeg|.png|.svg|.pdf|.txt)",status=~"404"}[10m])) > 120'
         labels:
           severity: medium
         annotations:


### PR DESCRIPTION
We appear to get a lot of traffic from bots/crawlers that hit non-hashed versions of the assets and get a 404. As we check all of our internal assets in our unit tests I think we should be safe to exclude them here; 404s are likely only to come from external websites that have linked to an image we have since removed, which we can do nothing about.

Exclude `*.txt` files as we don't host any and its another source of bot traffic (i.e. `passwords.txt` 🤦).