### PR TITLE
Update Terraform StatusCake provider to 2.0.3

### DIFF
--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -5,8 +5,7 @@ provider "cloudfoundry" {
 }
 
 provider "statuscake" {
-  username = local.infrastructure_secrets.SC-USERNAME
-  apikey   = local.infrastructure_secrets.SC-PASSWORD
+  api_token = local.infrastructure_secrets.SC-PASSWORD
 }
 
 locals {
@@ -32,7 +31,7 @@ terraform {
     }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "1.0.1"
+      version = "2.0.3"
     }
   }
 

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -1,13 +1,71 @@
-resource "statuscake_test" "alert" {
+resource "statuscake_uptime_check" "alert" {
   for_each = var.alerts
 
-  website_name  = each.value.website_name
-  website_url   = each.value.website_url
-  test_type     = each.value.test_type
-  check_rate    = each.value.check_rate
-  contact_group = each.value.contact_group
-  trigger_rate  = each.value.trigger_rate
-  custom_header = each.value.custom_header
-  test_tags     = ["GIT", "BETA"]
-  timeout       = each.value.timeout
+  name           = each.value.website_name
+  check_interval = each.value.check_rate
+  contact_groups = each.value.contact_group
+  confirmation   = 2
+  trigger_rate   = 0
+  regions        = ["london", "dublin"]
+  tags           = ["GIT", "BETA"]
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes = [
+      "204",
+      "205",
+      "206",
+      "303",
+      "400",
+      "401",
+      "403",
+      "404",
+      "405",
+      "406",
+      "408",
+      "410",
+      "413",
+      "444",
+      "429",
+      "494",
+      "495",
+      "496",
+      "499",
+      "500",
+      "501",
+      "502",
+      "503",
+      "504",
+      "505",
+      "506",
+      "507",
+      "508",
+      "509",
+      "510",
+      "511",
+      "521",
+      "522",
+      "523",
+      "524",
+      "520",
+      "598",
+      "599"
+    ]
+    dynamic "basic_authentication" {
+      for_each = var.statuscake_enable_basic_auth ? [1] : []
+      content {
+        username = local.infrastructure_secrets.HTTP-USERNAME
+        password = local.infrastructure_secrets.HTTP-PASSWORD
+      }
+    }
+    request_headers = {
+      Content-Type = "application/x-www-form-urlencoded"
+    }
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
 }

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -34,7 +34,7 @@ variable "paas_space" {
   default = "get-into-teaching"
 }
 
-variable "paas_monitoring_app" { }
+variable "paas_monitoring_app" {}
 
 variable "environment" {
   default = "sb"
@@ -90,6 +90,11 @@ variable "monitor_space" {
 
 variable "alerts" {
   type = map(any)
+}
+
+variable "statuscake_enable_basic_auth" {
+  type    = bool
+  default = false
 }
 
 ### Monitoring


### PR DESCRIPTION
Update the StatusCake provider to ensure it is not using a preview version.

There are no configured StatusCake alerts for the GiT API however the changes are the same as those recently implemented across SE, GiT App and GTTA.