### PR TITLE
Update various dependencies

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
        - name: Checkout
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
        image: ${{steps.docker_image.outputs.IMAGE}}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -49,7 +49,7 @@ jobs:
              ${{ runner.os }}-buildx-
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1.13.0
+        uses: docker/login-action@v1.14.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -85,7 +85,7 @@ jobs:
       release_sha: ${{github.sha}}
     steps:
        - name: Check out the repo
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master
@@ -149,7 +149,7 @@ jobs:
        name: Test 
     steps:
        - name: Check out the repo
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master
@@ -191,7 +191,7 @@ jobs:
     needs: qa
     steps:
        - name: Check out the repo
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master

--- a/.github/workflows/check_alert_rules.yml
+++ b/.github/workflows/check_alert_rules.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v3
 
     - name: Check Prometheus alert rules
       uses: peimanja/promtool-github-actions@master

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
     steps:
        - name: Checkout
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
    
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
 
     - uses: Azure/login@v1
       with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Models;
+﻿using System;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +17,13 @@ namespace GetIntoTeachingApi.Database
         public GetIntoTeachingDbContext(DbContextOptions<GetIntoTeachingDbContext> options)
             : base(options)
         {
+            ConfigureNpgsql();
+        }
+
+        public static void ConfigureNpgsql()
+        {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            AppContext.SetSwitch("Npgsql.DisableDateTimeInfinityConversions", true);
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -17,7 +17,6 @@
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.28" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.4" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
@@ -30,8 +29,9 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
+		<PackageReference Include="Npgsql" Version="6.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.3" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
@@ -67,6 +67,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.6" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -96,6 +97,7 @@
 	  <None Remove="Microsoft.Bcl.AsyncInterfaces" />
 	  <None Remove="Microsoft.EntityFrameworkCore.Relational" />
 	  <None Remove="Microsoft.CodeAnalysis.NetAnalyzers" />
+	  <None Remove="Hangfire.PostgreSql" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -12,37 +12,37 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.27" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.27" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.28" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.4" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.4.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
-		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.11.1" />
-		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.14.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.2" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 		<PackageReference Include="Fody" Version="6.6.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -51,9 +51,9 @@
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="4.0.1" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.10" />
-		<PackageReference Include="Flurl.Http" Version="3.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.0" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.17" />
+		<PackageReference Include="Flurl.Http" Version="3.2.2" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.2" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -62,7 +62,7 @@
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Castle.Core" Version="4.4.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.AppStart;
+using GetIntoTeachingApi.Database;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -12,6 +14,8 @@ namespace GetIntoTeachingApi
     {
         public static async Task Main(string[] args)
         {
+            GetIntoTeachingDbContext.ConfigureNpgsql();
+
             var webHost = CreateHostBuilder(args).Build();
 
             await webHost.RunAsync();

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -11,30 +11,33 @@
     <None Remove="Models\FindApply\" />
     <None Remove="Contracts\Data\teacher_training_adviser\" />
     <None Remove="FluentAssertions.Json" />
+    <None Remove="Microsoft.CodeAnalysis.Common" />
+    <None Remove="Microsoft.CodeAnalysis.CSharp" />
+    <None Remove="Microsoft.CodeAnalysis.Workspaces.Common" />
+    <None Remove="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="coverlet.msbuild" Version="3.1.0">
+	<PackageReference Include="coverlet.msbuild" Version="3.1.2">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.2.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-	<PackageReference Include="Moq" Version="4.16.1" />
-	<PackageReference Include="WireMock.Net" Version="1.4.27" />
+	<PackageReference Include="FluentAssertions" Version="6.5.1" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+	<PackageReference Include="Moq" Version="4.17.2" />
+	<PackageReference Include="WireMock.Net" Version="1.4.37" />
 	<PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
@@ -46,7 +46,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
@@ -81,7 +81,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
             candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
@@ -86,7 +86,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
             candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 
@@ -113,7 +113,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.HasMailingListSubscription.Should().BeTrue();
 
-            candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
+            candidate.TeachingEventRegistrations.First().EventId.Should().Be((Guid)request.EventId);
             candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.Event);
             candidate.TeachingEventRegistrations.First().IsCancelled.Should().BeFalse();
             candidate.TeachingEventRegistrations.First().RegistrationNotificationSeen.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
@@ -82,10 +82,10 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
-            candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
-            candidate.SecondaryPreferredTeachingSubjectId.Should().Equals(request.SecondaryPreferredTeachingSubjectId);
-            candidate.CountryId.Should().Equals(LookupItem.UnitedKingdomCountryId);
+            candidate.Id.Should().Be(request.CandidateId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
+            candidate.SecondaryPreferredTeachingSubjectId.Should().Be(request.SecondaryPreferredTeachingSubjectId);
+            candidate.CountryId.Should().Be(LookupItem.UnitedKingdomCountryId);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -125,9 +125,9 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 UkDegreeGradeId = 0,
                 DegreeStatusId = 1,
-                DegreeTypeId = 2,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
                 InitialTeacherTrainingYearId = 3,
-                PreferredEducationPhaseId = 4,
+                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = 7,
                 PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -149,17 +149,17 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
-            candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
-            candidate.CountryId.Should().Equals(request.CountryId);
-            candidate.InitialTeacherTrainingYearId.Should().Equals(request.InitialTeacherTrainingYearId);
-            candidate.PreferredEducationPhaseId.Should().Equals(request.PreferredEducationPhaseId);
-            candidate.HasGcseEnglishId.Should().Equals(request.HasGcseMathsAndEnglishId);
-            candidate.HasGcseMathsId.Should().Equals(request.HasGcseMathsAndEnglishId);
-            candidate.HasGcseScienceId.Should().Equals(request.HasGcseScienceId);
-            candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
-            candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
-            candidate.PlanningToRetakeGcseScienceId.Should().Equals(request.PlanningToRetakeGcseScienceId);
+            candidate.Id.Should().Be(request.CandidateId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
+            candidate.CountryId.Should().Be(request.CountryId);
+            candidate.InitialTeacherTrainingYearId.Should().Be(request.InitialTeacherTrainingYearId);
+            candidate.PreferredEducationPhaseId.Should().Be(request.PreferredEducationPhaseId);
+            candidate.HasGcseEnglishId.Should().Be(request.HasGcseMathsAndEnglishId);
+            candidate.HasGcseMathsId.Should().Be(request.HasGcseMathsAndEnglishId);
+            candidate.HasGcseScienceId.Should().Be(request.HasGcseScienceId);
+            candidate.PlanningToRetakeGcseEnglishId.Should().Be(request.PlanningToRetakeGcseMathsAndEnglishId);
+            candidate.PlanningToRetakeGcseMathsId.Should().Be(request.PlanningToRetakeGcseMathsAndEnglishId);
+            candidate.PlanningToRetakeGcseScienceId.Should().Be(request.PlanningToRetakeGcseScienceId);
             candidate.AdviserStatusId.Should().BeNull();
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);


### PR DESCRIPTION
Closes #935 #931 #925 #923 #922 #933 #934

- Update various dependencies
- Update GitHub action dependencies
- Update tests for FluentAssertion changes
- Update to latest Pgsql packages

The Hangfire Postgresql adapter we were using was not compatible with v6.0 of Pgsql so we've had to swap from a fork back to the main repository (which previously had an issue with database connection leaks, which is why we swapped it out - hopefully it no longer has this issue).