### PR TITLE
Updated Apply models for API v1.2 

### DIFF
--- a/GetIntoTeachingApi/Models/FindApply/ApplicationChoice.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationChoice.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GetIntoTeachingApi.Utils;
+using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class ApplicationChoice
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+        [JsonProperty("status")]
+        public string Status { get; set; }
+        [JsonProperty("provider")]
+        public Provider Provider { get; set; }
+        [JsonProperty("course")]
+        public Course Course { get; set; }
+        [JsonProperty("interviews")]
+        public IEnumerable<Interview> Interviews { get; set; }
+
+        public Crm.ApplicationChoice ToCrmModel()
+        {
+            return new Crm.ApplicationChoice()
+            {
+                FindApplyId = Id.ToString(CultureInfo.CurrentCulture),
+                CreatedAt = CreatedAt,
+                UpdatedAt = UpdatedAt,
+                StatusId = (int)Enum.Parse(typeof(Crm.ApplicationChoice.Status), Status.ToPascalCase()),
+                CourseId = Course.Id?.ToString(),
+                CourseName = Course.Name,
+                Provider = Provider.Name,
+                Interviews = Interviews?.Select(c => c.ToCrmModel()).ToList(),
+            };
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationForm.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GetIntoTeachingApi.Utils;
 using Newtonsoft.Json;
 
 namespace GetIntoTeachingApi.Models.FindApply
@@ -19,5 +23,35 @@ namespace GetIntoTeachingApi.Models.FindApply
         public string ApplicationPhase { get; set; }
         [JsonProperty("recruitment_cycle_year")]
         public int RecruitmentCycleYear { get; set; }
+        [JsonProperty("application_choices")]
+        public ApplicationResponse<IEnumerable<ApplicationChoice>> ApplicationChoices { get; set; }
+        [JsonProperty("references")]
+        public ApplicationResponse<IEnumerable<Reference>> References { get; set; }
+        [JsonProperty("qualifications")]
+        public ApplicationResponse<IEnumerable<object>> Qualifications { get; set; }
+        [JsonProperty("personal_statement")]
+        public ApplicationResponse<IEnumerable<object>> PersonalStatement { get; set; }
+
+        public Crm.ApplicationForm ToCrmModel()
+        {
+            var yearId = ((int)Crm.ApplicationForm.RecruitmentCycleYear.Year2020) + (RecruitmentCycleYear - 2020);
+
+            return new Crm.ApplicationForm()
+            {
+                FindApplyId = Id.ToString(CultureInfo.CurrentCulture),
+                CreatedAt = CreatedAt,
+                UpdatedAt = UpdatedAt,
+                SubmittedAt = SubmittedAt,
+                StatusId = (int)Enum.Parse(typeof(Crm.ApplicationForm.Status), ApplicationStatus.ToPascalCase()),
+                PhaseId = (int)Enum.Parse(typeof(Crm.ApplicationForm.Phase), ApplicationPhase.ToPascalCase()),
+                RecruitmentCycleYearId = yearId,
+                Choices = ApplicationChoices?.Data?.Select(c => c.ToCrmModel()).ToList(),
+                References = References?.Data?.Select(c => c.ToCrmModel()).ToList(),
+                ApplicationChoicesCompleted = ApplicationChoices?.Completed,
+                ReferencesCompleted = References?.Completed,
+                PersonalStatementCompleted = PersonalStatement?.Completed,
+                QualificationsCompleted = Qualifications?.Completed,
+            };
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/FindApply/ApplicationResponse.cs
+++ b/GetIntoTeachingApi/Models/FindApply/ApplicationResponse.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+    public class ApplicationResponse<T>
+    {
+        [JsonProperty("data")]
+        public T Data { get; set; }
+        [JsonProperty("completed")]
+        public bool? Completed { get; set; }
+    }
+}

--- a/GetIntoTeachingApi/Models/FindApply/Candidate.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Candidate.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Linq;
+using Newtonsoft.Json;
 
 namespace GetIntoTeachingApi.Models.FindApply
 {
@@ -8,5 +9,31 @@ namespace GetIntoTeachingApi.Models.FindApply
         public string Id { get; set; }
         [JsonProperty("attributes")]
         public CandidateAttributes Attributes { get; set; }
+
+        public Crm.Candidate ToCrmModel()
+        {
+            var candidate = new Crm.Candidate()
+            {
+                Email = Attributes.Email,
+                FindApplyId = Id,
+                FindApplyCreatedAt = Attributes.CreatedAt,
+                FindApplyUpdatedAt = Attributes.UpdatedAt,
+                ApplicationForms = Attributes.ApplicationForms?.Select(f => f.ToCrmModel()).ToList(),
+            };
+
+            var latestForm = candidate.ApplicationForms?.OrderByDescending(f => f.UpdatedAt).FirstOrDefault();
+
+            if (latestForm == null)
+            {
+                candidate.FindApplyStatusId = (int)Crm.ApplicationForm.Status.NeverSignedIn;
+            }
+            else
+            {
+                candidate.FindApplyStatusId = latestForm.StatusId;
+                candidate.FindApplyPhaseId = latestForm.PhaseId;
+            }
+
+            return candidate;
+        }
     }
 }

