### PR TITLE
Add Prometheus targets for dev/staging Sidekiq instances

### DIFF
--- a/terraform/paas/dev.env.tfvars
+++ b/terraform/paas/dev.env.tfvars
@@ -8,7 +8,8 @@ monitor_scrape_applications = ["get-into-teaching-api-dev-internal.apps.internal
   "get-into-teaching-app-dev-internal.apps.internal:3000",
   "get-teacher-training-adviser-service-dev-internal.apps.internal:3000",
   "school-experience-app-dev-internal.apps.internal:3000",
-  "school-experience-app-dev-delayed.apps.internal:3000"]
+  "school-experience-app-dev-delayed.apps.internal:3000",
+  "school-experience-app-dev-sidekiq.apps.internal:3000"]
 application_instances = 1
 logging               = 0
 monitoring            = 1

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -22,6 +22,7 @@ monitor_scrape_applications = ["get-into-teaching-api-prod-internal.apps.interna
   "school-experience-app-production-internal.apps.internal:3000",
   "school-experience-app-production-delayed.apps.internal:3000",
   "school-experience-app-staging-internal.apps.internal:3000",
-  "school-experience-app-staging-delayed.apps.internal:3000"
+  "school-experience-app-staging-delayed.apps.internal:3000",
+  "school-experience-app-staging-sidekiq.apps.internal:3000"
 ]
 alerts = {}


### PR DESCRIPTION
We are running Sidekiq instances in dev/staging now; this will make Prometheus scrape them.