### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/AppStart/DatabaseUtility.cs
+++ b/GetIntoTeachingApi/AppStart/DatabaseUtility.cs
@@ -26,13 +26,13 @@ namespace GetIntoTeachingApi.AppStart
             // Initial CRM sync.
             if (!dbContext.PickListItems.Any())
             {
-                RecurringJob.Trigger(JobConfiguration.CrmSyncJobId);
+                RecurringJob.TriggerJob(JobConfiguration.CrmSyncJobId);
             }
 
             // Initial location sync.
             if (!dbContext.Locations.Any())
             {
-                RecurringJob.Trigger(JobConfiguration.LocationSyncJobId);
+                RecurringJob.TriggerJob(JobConfiguration.LocationSyncJobId);
             }
         }
     }

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -12,26 +12,25 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
 		<PackageReference Include="CsvHelper" Version="28.0.1" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.30" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.31" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.31" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.8">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.7">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.7" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.8" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="6.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.5" />
+		<PackageReference Include="Npgsql" Version="6.0.6" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.6" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
@@ -42,7 +41,7 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
 		<PackageReference Include="YamlDotNet" Version="12.0.0" />
 		<PackageReference Include="Fody" Version="6.6.3">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -52,22 +51,23 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 		<PackageReference Include="GovukNotify" Version="6.0.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.8" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Serilog" Version="2.11.0" />
-		<PackageReference Include="Castle.Core" Version="5.0.0" />
+		<PackageReference Include="Castle.Core" Version="5.1.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.8" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.8" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.9" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -98,6 +98,8 @@
 	  <None Remove="Microsoft.EntityFrameworkCore.Relational" />
 	  <None Remove="Microsoft.CodeAnalysis.NetAnalyzers" />
 	  <None Remove="Hangfire.PostgreSql" />
+	  <None Remove="FluentValidation" />
+	  <None Remove="FluentValidation.AspNetCore" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Fixtures\clients.yml">

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -27,11 +27,11 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.7.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.7" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-	<PackageReference Include="Moq" Version="4.18.1" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+	<PackageReference Include="Moq" Version="4.18.2" />
 	<PackageReference Include="WireMock.Net" Version="1.5.3" />
-	<PackageReference Include="xunit" Version="2.4.1" />
+	<PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>

--- a/GetIntoTeachingApiTests/Helpers/NotThreadSafeResourceCollection.cs
+++ b/GetIntoTeachingApiTests/Helpers/NotThreadSafeResourceCollection.cs
@@ -3,5 +3,5 @@
 namespace GetIntoTeachingApiTests.Helpers
 {
     [CollectionDefinition(nameof(NotThreadSafeResourceCollection), DisableParallelization = true)]
-    class NotThreadSafeResourceCollection { }
+    public class NotThreadSafeResourceCollection { }
 }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/TeachingEventSearchRequestTests.cs
@@ -10,7 +10,7 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
         [Theory]
         [InlineData(1, 1.6093)]
         [InlineData(-1, -1.6093)]
-        [InlineData(0, 0)]
+        [InlineData(0, 0.0)]
         [InlineData(87, 140.0125)]
         [InlineData(null, null)]
         public void RadiusInKm_ConvertsCorrectly(int? miles, double? km)

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -199,14 +199,18 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void FindApplyApiUrl_ReturnsCorrectly()
+        public void FindApplyApiUrl_WhenV1_2FeatureIsOff_ReturnsCorrectly()
         {
-            var previous = Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
+            var previousUrl = Environment.GetEnvironmentVariable("FIND_APPLY_API_URL");
+            var previousFeature = Environment.GetEnvironmentVariable("APPLY_API_V1_2_FEATURE");
+
             Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", "find-apply-api-url");
+            Environment.SetEnvironmentVariable("APPLY_API_V1_2_FEATURE", "false");
 
             _env.FindApplyApiUrl.Should().Be("find-apply-api-url");
 
-            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", previous);
+            Environment.SetEnvironmentVariable("FIND_APPLY_API_URL", previousUrl);
+            Environment.SetEnvironmentVariable("APPLY_API_V1_2_FEATURE", previousFeature);
         }
 
         [Fact]


### PR DESCRIPTION
- Hangfire.AspNetCore 1.7.30 -> 1.7.31
- Hangfire.Core 1.7.30 -> 1.7/31
- Microsoft.EntityFrameworkCore 6.0.7 -> 6.0.8
- Microsoft.EntityFrameworkCore.Design 6.0.7 -> 6.0.8
- Microsoft.EntityFrameworkCore.Tools 6.0.7 -> 6.0.8
- Microsoft.VisualStudio.Web.CodeGeneration.Design 6.0.7 -> 6.0.8
- Npgsql 6.0.5 -> 6.0.6
- Npgsql.EntityFrameworkCore.PostgreSQL 6.0.5 -> 6.0.6
- Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite 6.0.5 -> 6.0.6
- Microsoft.Extensions.Caching.StackExchangeRedis 6.0.7 -> 6.0.8
- Microsoft.AspNetCore.DataProtection.StackExchangeRedis 6.0.7 -> 6.0.8
- Castle.Core 5.0.0 -> 5.0.1
- Microsoft.EntityFrameworkCore.Relational 6.0.7 -> 6.0.8
- Microsoft.AspNetCore.Mvc.Testing 6.0.7 -> 6.0.8
- Microsoft.NET.Test.Sdk 17.2.0 -> 17.3.0
- Moq 14.8.1 -> 14.8.2
- xunit 2.4.1 -> 2.4.2

Closes #1037, #1034, #1033, #1032

Also fixes a flakey test which was highlighted by one of these updates (we were writing to the same environment variable in two separate tests and it was causing an invalid state; the fix was to enforce the state of the `APPLY_API_V1_2_FEATURE` env var before the test).