### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/IOrganizationServiceAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Extensions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Adapters
         IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context);
         IEnumerable<Entity> RetrieveMultiple(QueryBase query);
         void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context);
-        IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
+        IEnumerable<PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName);
         IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName);
         OrganizationServiceContext Context();
         Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context);

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Extensions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
@@ -65,7 +66,7 @@ namespace GetIntoTeachingApi.Adapters
             return result;
         }
 
-        public IEnumerable<ServiceClient.PickListItem> GetPickListItemsForAttribute(
+        public IEnumerable<Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem> GetPickListItemsForAttribute(
             string entityName,
             string attributeName)
         {

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -12,62 +12,62 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.1" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.28" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.6.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.3">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.4" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="6.0.3" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.3" />
+		<PackageReference Include="Npgsql" Version="6.0.4" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.4" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.15.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.17.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.5" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
-		<PackageReference Include="Fody" Version="6.6.0">
+		<PackageReference Include="Fody" Version="6.6.1">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-		<PackageReference Include="GovukNotify" Version="4.0.1" />
-		<PackageReference Include="Flurl.Http" Version="3.2.2" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.3" />
+		<PackageReference Include="GovukNotify" Version="6.0.0" />
+		<PackageReference Include="Flurl.Http" Version="3.2.3" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.5" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Serilog" Version="2.11.0" />
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
+		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.7" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.17" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.6.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Models/PickListItem.cs
+++ b/GetIntoTeachingApi/Models/PickListItem.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
-using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace GetIntoTeachingApi.Models
 {
@@ -18,7 +17,7 @@ namespace GetIntoTeachingApi.Models
         {
         }
 
-        public PickListItem(ServiceClient.PickListItem pickListItem, string entityName, string attributeName)
+        public PickListItem(Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem pickListItem, string entityName, string attributeName)
         {
             Id = pickListItem.PickListItemId;
             Value = pickListItem.DisplayLabel;

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -28,11 +28,11 @@
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.6.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-	<PackageReference Include="Moq" Version="4.17.2" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+	<PackageReference Include="Moq" Version="4.18.0" />
 	<PackageReference Include="WireMock.Net" Version="1.4.41" />
 	<PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using GetIntoTeachingApi.Adapters;
+using Microsoft.PowerPlatform.Dataverse.Client.Extensions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Moq;
-using static Microsoft.PowerPlatform.Dataverse.Client.ServiceClient;
 
 namespace GetIntoTeachingApiTests.Helpers
 {

--- a/GetIntoTeachingApiTests/Models/PickListItemTests.cs
+++ b/GetIntoTeachingApiTests/Models/PickListItemTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using FluentAssertions;
 using GetIntoTeachingApi.Models;
-using Microsoft.PowerPlatform.Dataverse.Client;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models
@@ -20,7 +19,7 @@ namespace GetIntoTeachingApiTests.Models
         [Fact]
         public void Constructor_WithPickListItem()
         {
-            var pickListItem = new ServiceClient.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
+            var pickListItem = new Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem { PickListItemId = 123, DisplayLabel = "name" };
 
             var typeEntity = new PickListItem(pickListItem, "entityName", "attributeName");
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Xrm.Sdk.Query;
 using Xunit;
 using System.Linq.Dynamic.Core;
 using FluentValidation;
-using Microsoft.PowerPlatform.Dataverse.Client;
 using GetIntoTeachingApi.Models.Crm;
 using Microsoft.Extensions.Logging;
 using GetIntoTeachingApiTests.Helpers;
@@ -1028,13 +1027,13 @@ namespace GetIntoTeachingApiTests.Services
             return new[] { country1, country2, country3 }.AsQueryable();
         }
 
-        private static IEnumerable<ServiceClient.PickListItem> MockInitialTeacherTrainingYears()
+        private static IEnumerable<Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem> MockInitialTeacherTrainingYears()
         {
-            var year1 = new ServiceClient.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
-            var year2 = new ServiceClient.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
-            var year3 = new ServiceClient.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
+            var year1 = new Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem { PickListItemId = 1, DisplayLabel = "2010" };
+            var year2 = new Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem { PickListItemId = 2, DisplayLabel = "2011" };
+            var year3 = new Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem { PickListItemId = 3, DisplayLabel = "2012" };
 
-            return new List<ServiceClient.PickListItem> { year1, year2, year3 };
+            return new List<Microsoft.PowerPlatform.Dataverse.Client.Extensions.PickListItem> { year1, year2, year3 };
         }
     }
 }


### PR DESCRIPTION
The main update is to the `Dataverse.ServiceClient` which re-namepsaces the `PickListItem` model into `Extensions`. As we have our own `PickListItem` model we have to reference them explicitly via their namespace to avoid a conflict.

Closes #988, #987, #984, #968, #957