### PR TITLE
Fix Makefile naming of env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ print-infrastructure-secrets: install-fetch-config set-azure-account
 	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${INFRASTRUCTURE_SECRETS}  -f yaml
 
 setup-local-env: install-fetch-config set-azure-account
-	./fetch_config.rb -s azure-key-vault-secret:s146d01-local2-kv/${APPLICATION_SECRETS} -f shell-env-var > GetIntoTeachingApi/.env.local
+	./fetch_config.rb -s azure-key-vault-secret:s146d01-local2-kv/${APPLICATION_SECRETS} -f shell-env-var > GetIntoTeachingApi/env.local

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ az login
 make local setup-local-env
 ```
 
-Then **set properties of the created .env.local to "Always copy"**.
+Then **set properties of the created env.local to "Always copy"**.
 
 A number of non-secret, default development environment variables are pre-set in `GetIntoTeachingApi/Properties/launchSettings.json` (such as a development `ADMIN_API_KEY` of `admin-secret` and the `VCAP_SERVICES` setup for the Postgres instance running in Docker).
 


### PR DESCRIPTION
We don't have the preceding dot in the env file, but the Makefile generates one with it (which means it gets missed by the gitignore and may be accidentally committed).