### PR TITLE
Update postcode CSV URL

### DIFF
--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -21,7 +21,7 @@ namespace GetIntoTeachingApi.Jobs
     public class LocationSyncJob : BaseJob
     {
         public const string UkPostcodeCsvFilename = "ukpostcodes.csv";
-        public static readonly string FreeMapToolsUrl = "https://www.freemaptools.com/download/full-uk-postcodes/ukpostcodes.zip";
+        public static readonly string FreeMapToolsUrl = "https://data.freemaptools.com/download/full-uk-postcodes/ukpostcodes.zip";
         private const int BatchInterval = 300;
         private readonly ILogger<LocationSyncJob> _logger;
         private readonly IMetricService _metrics;

--- a/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/LocationSyncJobTests.cs
@@ -37,7 +37,7 @@ namespace GetIntoTeachingApiTests.Jobs
         [Fact]
         public void FreeMapToolsUrl_IsCorrect()
         {
-            LocationSyncJob.FreeMapToolsUrl.Should().Be("https://www.freemaptools.com/download/full-uk-postcodes/ukpostcodes.zip");
+            LocationSyncJob.FreeMapToolsUrl.Should().Be("https://data.freemaptools.com/download/full-uk-postcodes/ukpostcodes.zip");
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-3554](https://trello.com/c/mZeYYqN7/3554-fix-location-sync-job-in-api)

The service we use to sync UK postcode data from has changed the location of their CSV file (now on a `data` subdomain).

Update to fix the URL.