### PR TITLE
Add contract tests for v1.2 of the Apply API integration

### DIFF
--- a/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
@@ -18,6 +18,7 @@ namespace GetIntoTeachingApiTests.Contracts
         public ApplyCandidateApiTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
             Environment.SetEnvironmentVariable($"APPLY_API_FEATURE", "on");
+            Environment.SetEnvironmentVariable($"APPLY_API_V1_2_FEATURE", "on");
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Contracts/Data/application_choices.json
+++ b/GetIntoTeachingApiTests/Contracts/Data/application_choices.json
@@ -1,0 +1,13 @@
+﻿[
+  {
+    "Id": "765aa675-e6bf-41c5-ad5f-4e1e8de5d4ab",
+    "FindApplyId": "2",
+    "ApplicationFormId": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
+    "CreatedAt": "2021-12-16T00:00:00+00:00",
+    "UpdatedAt": "2022-03-14T14:23:39+00:00",
+    "Status": 222750004,
+    "ProviderName": "OAKS Norths Staffordshire and Shropshire Hub",
+    "CourseId": "353496bf-ad7d-4de7-bbe5-76751cb35973",
+    "CourseName": "History"
+  }
+]

--- a/GetIntoTeachingApiTests/Contracts/Data/application_forms.json
+++ b/GetIntoTeachingApiTests/Contracts/Data/application_forms.json
@@ -1,5 +1,6 @@
 ﻿[
   {
+    "Id": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
     "CandidateId": "271aa675-e6bf-41c5-ad5f-4e1e8de5d7ad",
     "FindApplyId": "2",
     "StatusId": 222750002,

--- a/GetIntoTeachingApiTests/Contracts/Data/application_interviews.json
+++ b/GetIntoTeachingApiTests/Contracts/Data/application_interviews.json
@@ -1,0 +1,12 @@
+﻿[
+  {
+    "Id": "823aa675-e6bf-41c5-ad5f-4e1e8de5d4ca",
+    "FindApplyId": "2",
+    "ApplicationChoiceId": "765aa675-e6bf-41c5-ad5f-4e1e8de5d4ab",
+    "ScheduledAt": "2022-01-26T00:00:00+00:00",
+    "CreatedAt": "2022-01-04T13:14:17+00:00",
+    "UpdatedAt": "2022-01-04T13:14:17+00:00",
+    "CancelledAt": "2022-01-24T00:00:00+00:00"
+  }
+]
+

--- a/GetIntoTeachingApiTests/Contracts/Data/application_references.json
+++ b/GetIntoTeachingApiTests/Contracts/Data/application_references.json
@@ -1,0 +1,10 @@
+﻿[
+  {
+    "Id": "933aa675-e6bf-41c5-ad5f-4e1e8de5d4cc",
+    "FindApplyId": "2",
+    "ApplicationFormId": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
+    "RequestedAt": "2022-01-26T00:00:00+00:00",
+    "FeedbackStatus": 222750001,
+    "Type": "academic"
+  }
+]

--- a/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidaite_and_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidaite_and_application_form.json
@@ -11,7 +11,8 @@
         "updated_at": "2022-04-24T23:04:08+00:00",
         "application_status": "unsubmitted_in_progress",
         "application_phase": "apply_1",
-        "recruitment_cycle_year": 2022
+        "recruitment_cycle_year": 2022,
+        "submitted_at": "2022-04-28T00:00:00+00:00"
       }
     ]
   }

