### PR TITLE
Add ApplicationFormUpsert job

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -102,7 +102,7 @@ namespace GetIntoTeachingApi.Jobs
 
             return findApplyApplicationForms.Select(findApplyForm =>
             {
-                var existingForm = _crm.GetApplicationForm(findApplyForm.Id.ToString(CultureInfo.CurrentCulture));
+                var existingForm = _crm.GetFindApplyModels<Models.Crm.ApplicationForm>(new string[] { findApplyForm.Id.ToString(CultureInfo.CurrentCulture) }).FirstOrDefault();
 
                 var yearId = ((int)Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2020) + (findApplyForm.RecruitmentCycleYear - 2020);
 

--- a/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging;
+using MoreLinq;
+
+namespace GetIntoTeachingApi.Jobs
+{
+    public class UpsertApplicationFormJob : BaseJob
+    {
+        private readonly IPerformContextAdapter _contextAdapter;
+        private readonly IMetricService _metrics;
+        private readonly ICrmService _crm;
+        private readonly IAppSettings _appSettings;
+        private readonly ILogger<UpsertApplicationFormJob> _logger;
+
+        public UpsertApplicationFormJob(
+            IEnv env,
+            IRedisService redis,
+            IPerformContextAdapter contextAdapter,
+            IMetricService metrics,
+            ICrmService crm,
+            ILogger<UpsertApplicationFormJob> logger,
+            IAppSettings appSettings)
+            : base(env, redis)
+        {
+            _contextAdapter = contextAdapter;
+            _metrics = metrics;
+            _crm = crm;
+            _logger = logger;
+            _appSettings = appSettings;
+        }
+
+        public void Run(string json, PerformContext context)
+        {
+            var form = json.DeserializeChangeTracked<ApplicationForm>();
+
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                throw new InvalidOperationException("UpsertApplicationFormJob - Aborting (CRM integration paused).");
+            }
+
+            _logger.LogInformation("UpsertApplicationFormJob - Started ({Attempt})", AttemptInfo(context, _contextAdapter));
+            _logger.LogInformation("UpsertApplicationFormJob - Payload {Payload}", Redactor.RedactJson(json));
+
+            if (IsLastAttempt(context, _contextAdapter))
+            {
+                _logger.LogInformation("UpsertApplicationFormJob - Deleted");
+            }
+            else
+            {
+                SaveApplicationForm(form);
+                SaveApplicationReferences(form.References, (Guid)form.Id);
+                SaveApplicationChoices(form.Choices, (Guid)form.Id);
+
+                _logger.LogInformation("UpsertApplicationFormJob - Succeeded - {Id}", form.Id);
+            }
+
+            var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"UpsertApplicationFormJob" }).Observe(duration);
+        }
+
+        private void SaveApplicationForm(ApplicationForm form)
+        {
+            var existing = _crm.GetFindApplyModels<ApplicationForm>(new string[] { form.FindApplyId }).FirstOrDefault();
+
+            if (existing != null)
+            {
+                form.Id = existing.Id;
+            }
+
+            _crm.Save(form);
+        }
+
+        private void SaveApplicationChoices(IEnumerable<ApplicationChoice> choices, Guid formId)
+        {
+            var existing = _crm.GetFindApplyModels<ApplicationChoice>(choices.Select(c => c.FindApplyId));
+
+            choices?.ForEach(c =>
+            {
+                c.Id = existing.FirstOrDefault(e => e.FindApplyId == c.FindApplyId)?.Id;
+                c.ApplicationFormId = formId;
+                _crm.Save(c);
+
+                SaveApplicationInterviews(c.Interviews, (Guid)c.Id);
+            });
+        }
+
+        private void SaveApplicationReferences(IEnumerable<ApplicationReference> references, Guid formId)
+        {
+            var existing = _crm.GetFindApplyModels<ApplicationReference>(references.Select(r => r.FindApplyId));
+
+            references?.ForEach(r =>
+            {
+                r.Id = existing.FirstOrDefault(e => e.FindApplyId == r.FindApplyId)?.Id;
+                r.ApplicationFormId = formId;
+                _crm.Save(r);
+            });
+        }
+
+        private void SaveApplicationInterviews(IEnumerable<ApplicationInterview> interviews, Guid choiceId)
+        {
+            var existing = _crm.GetFindApplyModels<ApplicationInterview>(interviews.Select(i => i.FindApplyId));
+
+            interviews?.ForEach(i =>
+            {
+                i.Id = existing.FirstOrDefault(e => e.FindApplyId == i.FindApplyId)?.Id;
+                i.ApplicationChoiceId = choiceId;
+                _crm.Save(i);
+            });
+        }
+    }
+}

