### PR TITLE
Support v1.2 of the Apply candidate API

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using GetIntoTeachingApi.Models.FindApply;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
@@ -46,78 +43,22 @@ namespace GetIntoTeachingApi.Jobs
 
         public void SyncCandidate(Candidate findApplyCandidate)
         {
-            var applicationForms = findApplyCandidate.Attributes.ApplicationForms;
-            var candidate = Candidate(findApplyCandidate, applicationForms);
+            var candidate = findApplyCandidate.ToCrmModel();
+            var match = _crm.MatchCandidate(candidate.Email);
 
-            candidate.ApplicationForms = ApplicationForms(applicationForms).ToList();
+            _logger.LogInformation("FindApplyCandidateSyncJob - {Status} - {Id}", match == null ? "Miss" : "Hit", findApplyCandidate.Id);
 
-            string json = candidate.SerializeChangeTracked();
-            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
-        }
-
-        private Models.Crm.Candidate Candidate(Candidate findApplyCandidate, IEnumerable<ApplicationForm> findApplyApplicationForms)
-        {
-            var match = _crm.MatchCandidate(findApplyCandidate.Attributes.Email);
-            var status = match == null ? "Miss" : "Hit";
-
-            _logger.LogInformation("FindApplyCandidateSyncJob - {Status} - {Id}", status, findApplyCandidate.Id);
-
-            // We persist a new Candidate to ensure we only write the find/apply
-            // attributes back to the CRM and not existing attributes on the match.
-            var candidate = new Models.Crm.Candidate()
+            if (match != null)
             {
-                Id = match?.Id,
-                Email = findApplyCandidate.Attributes.Email,
-                FindApplyId = findApplyCandidate.Id,
-                FindApplyCreatedAt = findApplyCandidate.Attributes.CreatedAt,
-                FindApplyUpdatedAt = findApplyCandidate.Attributes.UpdatedAt,
-            };
-
-            if (match == null)
+                candidate.Id = match.Id;
+            }
+            else
             {
                 candidate.ChannelId = (int)Models.Crm.Candidate.Channel.ApplyForTeacherTraining;
             }
 
-            var latestApplicationForm = findApplyApplicationForms?.OrderByDescending(f => f.UpdatedAt).FirstOrDefault();
-
-            if (latestApplicationForm == null)
-            {
-                candidate.FindApplyStatusId = (int)Models.Crm.ApplicationForm.Status.NeverSignedIn;
-            }
-            else
-            {
-                candidate.FindApplyStatusId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Status), latestApplicationForm.ApplicationStatus.ToPascalCase());
-                candidate.FindApplyPhaseId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Phase), latestApplicationForm.ApplicationPhase.ToPascalCase());
-            }
-
-            return candidate;
-        }
-
-        private IEnumerable<Models.Crm.ApplicationForm> ApplicationForms(IEnumerable<ApplicationForm> findApplyApplicationForms)
-        {
-            if (findApplyApplicationForms == null)
-            {
-                return Array.Empty<Models.Crm.ApplicationForm>();
-            }
-
-            return findApplyApplicationForms.Select(findApplyForm =>
-            {
-                var existingForm = _crm.GetFindApplyModels<Models.Crm.ApplicationForm>(new string[] { findApplyForm.Id.ToString(CultureInfo.CurrentCulture) }).FirstOrDefault();
-
-                var yearId = ((int)Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2020) + (findApplyForm.RecruitmentCycleYear - 2020);
-
-                return new Models.Crm.ApplicationForm()
-                {
-                    Id = existingForm?.Id,
-                    FindApplyId = findApplyForm.Id.ToString(CultureInfo.CurrentCulture),
-                    CreatedAt = findApplyForm.CreatedAt,
-                    UpdatedAt = findApplyForm.UpdatedAt,
-                    SubmittedAt = findApplyForm.SubmittedAt,
-                    StatusId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Status), findApplyForm.ApplicationStatus.ToPascalCase()),
-                    PhaseId = (int)Enum.Parse(typeof(Models.Crm.ApplicationForm.Phase), findApplyForm.ApplicationPhase.ToPascalCase()),
-                    RecruitmentCycleYearId = yearId,
-                };
-            });
+            string json = candidate.SerializeChangeTracked();
+            _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
         }
     }
 }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -24,11 +24,25 @@ namespace GetIntoTeachingApi.Utils
         public string CrmClientSecret => Environment.GetEnvironmentVariable("CRM_CLIENT_SECRET");
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
-        public string FindApplyApiUrl => Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
         public string FindApplyApiKey => Environment.GetEnvironmentVariable("FIND_APPLY_API_KEY");
         public string AppName => AppServices.ApplicationName;
         public string Organization => AppServices.OrganizationName;
         public string Space => AppServices.SpaceName;
