### PR TITLE
Deduplicate UpsertCandidateJob

### DIFF
--- a/GetIntoTeachingApi/Jobs/BaseJob.cs
+++ b/GetIntoTeachingApi/Jobs/BaseJob.cs
@@ -1,4 +1,8 @@
-﻿using GetIntoTeachingApi.Adapters;
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire.Server;
 
@@ -6,17 +10,25 @@ namespace GetIntoTeachingApi.Jobs
 {
     public abstract class BaseJob
     {
+        private static readonly TimeSpan _deduplicateTimeSpan = TimeSpan.FromSeconds(5);
+        private readonly IRedisService _redis;
         protected IEnv Env { get; init; }
 
-        protected BaseJob(IEnv env)
+        protected BaseJob(IEnv env, IRedisService redis)
         {
             Env = env;
+            _redis = redis;
         }
 
         protected bool IsLastAttempt(PerformContext context, IPerformContextAdapter adapter)
         {
             var currentAttempt = CurrentAttempt(context, adapter);
             return currentAttempt >= JobConfiguration.Attempts(Env);
+        }
+
+        protected bool IsFirstAttempt(PerformContext context, IPerformContextAdapter adapter)
+        {
+            return CurrentAttempt(context, adapter) == 1;
         }
 
         protected int CurrentAttempt(PerformContext context, IPerformContextAdapter adapter)
@@ -27,6 +39,26 @@ namespace GetIntoTeachingApi.Jobs
         protected string AttemptInfo(PerformContext context, IPerformContextAdapter adapter)
         {
             return $"{CurrentAttempt(context, adapter)}/{JobConfiguration.Attempts(Env)}";
+        }
+
+        protected bool Deduplicate(string signature, PerformContext context, IPerformContextAdapter adapter)
+        {
+            if (!IsFirstAttempt(context, adapter))
+            {
+                return false;
+            }
+
+            var redisKey = $"base_job.{GetType().Name}.{signature}";
+
+            if (_redis.Database.KeyExists(redisKey))
+            {
+                return true;
+            }
+            else
+            {
+                _redis.Database.StringSet(redisKey, true, _deduplicateTimeSpan);
+                return false;
+            }
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
+++ b/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
@@ -18,12 +18,13 @@ namespace GetIntoTeachingApi.Jobs
 
         public ClaimCallbackBookingSlotJob(
             IEnv env,
+            IRedisService redis,
             IPerformContextAdapter contextAdapter,
             ICrmService crm,
             IMetricService metrics,
             ILogger<ClaimCallbackBookingSlotJob> logger,
             IAppSettings appSettings)
-            : base(env)
+            : base(env, redis)
         {
             _contextAdapter = contextAdapter;
             _metrics = metrics;

--- a/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/CrmSyncJob.cs
@@ -17,11 +17,12 @@ namespace GetIntoTeachingApi.Jobs
 
         public CrmSyncJob(
             IEnv env,
+            IRedisService redis,
             IStore store,
             ILogger<CrmSyncJob> logger,
             IMetricService metrics,
             IAppSettings appSettings)
-            : base(env)
+            : base(env, redis)
         {
             _store = store;
             _logger = logger;

--- a/GetIntoTeachingApi/Jobs/FindApplyBackfillJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyBackfillJob.cs
@@ -22,10 +22,11 @@ namespace GetIntoTeachingApi.Jobs
 
         public FindApplyBackfillJob(
             IEnv env,
+            IRedisService redis,
             IBackgroundJobClient jobClient,
             ILogger<FindApplyBackfillJob> logger,
             IAppSettings appSettings)
-            : base(env)
+            : base(env, redis)
         {
             _jobClient = jobClient;
             _logger = logger;

--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -19,11 +19,12 @@ namespace GetIntoTeachingApi.Jobs
 
         public FindApplyCandidateSyncJob(
             IEnv env,
+            IRedisService redis,
             ILogger<FindApplyCandidateSyncJob> logger,
             ICrmService crm,
             IBackgroundJobClient jobClient,
             Models.IAppSettings appSettings)
-            : base(env)
+            : base(env, redis)
         {
             _logger = logger;
             _crm = crm;

--- a/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplySyncJob.cs
@@ -24,12 +24,13 @@ namespace GetIntoTeachingApi.Jobs
 
         public FindApplySyncJob(
             IEnv env,
+            IRedisService redis,
             ILogger<FindApplySyncJob> logger,
             IBackgroundJobClient jobClient,
             Models.IAppSettings appSettings,
             IMetricService metrics,
             IDateTimeProvider dateTime)
-            : base(env)
+            : base(env, redis)
         {
             _logger = logger;
             _metrics = metrics;

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -29,10 +29,11 @@ namespace GetIntoTeachingApi.Jobs
 
         public LocationSyncJob(
             IEnv env,
+            IRedisService redis,
             GetIntoTeachingDbContext dbContext,
             ILogger<LocationSyncJob> logger,
             IMetricService metrics)
-            : base(env)
+            : base(env, redis)
         {
             _logger = logger;
             _dbContext = dbContext;

--- a/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
+++ b/GetIntoTeachingApi/Jobs/MagicLinkTokenGenerationJob.cs
@@ -21,13 +21,14 @@ namespace GetIntoTeachingApi.Jobs
 
         public MagicLinkTokenGenerationJob(
             IEnv env,
+            IRedisService redis,
             IBackgroundJobClient jobClient,
             ICandidateMagicLinkTokenService magicLinkTokenService,
             ICrmService crm,
             ILogger<MagicLinkTokenGenerationJob> logger,
             IMetricService metrics,
             IAppSettings appSettings)
-            : base(env)
+            : base(env, redis)
         {
             _jobClient = jobClient;
             _magicLinkTokenService = magicLinkTokenService;

--- a/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertModelJob.cs
@@ -22,13 +22,14 @@ namespace GetIntoTeachingApi.Jobs
 
         public UpsertModelJob(
             IEnv env,
+            IRedisService redis,
             IPerformContextAdapter contextAdapter,
             ICrmService crm,
             IMetricService metrics,
             ILogger<UpsertModelJob<T>> logger,
             IAppSettings appSettings,
             INotifyService notifyService)
-            : base(env)
+            : base(env, redis)
         {
             _contextAdapter = contextAdapter;
             _metrics = metrics;

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -28,6 +28,7 @@
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 4432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 5379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
         "VCAP_APPLICATION": "{\"application_name\": \"app-name\",\"organization_name\": \"org-name\",\"space_name\": \"space-name\"}",
+        "CF_INSTANCE_INDEX": "0",
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",

--- a/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
@@ -32,7 +32,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _metrics = new MetricService();
             _scheduledAt = DateTime.UtcNow;
             _job = new ClaimCallbackBookingSlotJob(
-                new Env(), _mockContext.Object, _mockCrm.Object, _metrics, _mockLogger.Object, _mockAppSettings.Object);
+                new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _mockCrm.Object,
+                _metrics, _mockLogger.Object, _mockAppSettings.Object);
 
             _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "ClaimCallbackBookingSlotJob" });
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));

--- a/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/CrmSyncJobTests.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockStore = new Mock<IStore>();
             _mockAppSettings = new Mock<IAppSettings>();
             _metrics = new MetricService();
-            _job = new CrmSyncJob(new Env(), _mockStore.Object, _mockLogger.Object, _metrics, _mockAppSettings.Object);
+            _job = new CrmSyncJob(new Env(), new Mock<IRedisService>().Object, _mockStore.Object, _mockLogger.Object, _metrics, _mockAppSettings.Object);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/FindApplyBackfillJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyBackfillJobTests.cs
@@ -6,6 +6,7 @@ using Flurl.Http.Testing;
 using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.FindApply;
+using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using GetIntoTeachingApiTests.Helpers;
 using Hangfire;
@@ -38,6 +39,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _job = new FindApplyBackfillJob(
                 _mockEnv.Object,
+                new Mock<IRedisService>().Object,
                 _mockJobClient.Object,
                 _mockLogger.Object,
                 _mockAppSettings.Object);

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -34,6 +34,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _job = new FindApplyCandidateSyncJob(
                 new Env(),
+                new Mock<IRedisService>().Object,
                 _mockLogger.Object,
                 _mockCrm.Object,
                 _mockJobClient.Object,

--- a/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplySyncJobTests.cs
@@ -42,6 +42,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _job = new FindApplySyncJob(
                 _mockEnv.Object,
+                new Mock<IRedisService>().Object,
                 _mockLogger.Object,
                 _mockJobClient.Object,
                 _mockAppSettings.Object,

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -31,7 +31,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger = new Mock<ILogger<LocationSyncJob>>();
             _metrics = new MetricService();
             _job = new LocationSyncJob(_mockEnv.Object,
-                DbContext, _mockLogger.Object, _metrics);
+                new Mock<IRedisService>().Object, DbContext, _mockLogger.Object, _metrics);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/MagicLinkTokenGenerationJobTests.cs
@@ -35,6 +35,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _metrics = new MetricService();
             _job = new MagicLinkTokenGenerationJob(
                 new Env(),
+                new Mock<IRedisService>().Object,
                 _mockJobClient.Object,
                 _mockMagicLinkTokenService.Object,
                 _mockCrm.Object,

--- a/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertModelJobTests.cs
@@ -35,7 +35,8 @@ namespace GetIntoTeachingApiTests.Jobs
             _metrics = new MetricService();
             _policy = new CandidatePrivacyPolicy() { Id = Guid.NewGuid(), AcceptedAt = DateTime.UtcNow, CandidateId = Guid.NewGuid() };
             _job = new UpsertModelJob<CandidatePrivacyPolicy>(
-                new Env(), _mockContext.Object, _mockCrm.Object, _metrics, _mockLogger.Object, _mockAppSettings.Object, _mockNotifyService.Object);
+                new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _mockCrm.Object,
+                _metrics, _mockLogger.Object, _mockAppSettings.Object, _mockNotifyService.Object);
 
             _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" });
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));


### PR DESCRIPTION
[Trello-2952](https://trello.com/c/MuyRT0qK/2952-investigate-duplicate-records-reported-in-crm)

- Deduplicate UpsertCandidateJobs 

We occasionally find in the CRM that duplicate records have been created (i.e. multiple records with the same first name, last name and email address).

There is already quite a lot of protection in to prevent this; the end-services disable form submission buttons to prevent double-clicks and the API splits updating a candidate into several jobs in case one of the steps/requests fails (in which case only that step/request is retried).

That being said, there are still ways for duplicates to be created; the only one I'm aware of at the moment is if Javascript is disabled then a user can submit a form multiple times by double-clicking the submit button. There's nothing we can do about this, as the only prevention requires Javascript.

In an effort to deduplicate records in a more centralised way we are going to store a signature in Redis for `UpsertCandidateJob`s are they are processed; that way, if a subsequent job begins processing and finds the signature already in Redis it can de-duplicate itself by completing early.

The redis keys will have a short TTL of 5 seconds to ensure legitimate jobs that are either the same or very similar should still run.

Initially I wanted to use a hash of the entire JSON job payload as the signature, however due to the way the requests are processed these can contain dates set to 'now', which will change slightly between duplicate jobs. Instead, I've opted to make the signature:

``` 
base_job.<job-type>.<candidate-id>-<candidate-email>-<changed-properties>
```

This should lead to a unique enough key, assuming two distinct transactions/endpoints don't accept the same set of attributes which is certainly the case at the moment.

- Update other jobs to adhere to BaseJob interface

The `IRedisService` parameter is now required by all constructors.