--- a/GetIntoTeachingApi/Jobs/UpsertModelWithCandidateIdJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertModelWithCandidateIdJob.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace GetIntoTeachingApi.Jobs
 {
-    public class UpsertModelJob<T> : BaseJob
+    public class UpsertModelWithCandidateIdJob<T> : BaseJob
         where T : BaseModel, IHasCandidateId
     {
         private readonly IPerformContextAdapter _contextAdapter;
@@ -18,15 +18,15 @@ namespace GetIntoTeachingApi.Jobs
         private readonly IAppSettings _appSettings;
         private readonly INotifyService _notifyService;
         private readonly ICrmService _crm;
-        private readonly ILogger<UpsertModelJob<T>> _logger;
+        private readonly ILogger<UpsertModelWithCandidateIdJob<T>> _logger;
 
-        public UpsertModelJob(
+        public UpsertModelWithCandidateIdJob(
             IEnv env,
             IRedisService redis,
             IPerformContextAdapter contextAdapter,
             ICrmService crm,
             IMetricService metrics,
-            ILogger<UpsertModelJob<T>> logger,
+            ILogger<UpsertModelWithCandidateIdJob<T>> logger,
             IAppSettings appSettings,
             INotifyService notifyService)
             : base(env, redis)

--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -137,7 +137,7 @@ namespace GetIntoTeachingApi.Services
             {
                 applicationForm.CandidateId = (Guid)candidate.Id;
                 string json = applicationForm.SerializeChangeTracked();
-                _jobClient.Enqueue<UpsertModelJob<ApplicationForm>>((x) => x.Run(json, null));
+                _jobClient.Enqueue<UpsertApplicationFormJob>((x) => x.Run(json, null));
             }
         }
 

--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -117,7 +117,7 @@ namespace GetIntoTeachingApi.Services
             {
                 registration.CandidateId = (Guid)candidate.Id;
                 string json = registration.SerializeChangeTracked();
-                _jobClient.Enqueue<UpsertModelJob<TeachingEventRegistration>>((x) => x.Run(json, null));
+                _jobClient.Enqueue<UpsertModelWithCandidateIdJob<TeachingEventRegistration>>((x) => x.Run(json, null));
             }
         }
 
@@ -127,7 +127,7 @@ namespace GetIntoTeachingApi.Services
             {
                 qualification.CandidateId = (Guid)candidate.Id;
                 string json = qualification.SerializeChangeTracked();
-                _jobClient.Enqueue<UpsertModelJob<CandidateQualification>>((x) => x.Run(json, null));
+                _jobClient.Enqueue<UpsertModelWithCandidateIdJob<CandidateQualification>>((x) => x.Run(json, null));
             }
         }
 
@@ -147,7 +147,7 @@ namespace GetIntoTeachingApi.Services
             {
                 pastTeachingPosition.CandidateId = (Guid)candidate.Id;
                 string json = pastTeachingPosition.SerializeChangeTracked();
-                _jobClient.Enqueue<UpsertModelJob<CandidatePastTeachingPosition>>((x) => x.Run(json, null));
+                _jobClient.Enqueue<UpsertModelWithCandidateIdJob<CandidatePastTeachingPosition>>((x) => x.Run(json, null));
             }
         }
 
@@ -157,7 +157,7 @@ namespace GetIntoTeachingApi.Services
             {
                 schoolExperience.CandidateId = (Guid)candidate.Id;
                 string json = schoolExperience.SerializeChangeTracked();
-                _jobClient.Enqueue<UpsertModelJob<CandidateSchoolExperience>>((x) => x.Run(json, null));
+                _jobClient.Enqueue<UpsertModelWithCandidateIdJob<CandidateSchoolExperience>>((x) => x.Run(json, null));
             }
         }
 
