### PR TITLE
Update school experience statuses

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
@@ -14,11 +14,12 @@ namespace GetIntoTeachingApi.Models.Crm
         {
             Requested = 1, // default
             Confirmed = 222750000,
-            Withdrawn = 222750001,
+            DidNotAttend = 222750001,
             Rejected = 222750002,
             CancelledBySchool = 222750003,
             CancelledByCandidate = 222750004,
             Completed = 222750005,
+            Withdrawn = 222750006,
         }
 
         [JsonIgnore]


### PR DESCRIPTION
I accidentally used the `withdrawn` status for candidates who did not attend their placement when migrating the app to use the CandidateSchoolExperience entity. Withdrawing is a separate action.

To fix this, we have updated the `withdrawn` status name to `did not attend` (which will fix the existing requests), and added a new status for `withdrawn` (so that this can be used in the correct place).