--- a/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
@@ -1,0 +1,63 @@
+﻿{
+  "id": "C00001",
+  "attributes": {
+    "email_address": "john@doe.com",
+    "created_at": "2022-04-24T23:03:10+00:00",
+    "updated_at": "2022-04-24T23:04:01.853+00:00",
+    "application_forms": [
+      {
+        "id": 1,
+        "created_at": "2022-04-24T23:03:51+00:00",
+        "updated_at": "2022-04-24T23:04:08+00:00",
+        "application_status": "unsubmitted_in_progress",
+        "application_phase": "apply_1",
+        "recruitment_cycle_year": 2022,
+        "submitted_at": "2022-04-28T00:00:00+00:00",
+        "application_choices": {
+          "completed": true,
+          "data": [
+            {
+              "id": 1,
+              "created_at": "2021-12-16T00:00:00+00:00",
+              "updated_at": "2022-03-14T14:23:39+00:00",
+              "status": "interviewing",
+              "provider": {
+                "name": "OAKS Norths Staffordshire and Shropshire Hub"
+              },
+              "course": {
+                "uuid": "353496bf-ad7d-4de7-bbe5-76751cb35973",
+                "name": "History"
+              },
+              "interviews": [
+                {
+                  "id": 1,
+                  "date_and_time": "2022-01-26T00:00:00+00:00",
+                  "created_at": "2022-01-04T13:14:17+00:00",
+                  "updated_at": "2022-01-04T13:14:17+00:00",
+                  "cancelled_at": "2022-01-24T00:00:00+00:00"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "completed": true,
+          "data": [
+            {
+              "id": 1,
+              "requested_at": "2022-01-26T00:00:00+00:00",
+              "feedback_status": "not_requested_yet",
+              "referee_type": "academic"
+            }
+          ]
+        },
+        "qualifications": {
+          "completed": true
+        },
+        "personal_statement": {
+          "completed": false
+        }
+      }
+    ]
+  }
+}

--- a/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
@@ -1,0 +1,63 @@
+﻿{
+  "id": "C00002",
+  "attributes": {
+    "email_address": "existing@user.com",
+    "created_at": "2022-04-24T23:03:10+00:00",
+    "updated_at": "2022-04-24T23:04:01.853+00:00",
+    "application_forms": [
+      {
+        "id": 2,
+        "created_at": "2022-04-24T23:03:51+00:00",
+        "updated_at": "2022-04-24T23:04:08+00:00",
+        "application_status": "unsubmitted_in_progress",
+        "application_phase": "apply_1",
+        "recruitment_cycle_year": 2022,
+        "submitted_at": "2022-04-28T00:00:00+00:00",
+        "application_choices": {
+          "completed": true,
+          "data": [
+            {
+              "id": 2,
+              "created_at": "2021-12-16T00:00:00+00:00",
+              "updated_at": "2022-03-14T14:23:39+00:00",
+              "status": "interviewing",
+              "provider": {
+                "name": "OAKS Norths Staffordshire and Shropshire Hub"
+              },
+              "course": {
+                "uuid": "353496bf-ad7d-4de7-bbe5-76751cb35973",
+                "name": "History"
+              },
+              "interviews": [
+                {
+                  "id": 2,
+                  "date_and_time": "2022-01-26T00:00:00+00:00",
+                  "created_at": "2022-01-04T13:14:17+00:00",
+                  "updated_at": "2022-01-04T13:14:17+00:00",
+                  "cancelled_at": "2022-01-24T00:00:00+00:00"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "completed": true,
+          "data": [
+            {
+              "id": 2,
+              "requested_at": "2022-01-26T00:00:00+00:00",
+              "feedback_status": "not_requested_yet",
+              "referee_type": "academic"
+            }
+          ]
+        },
+        "qualifications": {
+          "completed": true
+        },
+        "personal_statement": {
+          "completed": false
+        }
+      }
+    ]
+  }
+}

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidaite_and_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidaite_and_application_form.json
@@ -57,6 +57,10 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
+        "Key": "dfe_applicationchoicescompleted",
+        "Value": null
+      },
+      {
         "Key": "dfe_applicationformid",
         "Value": "1"
       },
@@ -95,14 +99,26 @@
         "Value": "Application Form 1"
       },
       {
+        "Key": "dfe_personalstatementcompleted",
+        "Value": null
+      },
+      {
+        "Key": "dfe_qualificationscompleted",
+        "Value": null
+      },
+      {
         "Key": "dfe_recruitmentyear",
         "Value": {
           "Value": 222750002
         }
       },
       {
-        "Key": "dfe_submittedatdate",
+        "Key": "dfe_referencescompleted",
         "Value": null
+      },
+      {
+        "Key": "dfe_submittedatdate",
+        "Value": "2022-04-28T01:00:00+01:00"
       }
     ],
     "EntityState": 1,

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
@@ -1,0 +1,273 @@
+[
+  {
+    "LogicalName": "contact",
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Attributes": [
+      {
+        "Key": "dfe_applycreatedon",
+        "Value": "2022-04-25T00:03:10+01:00"
+      },
+      {
+        "Key": "dfe_applyid",
+        "Value": "C00001"
+      },
+      {
+        "Key": "dfe_applylastmodifiedon",
+        "Value": "2022-04-25T00:04:01.853+01:00"
+      },
+      {
+        "Key": "dfe_candidateapplyphase",
+        "Value": {
+          "Value": 222750000
+        }
+      },
+      {
+        "Key": "dfe_candidateapplystatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_channelcreation",
+        "Value": {
+          "Value": 222750025
+        }
+      },
+      {
+        "Key": "dfe_newregistrant",
+        "Value": true
+      },
+      {
+        "Key": "emailaddress1",
+        "Value": "john@doe.com"
+      },
+      {
+        "Key": "merged",
+        "Value": false
+      }
+    ],
+    "EntityState": 1,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyapplicationchoice",
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Attributes": [
+      {
+        "Key": "dfe_applicationchoicecoursename",
+        "Value": "History"
+      },
+      {
+        "Key": "dfe_applicationchoicecourseuuid",
+        "Value": "353496bf-ad7d-4de7-bbe5-76751cb35973"
+      },
+      {
+        "Key": "dfe_applicationchoiceid",
+        "Value": "1"
+      },
+      {
+        "Key": "dfe_applicationchoiceprovider",
+        "Value": "OAKS Norths Staffordshire and Shropshire Hub"
+      },
+      {
+        "Key": "dfe_applicationchoicestatus",
+        "Value": {
+          "Value": 222750003
+        }
+      },
+      {
+        "Key": "dfe_applyapplicationform",
+        "Value": {
+          "Id": "00000000-0000-0000-0000-000000000000",
+          "LogicalName": "dfe_applyapplicationform",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2021-12-16T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-03-14T14:23:39+00:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Choice 1"
+      }
+    ],
+    "EntityState": 1,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyapplicationform",
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Attributes": [
+      {
+        "Key": "dfe_applicationchoicescompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_applicationformid",
+        "Value": "1"
+      },
+      {
+        "Key": "dfe_applyphase",
+        "Value": {
+          "Value": 222750000
+        }
+      },
+      {
+        "Key": "dfe_applystatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_contact",
+        "Value": {
+          "Id": "00000000-0000-0000-0000-000000000000",
+          "LogicalName": "contact",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2022-04-25T00:03:51+01:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-04-25T00:04:08+01:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Form 1"
+      },
+      {
+        "Key": "dfe_personalstatementcompleted",
+        "Value": false
+      },
+      {
+        "Key": "dfe_qualificationscompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_recruitmentyear",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_referencescompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_submittedatdate",
+        "Value": "2022-04-28T01:00:00+01:00"
+      }
+    ],
+    "EntityState": 1,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyinterview",
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Attributes": [
+      {
+        "Key": "dfe_applyapplicationchoice",
+        "Value": {
+          "Id": "00000000-0000-0000-0000-000000000000",
+          "LogicalName": "dfe_applyapplicationchoice",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2022-01-04T13:14:17+00:00"
+      },
+      {
+        "Key": "dfe_interviewcancelledat",
+        "Value": "2022-01-24T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_interviewid",
+        "Value": "1"
+      },
+      {
+        "Key": "dfe_interviewscheduledat",
+        "Value": "2022-01-26T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-01-04T13:14:17+00:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Interview 1"
+      }
+    ],
+    "EntityState": 1,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyreference",
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Attributes": [
+      {
+        "Key": "dfe_applyapplicationform",
+        "Value": {
+          "Id": "00000000-0000-0000-0000-000000000000",
+          "LogicalName": "dfe_applyapplicationform",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Reference 1"
+      },
+      {
+        "Key": "dfe_referencefeedbackstatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_referenceid",
+        "Value": "1"
+      },
+      {
+        "Key": "dfe_referencetype",
+        "Value": "academic"
+      },
+      {
+        "Key": "dfe_requestedat",
+        "Value": "2022-01-26T00:00:00+00:00"
+      }
+    ],
+    "EntityState": 1,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  }
+]

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_application_form.json
@@ -48,8 +48,12 @@
   },
   {
     "LogicalName": "dfe_applyapplicationform",
-    "Id": "00000000-0000-0000-0000-000000000000",
+    "Id": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
     "Attributes": [
+      {
+        "Key": "dfe_applicationchoicescompleted",
+        "Value": null
+      },
       {
         "Key": "dfe_applicationformid",
         "Value": "2"
@@ -89,17 +93,29 @@
         "Value": "Application Form 2"
       },
       {
+        "Key": "dfe_personalstatementcompleted",
+        "Value": null
+      },
+      {
+        "Key": "dfe_qualificationscompleted",
+        "Value": null
+      },
+      {
         "Key": "dfe_recruitmentyear",
         "Value": {
           "Value": 222750002
         }
       },
       {
+        "Key": "dfe_referencescompleted",
+        "Value": null
+      },
+      {
         "Key": "dfe_submittedatdate",
         "Value": null
       }
     ],
-    "EntityState": 1,
+    "EntityState": null,
     "FormattedValues": [],
     "RelatedEntities": [],
     "RowVersion": null,

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
@@ -1,0 +1,267 @@
+[
+  {
+    "LogicalName": "contact",
+    "Id": "271aa675-e6bf-41c5-ad5f-4e1e8de5d7ad",
+    "Attributes": [
+      {
+        "Key": "dfe_applycreatedon",
+        "Value": "2022-04-25T00:03:10+01:00"
+      },
+      {
+        "Key": "dfe_applyid",
+        "Value": "C00002"
+      },
+      {
+        "Key": "dfe_applylastmodifiedon",
+        "Value": "2022-04-25T00:04:01.853+01:00"
+      },
+      {
+        "Key": "dfe_candidateapplyphase",
+        "Value": {
+          "Value": 222750000
+        }
+      },
+      {
+        "Key": "dfe_candidateapplystatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_newregistrant",
+        "Value": false
+      },
+      {
+        "Key": "emailaddress1",
+        "Value": "existing@user.com"
+      },
+      {
+        "Key": "merged",
+        "Value": false
+      }
+    ],
+    "EntityState": null,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyapplicationchoice",
+    "Id": "765aa675-e6bf-41c5-ad5f-4e1e8de5d4ab",
+    "Attributes": [
+      {
+        "Key": "dfe_applicationchoicecoursename",
+        "Value": "History"
+      },
+      {
+        "Key": "dfe_applicationchoicecourseuuid",
+        "Value": "353496bf-ad7d-4de7-bbe5-76751cb35973"
+      },
+      {
+        "Key": "dfe_applicationchoiceid",
+        "Value": "2"
+      },
+      {
+        "Key": "dfe_applicationchoiceprovider",
+        "Value": "OAKS Norths Staffordshire and Shropshire Hub"
+      },
+      {
+        "Key": "dfe_applicationchoicestatus",
+        "Value": {
+          "Value": 222750003
+        }
+      },
+      {
+        "Key": "dfe_applyapplicationform",
+        "Value": {
+          "Id": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
+          "LogicalName": "dfe_applyapplicationform",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2021-12-16T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-03-14T14:23:39+00:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Choice 2"
+      }
+    ],
+    "EntityState": null,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyapplicationform",
+    "Id": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
+    "Attributes": [
+      {
+        "Key": "dfe_applicationchoicescompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_applicationformid",
+        "Value": "2"
+      },
+      {
+        "Key": "dfe_applyphase",
+        "Value": {
+          "Value": 222750000
+        }
+      },
+      {
+        "Key": "dfe_applystatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_contact",
+        "Value": {
+          "Id": "271aa675-e6bf-41c5-ad5f-4e1e8de5d7ad",
+          "LogicalName": "contact",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2022-04-25T00:03:51+01:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-04-25T00:04:08+01:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Form 2"
+      },
+      {
+        "Key": "dfe_personalstatementcompleted",
+        "Value": false
+      },
+      {
+        "Key": "dfe_qualificationscompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_recruitmentyear",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_referencescompleted",
+        "Value": true
+      },
+      {
+        "Key": "dfe_submittedatdate",
+        "Value": "2022-04-28T01:00:00+01:00"
+      }
+    ],
+    "EntityState": null,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyinterview",
+    "Id": "823aa675-e6bf-41c5-ad5f-4e1e8de5d4ca",
+    "Attributes": [
+      {
+        "Key": "dfe_applyapplicationchoice",
+        "Value": {
+          "Id": "765aa675-e6bf-41c5-ad5f-4e1e8de5d4ab",
+          "LogicalName": "dfe_applyapplicationchoice",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_createdon",
+        "Value": "2022-01-04T13:14:17+00:00"
+      },
+      {
+        "Key": "dfe_interviewcancelledat",
+        "Value": "2022-01-24T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_interviewid",
+        "Value": "2"
+      },
+      {
+        "Key": "dfe_interviewscheduledat",
+        "Value": "2022-01-26T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-01-04T13:14:17+00:00"
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Interview 2"
+      }
+    ],
+    "EntityState": null,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  },
+  {
+    "LogicalName": "dfe_applyreference",
+    "Id": "933aa675-e6bf-41c5-ad5f-4e1e8de5d4cc",
+    "Attributes": [
+      {
+        "Key": "dfe_applyapplicationform",
+        "Value": {
+          "Id": "351aa675-e6bf-41c5-ad5f-4e1e8de5d5fe",
+          "LogicalName": "dfe_applyapplicationform",
+          "Name": null,
+          "KeyAttributes": [],
+          "RowVersion": null
+        }
+      },
+      {
+        "Key": "dfe_name",
+        "Value": "Application Reference 2"
+      },
+      {
+        "Key": "dfe_referencefeedbackstatus",
+        "Value": {
+          "Value": 222750002
+        }
+      },
+      {
+        "Key": "dfe_referenceid",
+        "Value": "2"
+      },
+      {
+        "Key": "dfe_referencetype",
+        "Value": "academic"
+      },
+      {
+        "Key": "dfe_requestedat",
+        "Value": "2022-01-26T00:00:00+00:00"
+      }
+    ],
+    "EntityState": null,
+    "FormattedValues": [],
+    "RelatedEntities": [],
+    "RowVersion": null,
+    "KeyAttributes": []
+  }
+]

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -211,6 +211,21 @@
     <None Update="Contracts\Data\application_forms.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Contracts\Input\ApplyCandidateApi\sync_with_a_new_candidate_and_fully_populated_application_form.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Contracts\Input\ApplyCandidateApi\sync_with_an_existing_candidate_and_fully_populated_application_form.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Contracts\Data\application_choices.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Contracts\Data\application_interviews.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Contracts\Data\application_references.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
@@ -22,12 +22,36 @@ namespace GetIntoTeachingApiTests.Helpers
                 return JsonConvert.DeserializeObject<IEnumerable<Candidate>>(json);
             }
         }
-        private IEnumerable<ApplicationForm> ApplicationForms
+        private static IEnumerable<ApplicationForm> ApplicationForms
         {
             get
             {
                 var json = File.ReadAllText("./Contracts/Data/application_forms.json");
                 return JsonConvert.DeserializeObject<IEnumerable<ApplicationForm>>(json);
+            }
+        }
+        private static IEnumerable<ApplicationChoice> ApplicationChoices
+        {
+            get
+            {
+                var json = File.ReadAllText("./Contracts/Data/application_choices.json");
+                return JsonConvert.DeserializeObject<IEnumerable<ApplicationChoice>>(json);
+            }
+        }
+        private static IEnumerable<ApplicationInterview> ApplicationInterviews
+        {
+            get
+            {
+                var json = File.ReadAllText("./Contracts/Data/application_interviews.json");
+                return JsonConvert.DeserializeObject<IEnumerable<ApplicationInterview>>(json);
+            }
+        }
+        private static IEnumerable<ApplicationReference> ApplicationReferences
+        {
+            get
+            {
+                var json = File.ReadAllText("./Contracts/Data/application_references.json");
+                return JsonConvert.DeserializeObject<IEnumerable<ApplicationReference>>(json);
             }
         }
 
@@ -77,6 +101,12 @@ namespace GetIntoTeachingApiTests.Helpers
             {
                 case "GetIntoTeachingApi.Models.Crm.ApplicationForm":
                     return ApplicationForms.Where(f => findApplyIds.Contains(f.FindApplyId)) as IEnumerable<T>;
+                case "GetIntoTeachingApi.Models.Crm.ApplicationChoice":
+                    return ApplicationChoices.Where(c => findApplyIds.Contains(c.FindApplyId)) as IEnumerable<T>;
+                case "GetIntoTeachingApi.Models.Crm.ApplicationInterview":
+                    return ApplicationInterviews.Where(i => findApplyIds.Contains(i.FindApplyId)) as IEnumerable<T>;
+                case "GetIntoTeachingApi.Models.Crm.ApplicationReference":
+                    return ApplicationReferences.Where(r => findApplyIds.Contains(r.FindApplyId)) as IEnumerable<T>;
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
- Add contract tests for v1.2 of Apply API integration

Add additional contract tests to cover the new attributes/related models in the v1.2 Apply API integration.

- Clean up contract tests

Encapsulates more of the logic into the `BaseTests` superclass so that the contract tests are easier to understand.