@@ -178,7 +178,7 @@ namespace GetIntoTeachingApi.Services
 
             phoneCall.CandidateId = candidate.Id.ToString();
             string json = phoneCall.SerializeChangeTracked();
-            _jobClient.Enqueue<UpsertModelJob<PhoneCall>>((x) => x.Run(json, null));
+            _jobClient.Enqueue<UpsertModelWithCandidateIdJob<PhoneCall>>((x) => x.Run(json, null));
         }
 
         private void SavePrivacyPolicy(CandidatePrivacyPolicy privacyPolicy, Candidate candidate)
@@ -190,7 +190,7 @@ namespace GetIntoTeachingApi.Services
 
             privacyPolicy.CandidateId = (Guid)candidate.Id;
             string json = privacyPolicy.SerializeChangeTracked();
-            _jobClient.Enqueue<UpsertModelJob<CandidatePrivacyPolicy>>((x) => x.Run(json, null));
+            _jobClient.Enqueue<UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy>>((x) => x.Run(json, null));
         }
     }
 }

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -23,7 +23,7 @@ namespace GetIntoTeachingApi.Services
         TeachingEvent GetTeachingEvent(string readableId);
         IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas();
         CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt);
-        ApplicationForm GetApplicationForm(string findApplyId);
+        public IEnumerable<T> GetFindApplyModels<T>(IEnumerable<string> findApplyIds) where T : BaseModel, IHasFindApplyId;
         bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);

--- a/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
@@ -71,9 +71,15 @@ namespace GetIntoTeachingApiTests.Helpers
             _crmService.DeleteLink(source, relationship, target, context);
         }
 
