### PR TITLE
Remove unused SecondaryEmail attribute from Candidate

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -171,8 +171,6 @@ namespace GetIntoTeachingApi.Models.Crm
         public DateTime? FindApplyCreatedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
-        [EntityField("emailaddress2")]
-        public string SecondaryEmail { get; set; }
         [EntityField("firstname")]
         public string FirstName { get; set; }
         [EntityField("lastname")]

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -17,7 +17,6 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(candidate => candidate.FirstName).MaximumLength(256);
             RuleFor(candidate => candidate.LastName).MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
             RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(25).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -12,7 +12,6 @@ namespace GetIntoTeachingApi.Utils
         {
             "password",
             "email",
-            "secondaryEmail",
             "fullName",
             "firstName",
             "lastName",

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -83,7 +83,6 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("FindApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon" && a.Features.Contains("APPLY_API"));
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
-            type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
             type.GetProperty("LastName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "lastname");
             type.GetProperty("DateOfBirth").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "birthdate");

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -217,33 +217,30 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         public void Validate_EmailAddressInvalid_HasError()
         {
             var invalidEmail = "invalid-email@";
-            var candidate = new Candidate() { Email = invalidEmail, SecondaryEmail = invalidEmail };
+            var candidate = new Candidate() { Email = invalidEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.Email);
-            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_EmailAddressTooLong_HasError()
         {
             var tooLongEmail = $"{new string('a', 50)}@{new string('a', 50)}.com";
-            var candidate = new Candidate() { Email = tooLongEmail, SecondaryEmail = tooLongEmail };
+            var candidate = new Candidate() { Email = tooLongEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.Email);
-            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_EmailAddressIsValid_HasNoError()
         {
             var validEmail = "valid@email.com";
-            var candidate = new Candidate() { Email = validEmail, SecondaryEmail = validEmail };
+            var candidate = new Candidate() { Email = validEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldNotHaveValidationErrorFor(c => c.Email);
-            result.ShouldNotHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-3515](https://trello.com/c/FF6qiIdL/3515-remove-emailaddress2-field-from-the-api)

We no longer collect a `SecondaryEmail` (we used to from the School Experience service). The CRM team have flagged that they are re-purposing that field and so we should remove it to make sure its not accidentally used in the future.