### PR TITLE
Update FluentValidation to latest version

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="11.1.0" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.30" />

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -14,37 +14,37 @@
 		<PackageReference Include="CsvHelper" Version="27.2.1" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.29" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.29" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.30" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.5" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.6" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="6.0.4" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.4" />
+		<PackageReference Include="Npgsql" Version="6.0.5" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.5" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.17.1" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.18.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.6" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
-		<PackageReference Include="Fody" Version="6.6.2">
+		<PackageReference Include="Fody" Version="6.6.3">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
@@ -52,7 +52,7 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="6.0.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.6" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -61,13 +61,13 @@
 		<PackageReference Include="Serilog" Version="2.11.0" />
 		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.7" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.6.6" />
+		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.8" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Mocks/MockModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockModel.cs
@@ -34,8 +34,8 @@ namespace GetIntoTeachingApi.Mocks
         {
         }
 
-        public MockModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public MockModel(Entity entity, ICrmService crm, IValidator<MockModel> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Mocks/MockRelatedModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockRelatedModel.cs
@@ -17,8 +17,8 @@ namespace GetIntoTeachingApi.Mocks
         {
         }
 
-        public MockRelatedModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public MockRelatedModel(Entity entity, ICrmService crm, IValidator<MockRelatedModel> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
@@ -69,8 +69,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationChoice(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationChoice(Entity entity, ICrmService crm, IValidator<ApplicationChoice> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -90,8 +90,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationForm(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationForm(Entity entity, ICrmService crm, IValidator<ApplicationForm> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationInterview.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationInterview.cs
@@ -41,8 +41,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationInterview(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationInterview(Entity entity, ICrmService crm, IValidator<ApplicationInterview> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
@@ -56,8 +56,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationReference(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationReference(Entity entity, ICrmService crm, IValidator<ApplicationReference> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/Crm/BaseModel.cs
@@ -36,14 +36,14 @@ namespace GetIntoTeachingApi.Models.Crm
             InitChangedPropertyNames();
         }
 
-        protected BaseModel(Entity entity, ICrmService crm, IValidatorFactory vaidatorFactory)
+        protected BaseModel(Entity entity, ICrmService crm, IValidator validator)
             : this()
         {
             Id = entity.Id;
 
             MapFieldAttributesFromEntity(entity);
-            MapRelationshipAttributesFromEntity(entity, crm, vaidatorFactory);
-            NullifyInvalidFieldAttributes(vaidatorFactory);
+            MapRelationshipAttributesFromEntity(entity, crm, validator);
+            NullifyInvalidFieldAttributes(validator);
         }
 
 #pragma warning disable 67
@@ -195,10 +195,8 @@ namespace GetIntoTeachingApi.Models.Crm
             }
         }
 
-        private void NullifyInvalidFieldAttributes(IValidatorFactory validatorFactory)
+        private void NullifyInvalidFieldAttributes(IValidator validator)
         {
-            var validator = validatorFactory.GetValidator(GetType());
-
             if (validator == null)
             {
                 return;
@@ -284,7 +282,7 @@ namespace GetIntoTeachingApi.Models.Crm
             }
         }
 
-        private void MapRelationshipAttributesFromEntity(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
+        private void MapRelationshipAttributesFromEntity(Entity entity, ICrmService crm, IValidator validator)
         {
             foreach (var property in GetProperties(this))
             {
@@ -303,7 +301,7 @@ namespace GetIntoTeachingApi.Models.Crm
                     continue;
                 }
 
-                var relatedModels = relatedEntities.Select(e => Activator.CreateInstance(attribute.Type, e, crm, validatorFactory));
+                var relatedModels = relatedEntities.Select(e => Activator.CreateInstance(attribute.Type, e, crm, validator));
 
                 if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
                 {

--- a/GetIntoTeachingApi/Models/Crm/CallbackBookingQuota.cs
+++ b/GetIntoTeachingApi/Models/Crm/CallbackBookingQuota.cs
@@ -29,8 +29,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CallbackBookingQuota(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CallbackBookingQuota(Entity entity, ICrmService crm, IValidator<CallbackBookingQuota> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -305,8 +305,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public Candidate(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public Candidate(Entity entity, ICrmService crm, IValidator<Candidate> validator)
+            : base(entity, crm, validator)
         {
         }
 

--- a/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
@@ -29,8 +29,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidatePastTeachingPosition(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidatePastTeachingPosition(Entity entity, ICrmService crm, IValidator<CandidatePastTeachingPosition> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidatePrivacyPolicy.cs
@@ -30,8 +30,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidatePrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidatePrivacyPolicy(Entity entity, ICrmService crm, IValidator<CandidatePrivacyPolicy> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidateQualification.cs
@@ -44,8 +44,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidateQualification(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidateQualification(Entity entity, ICrmService crm, IValidator<CandidateQualification> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
@@ -45,8 +45,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidateSchoolExperience(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidateSchoolExperience(Entity entity, ICrmService crm, IValidator<CandidateSchoolExperience> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
@@ -49,8 +49,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public PhoneCall(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public PhoneCall(Entity entity, ICrmService crm, IValidator<PhoneCall> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/PrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/Crm/PrivacyPolicy.cs
@@ -24,8 +24,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public PrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public PrivacyPolicy(Entity entity, ICrmService crm, IValidator<PrivacyPolicy> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
@@ -108,8 +108,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEvent(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEvent(Entity entity, ICrmService crm, IValidator<TeachingEvent> validator)
+            : base(entity, crm, validator)
         {
         }
 

--- a/GetIntoTeachingApi/Models/Crm/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventBuilding.cs
@@ -37,8 +37,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEventBuilding(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEventBuilding(Entity entity, ICrmService crm, IValidator<TeachingEventBuilding> validator)
+            : base(entity, crm, validator)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
@@ -33,8 +33,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEventRegistration(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEventRegistration(Entity entity, ICrmService crm, IValidator validator)
+            : base(entity, crm, validator)
         {
         }
 

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -27,7 +27,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.7.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 	<PackageReference Include="Moq" Version="4.18.1" />
 	<PackageReference Include="WireMock.Net" Version="1.5.0" />

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -31,15 +31,15 @@ namespace GetIntoTeachingApiTests.Services
 
         public CrmServiceTests()
         {
-            var mockValidatorFactory = new Mock<IValidatorFactory>();
-            mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(m => m.GetService(It.IsAny<Type>())).Returns<IValidator>(null);
 
             _mockAppSettings = new Mock<IAppSettings>();
             _mockService = new Mock<IOrganizationServiceAdapter>();
             _mockLogger = new Mock<ILogger<ICrmService>>();
             _context = new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
             _mockService.Setup(mock => mock.Context()).Returns(_context);
-            _crm = new CrmService(_mockService.Object, mockValidatorFactory.Object, _mockAppSettings.Object, new DateTimeProvider(), _mockLogger.Object);
+            _crm = new CrmService(_mockService.Object, _mockAppSettings.Object, new DateTimeProvider(), _mockLogger.Object, mockServiceProvider.Object);
         }
 
         [Fact]


### PR DESCRIPTION
- Upgrade to latest version of FluentValidation

The factory we were using to retrieve validators dynamically has been removed in favour of using the service provider. There may be a cleaner way to do this, but for now the simplest change is to inject the service provider and query the specific validator from that (instead of the factory, which no longer exists).