-        public ApplicationForm GetApplicationForm(string findApplyId)
+        public IEnumerable<T> GetFindApplyModels<T>(IEnumerable<string> findApplyIds) where T : BaseModel, IHasFindApplyId
         {
-            return ApplicationForms.FirstOrDefault(f => f.FindApplyId == findApplyId);
+            switch (typeof(T).ToString())
+            {
+                case "GetIntoTeachingApi.Models.Crm.ApplicationForm":
+                    return ApplicationForms.Where(f => findApplyIds.Contains(f.FindApplyId)) as IEnumerable<T>;
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         public CallbackBookingQuota GetCallbackBookingQuota(DateTime scheduledAt)

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -82,8 +82,8 @@ namespace GetIntoTeachingApiTests.Jobs
             var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.GetApplicationForm("1")).Returns<GetIntoTeachingApi.Models.Crm.ApplicationForm>(null);
-            _mockCrm.Setup(m => m.GetApplicationForm("2")).Returns(existingApplicationForm);
+            _mockCrm.Setup(m => m.GetFindApplyModels<GetIntoTeachingApi.Models.Crm.ApplicationForm>(new string[] { "1" })).Returns(Array.Empty<GetIntoTeachingApi.Models.Crm.ApplicationForm>());
+            _mockCrm.Setup(m => m.GetFindApplyModels<GetIntoTeachingApi.Models.Crm.ApplicationForm>(new string[] { "2" })).Returns(new[] { existingApplicationForm });
 
             _job.Run(_candidate);
 

--- a/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GetIntoTeachingApi.Adapters;
+using GetIntoTeachingApi.Jobs;
+using GetIntoTeachingApi.Models;
+using GetIntoTeachingApi.Models.Crm;
+using GetIntoTeachingApi.Services;
+using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApiTests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GetIntoTeachingApiTests.Jobs
+{
+    public class UpsertApplicationFormJobTests
+    {
+        private readonly Mock<IPerformContextAdapter> _mockContext;
+        private readonly Mock<IAppSettings> _mockAppSettings;
+        private readonly Mock<ICrmService> _mockCrm;
+        private readonly ApplicationForm _form;
+        private readonly ApplicationReference _reference;
+        private readonly ApplicationChoice _choice;
+        private readonly ApplicationInterview _interview;
+        private readonly IMetricService _metrics;
+        private readonly UpsertApplicationFormJob _job;
+        private readonly Mock<ILogger<UpsertApplicationFormJob>> _mockLogger;
+
+        public UpsertApplicationFormJobTests()
+        {
+            _mockContext = new Mock<IPerformContextAdapter>();
+            _mockLogger = new Mock<ILogger<UpsertApplicationFormJob>>();
+            _mockAppSettings = new Mock<IAppSettings>();
+            _mockCrm = new Mock<ICrmService>();
+            _metrics = new MetricService();
+            _job = new UpsertApplicationFormJob(
+                new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _metrics, _mockCrm.Object,
+                _mockLogger.Object, _mockAppSettings.Object);
+
+            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertApplicationFormJob" });
+            _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
+
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+
+            _reference = new ApplicationReference() { FindApplyId = "2" };
+            _interview = new ApplicationInterview() { FindApplyId = "4" };
+            _choice = new ApplicationChoice() { FindApplyId = "3", Interviews = new List<ApplicationInterview> { _interview } };
+            _form = new ApplicationForm()
+            {
+                FindApplyId = "1",
+                References = new List<ApplicationReference> { _reference },
+                Choices = new List<ApplicationChoice> { _choice },
+            };
+        }
+
+        [Fact]
+        public void Run_OnSuccessWithNewModels_InsertsApplicationFormAndRelatedModels()
+        {
+            var formId = Guid.NewGuid();
+            var choiceId = Guid.NewGuid();
+            var referenceId = Guid.NewGuid();
+            var interviewId = Guid.NewGuid();
+
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationForm>(new[] { _form.FindApplyId })).Returns(Array.Empty<ApplicationForm>());
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationChoice>(new[] { _choice.FindApplyId })).Returns(Array.Empty<ApplicationChoice>());
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationInterview>(new[] { _interview.FindApplyId })).Returns(Array.Empty<ApplicationInterview>());
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationReference>(new[] { _reference.FindApplyId })).Returns(Array.Empty<ApplicationReference>());
+
+            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationForm>())).Callback<BaseModel>(f => f.Id = formId);
+            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationChoice>())).Callback<BaseModel>(c => c.Id = choiceId);
+            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationInterview>())).Callback<BaseModel>(i => i.Id = interviewId);
+            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationReference>())).Callback<BaseModel>(r => r.Id = referenceId);
+
+            var json = _form.SerializeChangeTracked();
+            _job.Run(json, null);
+
+            _form.Id = formId;
+            _choice.Id = choiceId;
+            _choice.ApplicationFormId = formId;
+            _interview.Id = interviewId;
+            _interview.ApplicationChoiceId = choiceId;
+            _reference.Id = referenceId;
+            _reference.ApplicationFormId = formId;
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
+
+            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (1/24)");
+            _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Payload {Redactor.RedactJson(json)}");
+            _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Succeeded - {_form.Id}");
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertApplicationFormJob" }).Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Run_OnSuccessWithExistingModels_UpdatesApplicationFormAndRelatedModels()
+        {
+            var formId = Guid.NewGuid();
+            var choiceId = Guid.NewGuid();
+            var referenceId = Guid.NewGuid();
+            var interviewId = Guid.NewGuid();
+
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationForm>(new[] { _form.FindApplyId }))
+                .Returns(new[] { new ApplicationForm() { Id = formId, FindApplyId = _form.FindApplyId } });
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationChoice>(new[] { _choice.FindApplyId }))
+                .Returns(new[] { new ApplicationChoice() { Id = choiceId, FindApplyId = _choice.FindApplyId } });
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationInterview>(new[] { _interview.FindApplyId }))
+                .Returns(new[] { new ApplicationInterview() { Id = interviewId, FindApplyId = _interview.FindApplyId } });
+            _mockCrm.Setup(m => m.GetFindApplyModels<ApplicationReference>(new[] { _reference.FindApplyId }))
+                .Returns(new[] { new ApplicationReference() { Id = referenceId, FindApplyId = _reference.FindApplyId } });
+
+            var json = _form.SerializeChangeTracked();
+            _job.Run(json, null);
+
+            _form.Id = formId;
+            _choice.Id = choiceId;
+            _choice.ApplicationFormId = formId;
+            _interview.Id = interviewId;
+            _interview.ApplicationChoiceId = choiceId;
+            _reference.Id = referenceId;
+            _reference.ApplicationFormId = formId;
+
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
+            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
+        }
+
+        [Fact]
+        public void Run_OnFailure_Logs()
+        {
+            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
+
+            _job.Run(_form.SerializeChangeTracked(), null);
+
+            _mockCrm.Verify(mock => mock.Save(It.IsAny<ApplicationForm>()), Times.Never);
+
+            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (24/24)");
+            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Deleted");
+            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertApplicationFormJob" }).Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Run_WhenCrmIntegrationPaused_Aborts()
+        {
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+
+            var json = _form.SerializeChangeTracked();
+            Action action = () => _job.Run(json, null);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("UpsertApplicationFormJob - Aborting (CRM integration paused).");
+        }
+
+        private static bool IsMatch(object objectA, object objectB)
+        {
+            objectA.Should().BeEquivalentTo(objectB);
+            return true;
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Jobs/UpsertModelWithCandidateIdJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertModelWithCandidateIdJobTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Jobs
 {
-    public class UpsertModelJobTests
+    public class UpsertModelWithCandidateIdJobTests
     {
         private readonly Mock<IPerformContextAdapter> _mockContext;
         private readonly Mock<IAppSettings> _mockAppSettings;
@@ -22,19 +22,19 @@ namespace GetIntoTeachingApiTests.Jobs
         private readonly Mock<INotifyService> _mockNotifyService;
         private readonly CandidatePrivacyPolicy _policy;
         private readonly IMetricService _metrics;
-        private readonly UpsertModelJob<CandidatePrivacyPolicy> _job;
-        private readonly Mock<ILogger<UpsertModelJob<CandidatePrivacyPolicy>>> _mockLogger;
+        private readonly UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy> _job;
+        private readonly Mock<ILogger<UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy>>> _mockLogger;
 
-        public UpsertModelJobTests()
+        public UpsertModelWithCandidateIdJobTests()
         {
             _mockContext = new Mock<IPerformContextAdapter>();
-            _mockLogger = new Mock<ILogger<UpsertModelJob<CandidatePrivacyPolicy>>>();
+            _mockLogger = new Mock<ILogger<UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy>>>();
             _mockAppSettings = new Mock<IAppSettings>();
             _mockCrm = new Mock<ICrmService>();
             _mockNotifyService = new Mock<INotifyService>();
             _metrics = new MetricService();
             _policy = new CandidatePrivacyPolicy() { Id = Guid.NewGuid(), AcceptedAt = DateTime.UtcNow, CandidateId = Guid.NewGuid() };
-            _job = new UpsertModelJob<CandidatePrivacyPolicy>(
+            _job = new UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy>(
                 new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _mockCrm.Object,
                 _metrics, _mockLogger.Object, _mockAppSettings.Object, _mockNotifyService.Object);
 

--- a/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
@@ -48,7 +48,7 @@ namespace GetIntoTeachingApiTests.Services
             qualification.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-                           It.Is<Job>(job => job.Type == typeof(UpsertModelJob<CandidateQualification>) && job.Method.Name == "Run" &&
+                           It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<CandidateQualification>) && job.Method.Name == "Run" &&
                            IsMatch(qualification, (string)job.Args[0])),
                            It.IsAny<EnqueuedState>()));
         }
@@ -66,7 +66,7 @@ namespace GetIntoTeachingApiTests.Services
             pastTeachingPosition.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<CandidatePastTeachingPosition>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<CandidatePastTeachingPosition>) && job.Method.Name == "Run" &&
                IsMatch(pastTeachingPosition, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
         }
@@ -102,7 +102,7 @@ namespace GetIntoTeachingApiTests.Services
             schoolExperience.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<CandidateSchoolExperience>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<CandidateSchoolExperience>) && job.Method.Name == "Run" &&
                IsMatch(schoolExperience, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
         }
