### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -14,37 +14,37 @@
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.29" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.29" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.30" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.5" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.6" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="6.0.4" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.4" />
+		<PackageReference Include="Npgsql" Version="6.0.5" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.5" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.17.1" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.18.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.6" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
-		<PackageReference Include="Fody" Version="6.6.2">
+		<PackageReference Include="Fody" Version="6.6.3">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
@@ -52,7 +52,7 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="6.0.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.6" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -61,13 +61,13 @@
 		<PackageReference Include="Serilog" Version="2.11.0" />
 		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.7" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.6.6" />
+		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.8" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -27,7 +27,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.7.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 	<PackageReference Include="Moq" Version="4.18.1" />
 	<PackageReference Include="WireMock.Net" Version="1.5.0" />


### PR DESCRIPTION
- Hangfire.AspNetCore 1.7.29 -> 1.7.30
- Hangfire.Core 1.7.29 -> 1.7.40
- Microsoft.EntityFrameworkCore 6.0.5 -> 6.0.6
- Microsoft.EntityFrameworkCore.Design 6.0.5 -> 6.0.6
- Microsoft.EntityFrameworkCore.Tools 6.0.5 -> 6.0.6
- Microsoft.VisualStudio.Web.CodeGeneration.Design 6.0.5 -> 6.0.6
- Npgsql 6.0.4 -> 6.0.5
- Npgsql.EntityFrameworkCore.PostgreSQL 6.0.4 -> 6.0.5
- Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite 6.0.4 -> 6.0.5
- Sentry.AspNetCore 3.17.1 -> 3.18.0
- Microsoft.Extensions.Caching.StackExchangeRedis 6.0.5 -> 6.0.6
- Fody 6.6.2 -> 6.6.3
- Microsoft.AspNetCore.DataProtection.StackExchangeRedis 6.0.5 -> 6.0.6
- Microsoft.EntityFrameworkCore.Relational 6.0.5 -> 6.0.6
- Hangfire.PostgreSql 1.9.7 -> 1.9.8
- Microsoft.PowerPlatform.Dataverse.Client 0.6.6 -> 1.0.1
- Microsoft.AspNetCore.Mvc.Testing 6.0.5 -> 6.0.6