### PR TITLE
Use compact JSON in production logs

### DIFF
--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
+using Serilog.Formatting.Compact;
 
 namespace GetIntoTeachingApi
 {
@@ -25,10 +26,6 @@ namespace GetIntoTeachingApi
                     webBuilder.UseKestrel(opts => opts.AddServerHeader = false);
                     webBuilder.UseStartup<Startup>();
                 })
-            .UseSerilog(new LoggerConfiguration()
-                .MinimumLevel.Information()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .WriteTo.Console()
-                .CreateLogger());
+            .UseSerilog((ctx, config) => config.ReadFrom.Configuration(ctx.Configuration));
     }
 }

--- a/GetIntoTeachingApi/appsettings.Production.json
+++ b/GetIntoTeachingApi/appsettings.Production.json
@@ -1,0 +1,12 @@
+{
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  }
+}

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -1,4 +1,18 @@
 {
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
+  },
   "AllowedHosts": "*",
   "ClientRateLimiting": {
     "EnableEndpointRateLimiting": true,


### PR DESCRIPTION
If we serialise our logs using JSON we get better configuration options and search-ability in Kibana.

Move Serilog configuration into `appsettings.json` and use compact JSON logger in production.