+
+        public string FindApplyApiUrl
+        {
+            get
+            {
+                var url = Environment.GetEnvironmentVariable("FIND_APPLY_API_URL"); ;
+
+                if (IsFeatureOn("APPLY_API_V1_2"))
+                {
+                    url += "/v1.2";
+                }
+
+                return url;
+            }
+        }
 
         // The master instance boots first on deploy.
         public bool IsMasterInstance

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -49,6 +49,10 @@ namespace GetIntoTeachingApiTests.Jobs
                     ApplicationStatus = "awaiting_candidate_response",
                     ApplicationPhase = "apply_1",
                     RecruitmentCycleYear = 2021,
+                    ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
+                    References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
+                    Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
+                    PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
                 },
                 new ApplicationForm()
                 {
@@ -59,6 +63,10 @@ namespace GetIntoTeachingApiTests.Jobs
                     ApplicationStatus = "never_signed_in",
                     ApplicationPhase = "apply_2",
                     RecruitmentCycleYear = 2022,
+                    ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
+                    References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
+                    Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
+                    PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
                 },
             };
             _attributes = new CandidateAttributes()
@@ -69,27 +77,23 @@ namespace GetIntoTeachingApiTests.Jobs
                 ApplicationForms = _forms,
             };
             _candidate = new Candidate()
-            { 
+            {
                 Id = "12345",
                 Attributes = _attributes
             };
         }
 
         [Fact]
-        public void Run_OnSuccessWithExistingCandidate_QueuesUpsertJobForCandidateWithApplicationForms()
+        public void Run_OnSuccessWithExistingCandidate_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
             var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
-            var existingApplicationForm = new GetIntoTeachingApi.Models.Crm.ApplicationForm() { Id = Guid.NewGuid() };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
-            _mockCrm.Setup(m => m.GetFindApplyModels<GetIntoTeachingApi.Models.Crm.ApplicationForm>(new string[] { "1" })).Returns(Array.Empty<GetIntoTeachingApi.Models.Crm.ApplicationForm>());
-            _mockCrm.Setup(m => m.GetFindApplyModels<GetIntoTeachingApi.Models.Crm.ApplicationForm>(new string[] { "2" })).Returns(new[] { existingApplicationForm });
 
             _job.Run(_candidate);
 
             var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
             {
-                Id = null,
                 FindApplyId = _forms[1].Id.ToString(),
                 CreatedAt = _forms[1].CreatedAt,
                 PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
@@ -97,11 +101,14 @@ namespace GetIntoTeachingApiTests.Jobs
                 RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
                 UpdatedAt = _forms[1].UpdatedAt,
                 SubmittedAt = _forms[1].SubmittedAt,
+                ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
+                ReferencesCompleted = _forms[1].References.Completed,
+                PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
+                QualificationsCompleted = _forms[1].Qualifications.Completed,
             };
 
             var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
             {
-                Id = existingApplicationForm.Id,
                 FindApplyId = _forms[0].Id.ToString(),
                 PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
                 StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
@@ -109,6 +116,10 @@ namespace GetIntoTeachingApiTests.Jobs
                 CreatedAt = _forms[0].CreatedAt,
                 UpdatedAt = _forms[0].UpdatedAt,
                 SubmittedAt = null,
+                ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
+                ReferencesCompleted = _forms[0].References.Completed,
+                PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
+                QualificationsCompleted = _forms[0].Qualifications.Completed,
             };
 
             var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
