### PR TITLE
Migrate non-secret environment variables into .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ msbuild.wrn
 TestResults
 
 # Dotenv
-.env*
+.env.local
 
 # DevOps file
 fetch_config.rb

--- a/GetIntoTeachingApi/.env.dev
+++ b/GetIntoTeachingApi/.env.dev
@@ -1,0 +1,3 @@
+﻿APPLY_API_FEATURE=true
+APPLY_API_V1_2_FEATURE=true
+FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/.env.production
+++ b/GetIntoTeachingApi/.env.production
@@ -1,0 +1,3 @@
+﻿APPLY_API_FEATURE=true
+APPLY_API_V1_2_FEATURE=false
+FIND_APPLY_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/.env.staging
+++ b/GetIntoTeachingApi/.env.staging
@@ -1,0 +1,3 @@
+﻿APPLY_API_FEATURE=true
+APPLY_API_V1_2_FEATURE=false
+FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
 using dotenv.net;
 using FluentValidation.AspNetCore;
@@ -27,9 +27,10 @@ namespace GetIntoTeachingApi.AppStart
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            if (_env.IsDevelopment)
+            if (!_env.IsTest)
             {
-                DotEnv.Load(options: new DotEnvOptions(ignoreExceptions: false, envFilePaths: new[] { ".env.development" }));
+                var envFile = $".env.{_env.CloudFoundryEnvironmentName.ToLowerInvariant()}";
+                DotEnv.Load(options: new DotEnvOptions(ignoreExceptions: false, envFilePaths: new[] { envFile }));
             }
 
             services.RegisterServices(_configuration, _env);

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -27,8 +27,9 @@
         "DATABASE_INSTANCE_NAME": "gis",
         "HANGFIRE_INSTANCE_NAME": "gis",
         "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 4432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 5379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
-        "VCAP_APPLICATION": "{\"application_name\": \"app-name\",\"organization_name\": \"org-name\",\"space_name\": \"space-name\"}",
+        "VCAP_APPLICATION": "{\"application_name\": \"app-name\",\"organization_name\": \"org-name\",\"space_name\": \"local\"}",
         "CF_INSTANCE_INDEX": "0",
+        "FIND_APPLY_API_URL": "https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api",
         "ADMIN_API_KEY": "secret-admin",
         "GIT_API_KEY": "secret-git",
         "TTA_API_KEY": "secret-tta",
@@ -40,4 +41,3 @@
     }
   }
 }
-

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -62,6 +63,14 @@ namespace GetIntoTeachingApi.Utils
             {
                 var name = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
                 return name ?? "Test";
+            }
+        }
+
+        public string CloudFoundryEnvironmentName
+        {
+            get
+            {
+                return AppServices.SpaceName.Split("-").Last();
             }
         }
 

--- a/GetIntoTeachingApi/Utils/IEnv.cs
+++ b/GetIntoTeachingApi/Utils/IEnv.cs
@@ -14,6 +14,7 @@
         string HangfireUsername { get; }
         string HangfirePassword { get; }
         string EnvironmentName { get; }
+        string CloudFoundryEnvironmentName { get; }
         string TotpSecretKey { get; }
         string VcapServices { get; }
         string AppName { get; }

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -183,6 +183,21 @@ namespace GetIntoTeachingApiTests.Utils
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", previous);
         }
 
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("get-into-teaching-test", "test")]
+        [InlineData("get-into-teaching-dev", "dev")]
+        [InlineData("get-into-teaching-production", "production")]
+        public void CloudFoundryEnvironmentName_ReturnsCorrectly(string spaceName, string expected)
+        {
+            var previous = Environment.GetEnvironmentVariable("VCAP_APPLICATION");
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", $"{{\"space_name\":\"{spaceName}\"}}");
+
+            _env.CloudFoundryEnvironmentName.Should().Be(expected);
+
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", previous);
+        }
+
         [Fact]
         public void FindApplyApiUrl_ReturnsCorrectly()
         {

--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ print-infrastructure-secrets: install-fetch-config set-azure-account
 	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${INFRASTRUCTURE_SECRETS}  -f yaml
 
 setup-local-env: install-fetch-config set-azure-account
-	./fetch_config.rb -s azure-key-vault-secret:s146d01-local2-kv/${APPLICATION_SECRETS} -f shell-env-var > GetIntoTeachingApi/.env.development
+	./fetch_config.rb -s azure-key-vault-secret:s146d01-local2-kv/${APPLICATION_SECRETS} -f shell-env-var > GetIntoTeachingApi/.env.local

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ az login
 make local setup-local-env
 ```
 
-Then **set properties of the created .env.development to "Always copy"**.
+Then **set properties of the created .env.local to "Always copy"**.
 
 A number of non-secret, default development environment variables are pre-set in `GetIntoTeachingApi/Properties/launchSettings.json` (such as a development `ADMIN_API_KEY` of `admin-secret` and the `VCAP_SERVICES` setup for the Postgres instance running in Docker).
 


### PR DESCRIPTION
[Trello-3177](https://trello.com/c/fr6To0cP/3177-remove-unused-secrets)

We have a number of environment variables in keyvault that are not secrets; they are better placed in the application.

Adds additional .env files for hosted dev/test/prod environments and migrates the non-secret environment variables from Azure keyvault.

Rename the local .env file to `.env.local` to differentiate from the hosted development environment (which is configured with `.env.development`).