@@ -120,7 +120,7 @@ namespace GetIntoTeachingApiTests.Services
             registration.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<TeachingEventRegistration>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<TeachingEventRegistration>) && job.Method.Name == "Run" &&
                IsMatch(registration, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
         }
@@ -139,7 +139,7 @@ namespace GetIntoTeachingApiTests.Services
             phoneCall.CandidateId = candidateId.ToString();
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<PhoneCall>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<PhoneCall>) && job.Method.Name == "Run" &&
                IsMatch(phoneCall, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
 
@@ -162,7 +162,7 @@ namespace GetIntoTeachingApiTests.Services
             policy.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<CandidatePrivacyPolicy>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<CandidatePrivacyPolicy>) && job.Method.Name == "Run" &&
                IsMatch(policy, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
         }

--- a/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
@@ -84,7 +84,7 @@ namespace GetIntoTeachingApiTests.Services
             applicationForm.CandidateId = candidateId;
 
             _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(UpsertModelJob<ApplicationForm>) && job.Method.Name == "Run" &&
+               It.Is<Job>(job => job.Type == typeof(UpsertApplicationFormJob) && job.Method.Name == "Run" &&
                IsMatch(applicationForm, (string)job.Args[0])),
                It.IsAny<EnqueuedState>()));
         }

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Services;
@@ -218,27 +218,35 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetApplicationForm_WithExistingFindApplyId_ReturnsMatchingForm()
+        public void GetFindApplyModels_WithExistingFindApplyIds_ReturnsMatchingModels()
         {
             var findApplyId = "12345";
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
                 q => VerifyGetApplicationFormQueryExpression(q, findApplyId)))).Returns(MockApplicationForms());
 