@@ -134,34 +145,59 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_OnSuccessWithNewCandidateAndNoApplicationForms_QueuesUpsertJobForCandidateWithNeverSignedInStatus()
+        public void Run_OnSuccessWithNewCandidate_SetsChannelAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
-            _candidate.Attributes.ApplicationForms = Array.Empty<ApplicationForm>();
-
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
 
             _job.Run(_candidate);
 
+            var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+            {
+                FindApplyId = _forms[1].Id.ToString(),
+                CreatedAt = _forms[1].CreatedAt,
+                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
+                UpdatedAt = _forms[1].UpdatedAt,
+                SubmittedAt = _forms[1].SubmittedAt,
+                ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
+                ReferencesCompleted = _forms[1].References.Completed,
+                PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
+                QualificationsCompleted = _forms[1].Qualifications.Completed,
+            };
+
+            var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+            {
+                FindApplyId = _forms[0].Id.ToString(),
+                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
+                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
+                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
+                CreatedAt = _forms[0].CreatedAt,
+                UpdatedAt = _forms[0].UpdatedAt,
+                SubmittedAt = null,
+                ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
+                ReferencesCompleted = _forms[0].References.Completed,
+                PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
+                QualificationsCompleted = _forms[0].Qualifications.Completed,
+            };
+
             var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
             {
-                Id = null,
-                ChannelId = (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining,
                 FindApplyId = _candidate.Id,
                 Email = _attributes.Email,
                 FindApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+                FindApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
                 FindApplyCreatedAt = _attributes.CreatedAt,
                 FindApplyUpdatedAt = _attributes.UpdatedAt,
+                ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form2, form1 },
+                ChannelId = (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining,
             };
 
             _mockJobClient.Verify(x => x.Create(
                 It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
                 IsMatch(candidate, (string)job.Args[0])),
                 It.IsAny<EnqueuedState>()));
-
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Started - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Miss - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"FindApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -195,6 +195,20 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
+        public void FindApplyApiUrl_WhenV1_2FeatreIsOn_ReturnsCorrectly()
+        {
+            var previousUrl = Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
+            var previousFeature = Environment.GetEnvironmentVariable("APPLY_API_V1_2_FEATURE");
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", "find-apply-api-url");
+            Environment.SetEnvironmentVariable("APPLY_API_V1_2_FEATURE", "true");
+
+            _env.FindApplyApiUrl.Should().Be("find-apply-api-url/v1.2");
+
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", previousUrl);
+            Environment.SetEnvironmentVariable("APPLY_API_V1_2_FEATURE", previousFeature);
+        }
+
+        [Fact]
         public void FindApplyApiKey_ReturnsCorrectly()
         {
             var previous = Environment.GetEnvironmentVariable("FIND_APPLY_API_KEY");


### PR DESCRIPTION
[Trello-3085](https://trello.com/c/2HSIv6Bq/3085-update-api-for-v12-of-apply-git-datasharing)

- Ensure Apply API url is correct depending on features

If the new `APPLY_API_V2_1` feature is enabled we need to append `/v1.2` to the URL to ensure the correct response payload is returned from the Apply API.

- Use UpsertApplicationForm job when syncing Apply API

We have a new `UpsertApplicationFormJob` that deals with upserting either a v1.1 or v1.2 `ApplicationForm` and associated entities. Switching to use this in the `FindApplyCandidateSyncJob` simplifies the logic for updating (otherwise we would have a job per API version).