### PR TITLE
Add new date fields to ApplicationReference

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
@@ -31,6 +31,10 @@ namespace GetIntoTeachingApi.Models.Crm
         public string FindApplyId { get; set; }
         [EntityField("dfe_requestedat")]
         public DateTime? RequestedAt { get; set; }
+        [EntityField("dfe_createdon")]
+        public DateTime CreatedAt { get; set; }
+        [EntityField("dfe_modifiedon")]
+        public DateTime UpdatedAt { get; set; }
         [EntityField("dfe_referencetype")]
         public string Type { get; set; }
         [EntityField("dfe_name")]

--- a/GetIntoTeachingApi/Models/FindApply/Reference.cs
+++ b/GetIntoTeachingApi/Models/FindApply/Reference.cs
@@ -11,6 +11,10 @@ namespace GetIntoTeachingApi.Models.FindApply
 		public int Id { get; set; }
 		[JsonProperty("requested_at")]
 		public DateTime? RequestedAt { get; set; }
+		[JsonProperty("created_at")]
+		public DateTime CreatedAt { get; set; }
+		[JsonProperty("updated_at")]
+		public DateTime UpdatedAt { get; set; }
 		[JsonProperty("feedback_status")]
 		public string FeedbackStatus { get; set; }
 		[JsonProperty("referee_type")]
@@ -22,6 +26,8 @@ namespace GetIntoTeachingApi.Models.FindApply
 			{
 				FindApplyId = Id.ToString(CultureInfo.CurrentCulture),
 				RequestedAt = RequestedAt,
+				CreatedAt = CreatedAt,
+				UpdatedAt = UpdatedAt,
 				FeedbackStatusId = (int)Enum.Parse(typeof(Crm.ApplicationReference.FeedbackStatus), FeedbackStatus.ToPascalCase()),
 				Type = RefereeType,
 			};

--- a/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
@@ -46,6 +46,8 @@
             {
               "id": 1,
               "requested_at": "2022-01-26T00:00:00+00:00",
+              "created_at": "2022-01-25T00:00:00+00:00",
+              "updated_at": "2022-01-27T00:00:00+00:00",
               "feedback_status": "not_requested_yet",
               "referee_type": "academic"
             }

--- a/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
@@ -46,6 +46,8 @@
             {
               "id": 2,
               "requested_at": "2022-01-26T00:00:00+00:00",
+              "created_at": "2022-01-25T00:00:00+00:00",
+              "updated_at": "2022-01-27T00:00:00+00:00",
               "feedback_status": "not_requested_yet",
               "referee_type": "academic"
             }

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_a_new_candidate_and_fully_populated_application_form.json
@@ -242,6 +242,14 @@
         }
       },
       {
+        "Key": "dfe_createdon",
+        "Value": "2022-01-25T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-01-27T00:00:00+00:00"
+      },
+      {
         "Key": "dfe_name",
         "Value": "Application Reference 1"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/ApplyCandidateApi/sync_with_an_existing_candidate_and_fully_populated_application_form.json
@@ -236,6 +236,14 @@
         }
       },
       {
+        "Key": "dfe_createdon",
+        "Value": "2022-01-25T00:00:00+00:00"
+      },
+      {
+        "Key": "dfe_modifiedon",
+        "Value": "2022-01-27T00:00:00+00:00"
+      },
+      {
         "Key": "dfe_name",
         "Value": "Application Reference 2"
       },

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationReferenceTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationReferenceTests.cs
@@ -24,6 +24,8 @@ namespace GetIntoTeachingApiTests.Models.Crm
 
             type.GetProperty("FindApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_referenceid");
             type.GetProperty("RequestedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_requestedat");
+            type.GetProperty("CreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_createdon");
+            type.GetProperty("UpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_modifiedon");
             type.GetProperty("Type").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_referencetype");
         }
 

--- a/GetIntoTeachingApiTests/Models/FindApply/ReferenceTests.cs
+++ b/GetIntoTeachingApiTests/Models/FindApply/ReferenceTests.cs
@@ -18,6 +18,10 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "id");
             type.GetProperty("RequestedAt").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "requested_at");
+            type.GetProperty("CreatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "created_at");
+            type.GetProperty("UpdatedAt").Should()
+                .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "updated_at");
             type.GetProperty("FeedbackStatus").Should()
                 .BeDecoratedWith<JsonPropertyAttribute>(a => a.PropertyName == "feedback_status");
             type.GetProperty("RefereeType").Should()
@@ -33,6 +37,8 @@ namespace GetIntoTeachingApiTests.Models.FindApply
                 FeedbackStatus = "cancelled",
                 RefereeType = "employer",
                 RequestedAt = new DateTime(2021, 1, 2),
+                CreatedAt = new DateTime(2021, 1, 1),
+                UpdatedAt = new DateTime(2021, 1, 3),
             };
 
             var crmReference = reference.ToCrmModel();
@@ -41,6 +47,8 @@ namespace GetIntoTeachingApiTests.Models.FindApply
             crmReference.FeedbackStatusId.Should().Be((int)ApplicationReference.FeedbackStatus.Cancelled);
             crmReference.Type.Should().Be(reference.RefereeType);
             crmReference.RequestedAt.Should().Be(reference.RequestedAt);
+            crmReference.CreatedAt.Should().Be(reference.CreatedAt);
+            crmReference.UpdatedAt.Should().Be(reference.UpdatedAt);
         }
     }
 }


### PR DESCRIPTION
We want to be able to track the created/updated on dates for `ApplicationReference` entities; the Apply API has been updated to include these and this commit maps them into the respective CRM entity fields.