### PR TITLE
Update various dependencies

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
        - name: Checkout
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
        image: ${{steps.docker_image.outputs.IMAGE}}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -49,7 +49,7 @@ jobs:
              ${{ runner.os }}-buildx-
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1.13.0
+        uses: docker/login-action@v1.14.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -85,7 +85,7 @@ jobs:
       release_sha: ${{github.sha}}
     steps:
        - name: Check out the repo
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master
@@ -149,7 +149,7 @@ jobs:
        name: Test 
     steps:
        - name: Check out the repo
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
 
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master
@@ -184,6 +184,4 @@ jobs:
            SLACK_TITLE:   Failure in Post-Development Deploy
            SLACK_MESSAGE: Failure with initialising QA deployment for ${{env.APPLICATION}}
            SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
-
-
 

--- a/.github/workflows/check_alert_rules.yml
+++ b/.github/workflows/check_alert_rules.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v3
 
     - name: Check Prometheus alert rules
       uses: peimanja/promtool-github-actions@master

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
     steps:
        - name: Checkout
-         uses: actions/checkout@v2.4.0
+         uses: actions/checkout@v3
    
        - name: set-up-environment
          uses: DFE-Digital/github-actions/set-up-environment@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
 
     - uses: Azure/login@v1
       with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
+++ b/GetIntoTeachingApi/AppStart/ServiceCollectionExtensions.cs
@@ -132,7 +132,10 @@ The GIT API aims to provide:
                 }
                 else
                 {
-                    config.UsePostgreSqlStorage(DbConfiguration.HangfireConnectionString(env));
+                    config.UsePostgreSqlStorage(DbConfiguration.HangfireConnectionString(env), new PostgreSqlStorageOptions
+                    {
+                        SchemaName = "hangfire_postgres"
+                    });
                 }
             });
 

--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -35,54 +34,6 @@ namespace GetIntoTeachingApi.Database
         public void Migrate()
         {
             _dbContext.Database.Migrate();
-        }
-
-        // TODO: temp code to be removed as soon as its deployed/ran.
-        public static void DropHangfireDatabase()
-        {
-            var env = new Env();
-
-            if (!env.IsMasterInstance)
-            {
-                return;
-            }
-
-            var conn = new NpgsqlConnection(HangfireConnectionString(env));
-            conn.Open();
-
-            var sql = "SELECT COUNT(*) FROM hangfire.jobqueue";
-            var cmd = new NpgsqlCommand(sql, conn);
-            var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.CurrentCulture);
-
-            // Don't drop database and force deploy to abort if Hangfire has jobs in the queue.
-            if (count != 0)
-            {
-                conn.Close();
-                conn.Dispose();
-
-                System.Environment.Exit(1);
-            }
-
-            var dropSql = "ALTER TABLE hangfire.state DROP CONSTRAINT state_jobid_fkey;" +
-                "ALTER TABLE hangfire.jobparameter DROP CONSTRAINT jobparameter_jobid_fkey;" +
-                "DROP TABLE hangfire.schema;" +
-                "DROP TABLE hangfire.job;" +
-                "DROP TABLE hangfire.state;" +
-                "DROP TABLE hangfire.jobparameter;" +
-                "DROP TABLE hangfire.jobqueue;" +
-                "DROP TABLE hangfire.server;" +
-                "DROP TABLE hangfire.list;" +
-                "DROP TABLE hangfire.set;" +
-                "DROP TABLE hangfire.lock;" +
-                "DROP TABLE hangfire.counter;" +
-                "DROP TABLE hangfire.hash;" +
-                "DROP SCHEMA hangfire Cascade;";
-
-            var dropCmd = new NpgsqlCommand(dropSql, conn);
-            dropCmd.ExecuteNonQuery();
-
-            conn.Close();
-            conn.Dispose();
         }
 
         private static string GenerateConnectionString(IEnv env, string instanceName)

--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -33,6 +35,54 @@ namespace GetIntoTeachingApi.Database
         public void Migrate()
         {
             _dbContext.Database.Migrate();
+        }
+
+        // TODO: temp code to be removed as soon as its deployed/ran.
+        public static void DropHangfireDatabase()
+        {
+            var env = new Env();
+
+            if (!env.IsMasterInstance)
+            {
+                return;
+            }
+
+            var conn = new NpgsqlConnection(HangfireConnectionString(env));
+            conn.Open();
+
+            var sql = "SELECT COUNT(*) FROM hangfire.jobqueue";
+            var cmd = new NpgsqlCommand(sql, conn);
+            var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.CurrentCulture);
+
+            // Don't drop database and force deploy to abort if Hangfire has jobs in the queue.
+            if (count != 0)
+            {
+                conn.Close();
+                conn.Dispose();
+
+                System.Environment.Exit(1);
+            }
+
+            var dropSql = "ALTER TABLE hangfire.state DROP CONSTRAINT state_jobid_fkey;" +
+                "ALTER TABLE hangfire.jobparameter DROP CONSTRAINT jobparameter_jobid_fkey;" +
+                "DROP TABLE hangfire.schema;" +
+                "DROP TABLE hangfire.job;" +
+                "DROP TABLE hangfire.state;" +
+                "DROP TABLE hangfire.jobparameter;" +
+                "DROP TABLE hangfire.jobqueue;" +
+                "DROP TABLE hangfire.server;" +
+                "DROP TABLE hangfire.list;" +
+                "DROP TABLE hangfire.set;" +
+                "DROP TABLE hangfire.lock;" +
+                "DROP TABLE hangfire.counter;" +
+                "DROP TABLE hangfire.hash;" +
+                "DROP SCHEMA hangfire Cascade;";
+
+            var dropCmd = new NpgsqlCommand(dropSql, conn);
+            dropCmd.ExecuteNonQuery();
+
+            conn.Close();
+            conn.Dispose();
         }
 
         private static string GenerateConnectionString(IEnv env, string instanceName)