--- a/GetIntoTeachingApi/Models/FindApply/Course.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Course.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+	public class Course
+	{
+		[JsonProperty("uuid")]
+		public Guid? Id { get; set; }
+		[JsonProperty("name")]
+		public string Name { get; set; }
+	}
+}

--- a/GetIntoTeachingApi/Models/FindApply/Interview.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Interview.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+	public class Interview
+	{
+		[JsonProperty("id")]
+		public int Id { get; set; }
+		[JsonProperty("date_and_time")]
+		public DateTime DateAndTime { get; set; }
+		[JsonProperty("created_at")]
+		public DateTime CreatedAt { get; set; }
+		[JsonProperty("updated_at")]
+		public DateTime UpdatedAt { get; set; }
+		[JsonProperty("cancelled_at")]
+		public DateTime? CancelledAt { get; set; }
+
+		public Crm.ApplicationInterview ToCrmModel()
+		{
+			return new Crm.ApplicationInterview()
+			{
+				FindApplyId = Id.ToString(CultureInfo.CurrentCulture),
+				CreatedAt = CreatedAt,
+				UpdatedAt = UpdatedAt,
+				ScheduledAt = DateAndTime,
+				CancelledAt = CancelledAt,
+			};
+		}
+	}
+}

--- a/GetIntoTeachingApi/Models/FindApply/Provider.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Provider.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+	public class Provider
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+	}
+}

--- a/GetIntoTeachingApi/Models/FindApply/Reference.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Reference.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Globalization;
+using GetIntoTeachingApi.Utils;
+using Newtonsoft.Json;
+
+namespace GetIntoTeachingApi.Models.FindApply
+{
+	public class Reference
+	{
+		[JsonProperty("id")]
+		public int Id { get; set; }
+		[JsonProperty("requested_at")]
+		public DateTime? RequestedAt { get; set; }
+		[JsonProperty("feedback_status")]
+		public string FeedbackStatus { get; set; }
+		[JsonProperty("referee_type")]
+		public string RefereeType { get; set; }
+
+		public Crm.ApplicationReference ToCrmModel()
+		{
+			return new Crm.ApplicationReference()
+			{
+				FindApplyId = Id.ToString(CultureInfo.CurrentCulture),
+				RequestedAt = RequestedAt,
+				FeedbackStatusId = (int)Enum.Parse(typeof(Crm.ApplicationReference.FeedbackStatus), FeedbackStatus.ToPascalCase()),
+				Type = RefereeType,
+			};
+		}
+	}
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationChoiceTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationChoiceTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ApplicationChoiceTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(ApplicationChoice);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
+            type.GetProperty("CreatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
+            type.GetProperty("UpdatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+            type.GetProperty("Status").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "status");
+            type.GetProperty("Provider").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "provider");
+            type.GetProperty("Course").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "course");
+            type.GetProperty("Interviews").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "interviews");
+        }
+
+        [Fact]
+        public void ToCrmModel_MapsToACrmApplicationChoiceModel()
+        {
+            var interview = new Interview()
+            {
+                Id = 456,
+                DateAndTime = new DateTime(2021, 1, 2),
+                CreatedAt = new DateTime(2021, 1, 3),
+                UpdatedAt = new DateTime(2021, 1, 4),
+                CancelledAt = new DateTime(2021, 1, 5),
+            };
+
+            var choice = new ApplicationChoice()
+            {
+                Id = 123,
+                CreatedAt = new DateTime(2021, 1, 3),
+                UpdatedAt = new DateTime(2021, 1, 4),
+                Status = "cancelled",
+                Provider = new Provider() { Name = "Provider Name" },
+                Course = new Course() { Id = Guid.NewGuid(), Name = "Course Name" },
+                Interviews = new List<Interview>() { interview },
+            };
+
+            var crmChoice = choice.ToCrmModel();
+
+            crmChoice.FindApplyId.Should().Be(choice.Id.ToString());
+            crmChoice.CreatedAt.Should().Be(choice.CreatedAt);
+            crmChoice.UpdatedAt.Should().Be(choice.UpdatedAt);
+            crmChoice.StatusId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationChoice.Status.Cancelled);
+            crmChoice.Provider.Should().Be(choice.Provider.Name);
+            crmChoice.CourseId.Should().Be(choice.Course.Id.ToString());
+            crmChoice.CourseName.Should().Be(choice.Course.Name);
+            crmChoice.Interviews.First().FindApplyId.Should().Be(interview.Id.ToString());
+        }
+
+        [Fact]
+        public void ToCrmModel_WhenRelationshipsAreNull_MapsToACrmApplicationChoiceModel()
+        {
+            var choice = new ApplicationChoice()
+            {
+                Status = "cancelled",
+                Provider = new Provider() { Name = "Provider Name" },
+                Course = new Course() { Id = Guid.NewGuid(), Name = "Course Name" },
+            };
+
+            var crmChoice = choice.ToCrmModel();
+
+            crmChoice.Interviews.Should().BeNull();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationFormTests.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using GetIntoTeachingApi.Models.FindApply;
 using Newtonsoft.Json;
 using Xunit;
@@ -26,6 +29,77 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_phase");
             type.GetProperty("RecruitmentCycleYear").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "recruitment_cycle_year");
