### PR TITLE
Workflow to rebuild master docker image

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -1,0 +1,74 @@
+name: Rebuild master docker image
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 12 * * 0'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: INFRA-KEYS
+          key: SLACK-WEBHOOK, SNYK-TOKEN
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Get Short SHA
+        id: vars
+        run: echo ::set-output name=sha_short::$(echo $GITHUB_SHA | cut -c -7)
+
+      - name: Login to GitHub Container Repository
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          tags: ${{ env.DOCKER_REPOSITORY }}:master
+          load: true
+          push: false
+          build-args: GIT_COMMIT_SHA=${{ steps.vars.outputs.sha_short }}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK-TOKEN }}
+        with:
+          image: ${{ env.DOCKER_REPOSITORY }}:master
+          args: --severity-threshold=high --file=Dockerfile
+
+      - name: Push image to registry
+        if: success()
+        run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
+
+      - name: Slack Notification
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: ${{ env.SLACK_ERROR }}
+           SLACK_MESSAGE: 'There has been a failure building the application'
+           SLACK_TITLE: 'Failure Building Application'
+           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet-core
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /source
 ARG GIT_COMMIT_SHA
 ENV ASPNETCORE_URLS=http://+:8080
@@ -8,7 +8,7 @@ ENV ASPNETCORE_URLS=http://+:8080
 COPY *.sln .
 COPY GetIntoTeachingApi/*.csproj ./GetIntoTeachingApi/
 COPY GetIntoTeachingApiTests/*.csproj ./GetIntoTeachingApiTests/
-RUN dotnet restore -r linux-x64 
+RUN dotnet restore -r linux-x64
 
 # copy everything else and build app
 COPY GetIntoTeachingApi/. ./GetIntoTeachingApi/
@@ -16,11 +16,7 @@ WORKDIR /source/GetIntoTeachingApi
 RUN dotnet publish -c release -o /app --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
-
-# Upgrade the distrubution to clear CVE warning
-# hadolint ignore=DL3005
-RUN apt-get update -y && apt-get dist-upgrade  -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 WORKDIR /app
 COPY --from=build /app ./


### PR DESCRIPTION
### Context
Docker build layers are cached to optimise build performance but sometimes the base image is updated so we need to rebuild it.  Implementing snyk in this workflow highlights a high severity vulnerability in the base image.

### Changes proposed in this pull request
- Add a build-no-cache workflow that is scheduled once a week on Sunday and can be run manually as required.
- Change the base image tag from the default to the alpine version.  This addresses the vulnerability, simplifies the dockerfile and aligns the OS with other projects which will simplify future maintenance. 

### Guidance to review
- Check the new workflow runs as expected, example [here](https://github.com/DFE-Digital/get-into-teaching-api/actions/runs/2232025759)
- Test the application to identify any issues with the OS change