--- a/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
+++ b/GetIntoTeachingApi/Database/GetIntoTeachingDbContext.cs
@@ -1,4 +1,5 @@
-﻿using GetIntoTeachingApi.Models;
+﻿using System;
+using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +17,13 @@ namespace GetIntoTeachingApi.Database
         public GetIntoTeachingDbContext(DbContextOptions<GetIntoTeachingDbContext> options)
             : base(options)
         {
+            ConfigureNpgsql();
+        }
+
+        public static void ConfigureNpgsql()
+        {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            AppContext.SetSwitch("Npgsql.DisableDateTimeInfinityConversions", true);
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -17,7 +17,6 @@
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.28" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.4" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
@@ -30,8 +29,9 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
+		<PackageReference Include="Npgsql" Version="6.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.3" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
@@ -67,6 +67,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.6" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -96,6 +97,7 @@
 	  <None Remove="Microsoft.Bcl.AsyncInterfaces" />
 	  <None Remove="Microsoft.EntityFrameworkCore.Relational" />
 	  <None Remove="Microsoft.CodeAnalysis.NetAnalyzers" />
+	  <None Remove="Hangfire.PostgreSql" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -12,37 +12,37 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.27" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.27" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.28" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.4" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.4.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="5.0.7" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
-		<PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.11.1" />
-		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.14.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.2" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 		<PackageReference Include="Fody" Version="6.6.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -51,9 +51,9 @@
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="4.0.1" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.10" />
-		<PackageReference Include="Flurl.Http" Version="3.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.0" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.17" />
+		<PackageReference Include="Flurl.Http" Version="3.2.2" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.2" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -62,7 +62,7 @@
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Castle.Core" Version="4.4.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading.Tasks;
 using GetIntoTeachingApi.AppStart;
+using GetIntoTeachingApi.Database;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -12,6 +14,8 @@ namespace GetIntoTeachingApi
     {
         public static async Task Main(string[] args)
         {
+            GetIntoTeachingDbContext.ConfigureNpgsql();
+
             var webHost = CreateHostBuilder(args).Build();
 
             await webHost.RunAsync();

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -15,7 +15,6 @@ namespace GetIntoTeachingApi
         public static async Task Main(string[] args)
         {
             GetIntoTeachingDbContext.ConfigureNpgsql();
-            DbConfiguration.DropHangfireDatabase();
 
             var webHost = CreateHostBuilder(args).Build();
 

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApi
         public static async Task Main(string[] args)
         {
             GetIntoTeachingDbContext.ConfigureNpgsql();
+            DbConfiguration.DropHangfireDatabase();
 
             var webHost = CreateHostBuilder(args).Build();
 

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -11,30 +11,33 @@
     <None Remove="Models\FindApply\" />
     <None Remove="Contracts\Data\teacher_training_adviser\" />
     <None Remove="FluentAssertions.Json" />
+    <None Remove="Microsoft.CodeAnalysis.Common" />
+    <None Remove="Microsoft.CodeAnalysis.CSharp" />
+    <None Remove="Microsoft.CodeAnalysis.Workspaces.Common" />
+    <None Remove="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="coverlet.msbuild" Version="3.1.0">
+	<PackageReference Include="coverlet.msbuild" Version="3.1.2">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.2.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-	<PackageReference Include="Moq" Version="4.16.1" />
-	<PackageReference Include="WireMock.Net" Version="1.4.27" />
+	<PackageReference Include="FluentAssertions" Version="6.5.1" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+	<PackageReference Include="Moq" Version="4.17.2" />
+	<PackageReference Include="WireMock.Net" Version="1.4.37" />
 	<PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/GetIntoTeachingCallbackTests.cs
@@ -46,7 +46,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
@@ -81,7 +81,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
             candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventAddAttendeeTests.cs
@@ -86,7 +86,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
+            candidate.Id.Should().Be(request.CandidateId);
             candidate.ConsiderationJourneyStageId.Should().Be(request.ConsiderationJourneyStageId);
             candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
 
@@ -113,7 +113,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             candidate.HasEventsSubscription.Should().BeTrue();
             candidate.HasMailingListSubscription.Should().BeTrue();
 
-            candidate.TeachingEventRegistrations.First().EventId.Should().Equals(request.EventId);
+            candidate.TeachingEventRegistrations.First().EventId.Should().Be((Guid)request.EventId);
             candidate.TeachingEventRegistrations.First().ChannelId.Should().Be((int)TeachingEventRegistration.Channel.Event);
             candidate.TeachingEventRegistrations.First().IsCancelled.Should().BeFalse();
             candidate.TeachingEventRegistrations.First().RegistrationNotificationSeen.Should().BeFalse();

--- a/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/SchoolsExperience/SchoolsExperienceSignUpTests.cs
@@ -82,10 +82,10 @@ namespace GetIntoTeachingApiTests.Models.SchoolsExperience
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
-            candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
-            candidate.SecondaryPreferredTeachingSubjectId.Should().Equals(request.SecondaryPreferredTeachingSubjectId);
-            candidate.CountryId.Should().Equals(LookupItem.UnitedKingdomCountryId);
+            candidate.Id.Should().Be(request.CandidateId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
+            candidate.SecondaryPreferredTeachingSubjectId.Should().Be(request.SecondaryPreferredTeachingSubjectId);
+            candidate.CountryId.Should().Be(LookupItem.UnitedKingdomCountryId);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
             candidate.LastName.Should().Be(request.LastName);

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -125,9 +125,9 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 TypeId = (int)Candidate.Type.ReturningToTeacherTraining,
                 UkDegreeGradeId = 0,
                 DegreeStatusId = 1,
-                DegreeTypeId = 2,
+                DegreeTypeId = (int)CandidateQualification.DegreeType.Degree,
                 InitialTeacherTrainingYearId = 3,
-                PreferredEducationPhaseId = 4,
+                PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary,
                 HasGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 HasGcseScienceId = 7,
                 PlanningToRetakeGcseMathsAndEnglishId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
@@ -149,17 +149,17 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
 
             var candidate = request.Candidate;
 
-            candidate.Id.Should().Equals(request.CandidateId);
-            candidate.PreferredTeachingSubjectId.Should().Equals(request.PreferredTeachingSubjectId);
-            candidate.CountryId.Should().Equals(request.CountryId);
-            candidate.InitialTeacherTrainingYearId.Should().Equals(request.InitialTeacherTrainingYearId);
-            candidate.PreferredEducationPhaseId.Should().Equals(request.PreferredEducationPhaseId);
-            candidate.HasGcseEnglishId.Should().Equals(request.HasGcseMathsAndEnglishId);
-            candidate.HasGcseMathsId.Should().Equals(request.HasGcseMathsAndEnglishId);
-            candidate.HasGcseScienceId.Should().Equals(request.HasGcseScienceId);
-            candidate.PlanningToRetakeGcseEnglishId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
-            candidate.PlanningToRetakeGcseMathsId.Should().Equals(request.PlanningToRetakeGcseMathsAndEnglishId);
-            candidate.PlanningToRetakeGcseScienceId.Should().Equals(request.PlanningToRetakeGcseScienceId);
+            candidate.Id.Should().Be(request.CandidateId);
+            candidate.PreferredTeachingSubjectId.Should().Be(request.PreferredTeachingSubjectId);
+            candidate.CountryId.Should().Be(request.CountryId);
+            candidate.InitialTeacherTrainingYearId.Should().Be(request.InitialTeacherTrainingYearId);
+            candidate.PreferredEducationPhaseId.Should().Be(request.PreferredEducationPhaseId);
+            candidate.HasGcseEnglishId.Should().Be(request.HasGcseMathsAndEnglishId);
+            candidate.HasGcseMathsId.Should().Be(request.HasGcseMathsAndEnglishId);
+            candidate.HasGcseScienceId.Should().Be(request.HasGcseScienceId);
+            candidate.PlanningToRetakeGcseEnglishId.Should().Be(request.PlanningToRetakeGcseMathsAndEnglishId);
+            candidate.PlanningToRetakeGcseMathsId.Should().Be(request.PlanningToRetakeGcseMathsAndEnglishId);
+            candidate.PlanningToRetakeGcseScienceId.Should().Be(request.PlanningToRetakeGcseScienceId);
             candidate.AdviserStatusId.Should().BeNull();
             candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);


### PR DESCRIPTION
Second attempt at #936 

- Migrate Hangfire database to new storage provider

Our new Postgres storage provider (compatible with Npgsql v6) is not compatible with the structure from the old provider. Its difficult to work out what the difference is in order to create a migration to fix it (as they are very similar) so we can instead point the new provider to a separate schema, which also means we should be able to revert without issues.

We'll need to manually check the job queue after releasing to clear any jobs that are pending down (from the old provider schema).