-            var result = _crm.GetApplicationForm(findApplyId);
+            var results = _crm.GetFindApplyModels<ApplicationForm>(new string[] { findApplyId });
 
-            result.Should().NotBeNull();
+            results.Should().NotBeEmpty();
         }
 
         [Fact]
-        public void GetApplicationForm_WithUnknownFindApplyId_ReturnsNull()
+        public void GetFindApplyModels_WithUnknownFindApplyIds_ReturnsEmpty()
         {
             var findApplyId = "12345";
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
                 q => VerifyGetApplicationFormQueryExpression(q, findApplyId)))).Returns(Array.Empty<Entity>());
 
-            var result = _crm.GetApplicationForm(findApplyId);
+            var results = _crm.GetFindApplyModels<ApplicationForm>(new string[] { findApplyId });
 
-            result.Should().BeNull();
+            results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetFindApplyModels_WithEmptyFindApplyIds_ReturnsEmpty()
+        {
+            var results = _crm.GetFindApplyModels<ApplicationForm>(Array.Empty<string>());
+
+            results.Should().BeEmpty();
         }
 
         [Fact]
@@ -467,7 +475,7 @@ namespace GetIntoTeachingApiTests.Services
             var conditions = query.Criteria.Conditions;
 
             var hasFindApplyIdCondition = conditions.Where(c => c.AttributeName == "dfe_applicationformid" &&
-                c.Operator == ConditionOperator.Equal && c.Values.FirstOrDefault().ToString() == findApplyId).Any();
+                c.Operator == ConditionOperator.In && (c.Values.First() as string) == findApplyId).Any();
 
             return hasEntityName && hasFindApplyIdCondition;
         }


### PR DESCRIPTION
[Trello-3085](https://trello.com/c/2HSIv6Bq/3085-update-api-for-v12-of-apply-git-datasharing)

- Add generic Find/Apply CRM query

We are going to need to query application forms/choices/references/interviews from the CRM in order to reconcile the Apply API response with existing records based on the Find/Apply ID. Instead of having multiple CRM methods for each model we can leverage the `IHasFindApply` interface to make a generic method to query the models.

- Add job to upsert an ApplicationForm and related models

The `ApplicationForm` requires its own upserter job to match records to existing CRM models before persisting (as we used the `FindApplyId` rathern than the CRM `Id`).

Unlike the `Candidate` model it doesn't matter if an `ApplicationForm` gets part way through upserting and then fails; retrying will just update the partially created records from the previous job run and there's no issue with doing this (so we don't need to spawn a job per model we're updating).

It would be ideal if the CRM SDK we use supported deep-insert (which it used to but subsequently was found to be unreliable/flakey) and we could persist the entire form and related models in a single request, but for now this should
suffice and we can look into it if performance is an issue. Similarly, we make multiple requests to get existing models from the CRM whereas we _could_ load an application form and related models in a single request but this involves a more complicated query so I'm going to defer this until its needed.

- Rename UpsertModelJob to clarify intent

The `UpsertModelJob` actually deals with upserting a model related to a `Candidate` and will email the candidate if the job fails.