### PR TITLE
New email template verification code

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -82,7 +82,10 @@ namespace GetIntoTeachingApi.Controllers
             }
 
             var token = _accessTokenService.GenerateToken(request, (Guid)candidate.Id);
-            var personalisation = new Dictionary<string, dynamic> { { "pin_code", token } };
+            var personalisation = new Dictionary<string, dynamic> {
+                { "pin_code", token },
+                { "first_name", request.FirstName }
+            };
 
             // We respond immediately/assume this will be successful.
             _notifyService.SendEmailAsync(request.Email, NotifyService.NewPinCodeEmailTemplateId, personalisation);

--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -11,12 +11,12 @@
   api_key_prefix: ADMIN
   role: Admin
 -
-  name: Get into Teaching
+  name: Get Into Teaching
   description: "A service to support potential teachers on their journey into teaching"
   api_key_prefix: GIT
   role: GetIntoTeaching
 -
-  name: Get an Adviser
+  name: Get an adviser
   description: "A service to enable candidates to sign up for a Teacher Training Adviser (TTA)"
   api_key_prefix: TTA
   role: GetAnAdviser
@@ -26,7 +26,7 @@
   api_key_prefix: CRM
   role: Crm
 -
-  name: Schools Experience
+  name: Get school experience
   description: "A service that allows candidates to book school experience"
   api_key_prefix: SE
   role: SchoolsExperience

--- a/GetIntoTeachingApi/Services/NotifyService.cs
+++ b/GetIntoTeachingApi/Services/NotifyService.cs
@@ -8,7 +8,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class NotifyService : INotifyService
     {
-        public const string NewPinCodeEmailTemplateId = "f974aa10-f3a6-450d-87ca-8757644335fc";
+        public const string NewPinCodeEmailTemplateId = "44327bdb-0d65-4ba7-85d5-facd9d51fa4a";
         public const string CandidateRegistrationFailedEmailTemplateId = "00ea3516-17b0-4e09-8a92-ddec606310fd";
         public const string TeachingEventRegistrationFailedEmailTemplateId = "b4084e28-60a6-417d-bd66-42112bd7ad09";
         public const string MailingListAddMemberFailedEmailTemplateId = "4b3653b4-e524-42b8-bfed-201cb6bb8a25";

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -76,7 +76,9 @@ namespace GetIntoTeachingApiTests.Controllers
                 mock => mock.SendEmailAsync(
                     "email@address.com",
                     NotifyService.NewPinCodeEmailTemplateId,
-                    It.Is<Dictionary<string, dynamic>>(personalisation => personalisation["pin_code"] as string == "123456")
+                    It.Is<Dictionary<string, dynamic>>(personalisation =>
+                        personalisation["pin_code"] as string == "123456" &&
+                        personalisation["first_name"] as string == "John")
                 )
             );
         }


### PR DESCRIPTION
- Use new email template on create access token

The new email template has updated copy and uses the candidate's first name to make it more personalised.

<img width="814" alt="Screenshot 2022-02-21 at 08 25 28" src="https://user-images.githubusercontent.com/29867726/154916185-9eb5e898-4f8f-47a6-9ec0-18bb1b46846e.png">