+            type.GetProperty("ApplicationChoices").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "application_choices");
+            type.GetProperty("References").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "references");
+            type.GetProperty("Qualifications").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "qualifications");
+            type.GetProperty("PersonalStatement").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "personal_statement");
+        }
+
+        [Fact]
+        public void ToCrmModel_MapsToACrmApplicationFormModel()
+        {
+            var reference = new Reference()
+            {
+                Id = 123,
+                FeedbackStatus = "cancelled",
+                RefereeType = "employer",
+                RequestedAt = new DateTime(2021, 1, 2),
+            };
+
+            var choice = new ApplicationChoice()
+            {
+                Id = 456,
+                CreatedAt = new DateTime(2021, 1, 3),
+                UpdatedAt = new DateTime(2021, 1, 4),
+                Status = "cancelled",
+                Provider = new Provider() { Name = "Provider Name" },
+                Course = new Course() { Id = Guid.NewGuid(), Name = "Course Name" },
+            };
+
+            var form = new ApplicationForm()
+            {
+                Id = 789,
+                CreatedAt = new DateTime(2021, 1, 5),
+                UpdatedAt = new DateTime(2021, 1, 6),
+                SubmittedAt = new DateTime(2021, 1, 7),
+                ApplicationStatus = "never_signed_in",
+                ApplicationPhase = "apply_1",
+                RecruitmentCycleYear = 2022,
+                ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = true, Data = new List<ApplicationChoice> { choice } },
+                References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false, Data = new List<Reference> { reference } },
+                Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
+                PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
+            };
+
+            var crmForm = form.ToCrmModel();
+
+            crmForm.FindApplyId.Should().Be(form.Id.ToString());
+            crmForm.CreatedAt.Should().Be(form.CreatedAt);
+            crmForm.UpdatedAt.Should().Be(form.UpdatedAt);
+            crmForm.StatusId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn);
+            crmForm.PhaseId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1);
+            crmForm.RecruitmentCycleYearId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022);
+            crmForm.Choices.First().FindApplyId.Should().Be(choice.Id.ToString());
+            crmForm.References.First().FindApplyId.Should().Be(reference.Id.ToString());
+            crmForm.ApplicationChoicesCompleted.Should().Be(form.ApplicationChoices.Completed);
+            crmForm.ReferencesCompleted.Should().Be(form.References.Completed);
+            crmForm.QualificationsCompleted.Should().Be(form.Qualifications.Completed);
+            crmForm.PersonalStatementCompleted.Should().Be(form.PersonalStatement.Completed);
+        }
+
+        [Fact]
+        public void ToCrmModel_WhenRelationshipsAreNull_MapsToACrmApplicationFormModel()
+        {
+            var form = new ApplicationForm() { ApplicationStatus = "never_signed_in", ApplicationPhase = "apply_1" };
+
+            var crmForm = form.ToCrmModel();
+
+            crmForm.Choices.Should().BeNull();
+            crmForm.References.Should().BeNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/ApplicationResponseTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ApplicationResponseTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ApplicationResponseTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(ApplicationResponse<object>);
+
+            type.GetProperty("Data").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "data");
+            type.GetProperty("Completed").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "completed");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CandidateTests.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using GetIntoTeachingApi.Models.FindApply;
 using Newtonsoft.Json;
 using Xunit;
@@ -16,6 +19,57 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
             type.GetProperty("Attributes").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "attributes");
+        }
+
+        [Fact]
+        public void ToCrmModel_MapsToACrmCandidateModel()
+        {
+            var form = new ApplicationForm()
+            {
+                Id = 123,
+                ApplicationStatus = "offer_deferred",
+                ApplicationPhase = "apply_1",
+            };
+
+            var candidate = new Candidate()
+            {
+                Id = "123",
+                Attributes = new CandidateAttributes()
+                {
+                    Email = "email@address.com",
+                    CreatedAt = new DateTime(2021, 1, 1),
+                    UpdatedAt = new DateTime(2021, 1, 2),
+                    ApplicationForms = new List<ApplicationForm>() { form },
+                },
+            };
+
+            var crmCandidate = candidate.ToCrmModel();
+
+            crmCandidate.FindApplyId.Should().Be(candidate.Id);
+            crmCandidate.FindApplyCreatedAt.Should().Be(candidate.Attributes.CreatedAt);
+            crmCandidate.FindApplyUpdatedAt.Should().Be(candidate.Attributes.UpdatedAt);
+            crmCandidate.FindApplyStatusId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.OfferDeferred);
+            crmCandidate.FindApplyPhaseId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1);
+            crmCandidate.ApplicationForms.First().FindApplyId.Should().Be(form.Id.ToString());
+        }
+
+        [Fact]
+        public void ToCrmModel_WhenApplicationFormsIsNull_MapsToACrmCandidateModel()
+        {
+            var candidate = new Candidate()
+            {
+                Id = "123",
+                Attributes = new CandidateAttributes()
+                {
+                    ApplicationForms = null,
+                },
+            };
+
+            var crmCandidate = candidate.ToCrmModel();
+
+            crmCandidate.FindApplyId.Should().Be(candidate.Id);
+            crmCandidate.FindApplyStatusId.Should().Be((int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn);
+            crmCandidate.FindApplyPhaseId.Should().BeNull();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/FindApply/CourseTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/CourseTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class CourseTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Course);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "uuid");
+            type.GetProperty("Name").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "name");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/InterviewTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/InterviewTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class InterviewTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Interview);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
+            type.GetProperty("DateAndTime").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "date_and_time");
+            type.GetProperty("CreatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
+            type.GetProperty("UpdatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
+            type.GetProperty("CancelledAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "cancelled_at");
+        }
+
+        [Fact]
+        public void ToCrmModel_MapsToACrmApplicationInterviewModel()
+        {
+            var interview = new Interview()
+            {
+                Id = 123,
+                DateAndTime = new DateTime(2021, 1, 2),
+                CreatedAt = new DateTime(2021, 1, 3),
+                UpdatedAt = new DateTime(2021, 1, 4),
+                CancelledAt = new DateTime(2021, 1, 5),
+            };
+
+            var crmInterview = interview.ToCrmModel();
+
+            crmInterview.FindApplyId.Should().Be(interview.Id.ToString());
+            crmInterview.ScheduledAt.Should().Be(interview.DateAndTime);
+            crmInterview.CreatedAt.Should().Be(interview.CreatedAt);
+            crmInterview.UpdatedAt.Should().Be(interview.UpdatedAt);
+            crmInterview.CancelledAt.Should().Be(interview.CancelledAt);
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/ProviderTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ProviderTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ProviderTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Provider);
+
+            type.GetProperty("Name").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "name");
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Models/FindApply/ReferenceTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ReferenceTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using FluentAssertions;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Models.FindApply;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Models.FindApply
+{
+    public class ReferenceTests
+    {
+        [Fact]
+        public void JsonAttributes()
+        {
+            var type = typeof(Reference);
+
+            type.GetProperty("Id").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
+            type.GetProperty("RequestedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "requested_at");
+            type.GetProperty("FeedbackStatus").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "feedback_status");
+            type.GetProperty("RefereeType").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "referee_type");
+        }
+
+        [Fact]
+        public void ToCrmModel_MapsToACrmApplicationReferenceModel()
+        {
+            var reference = new Reference()
+            {
+                Id = 123,
+                FeedbackStatus = "cancelled",
+                RefereeType = "employer",
+                RequestedAt = new DateTime(2021, 1, 2),
+            };
+
+            var crmReference = reference.ToCrmModel();
+
+            crmReference.FindApplyId.Should().Be(reference.Id.ToString());
+            crmReference.FeedbackStatusId.Should().Be((int)ApplicationReference.FeedbackStatus.Cancelled);
+            crmReference.Type.Should().Be(reference.RefereeType);
+            crmReference.RequestedAt.Should().Be(reference.RequestedAt);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-3085](https://trello.com/c/2HSIv6Bq/3085-update-api-for-v12-of-apply-git-datasharing)

- Updated Apply models for API v1.2

The updated Apply API (v1.2) contains additional models related to the `ApplicationForm`; this commit adds them and maps the attributes to the JSON response payload from the API.

Add convenience methods on each model to map from the Apply models to the CRM models.