### PR TITLE
Update job alerts for Sidekiq

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -219,30 +219,30 @@ groups:
   - name: GSE
     rules:
       - alert: HighJobsWaiting (GSE)
-        expr: 'sum(min_over_time(delayed_job_jobs_waiting_count{app="school-experience-app-production-delayed_job"}[10m])) > 20'
+        expr: 'sum(min_over_time(sidekiq_jobs_waiting_count{app="school-experience-app-production-sidekiq"}[10m])) > 20'
         labels:
           severity: high
         annotations:
-          summary: Alerts when jobs are backing up in the GSE delayed job queue.
+          summary: Alerts when jobs are backing up in the GSE Sidekiq job queue.
           description: Alerts if there have been more than 20 jobs waiting for a 10 minute period (indicating they aren't being picked up).
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/3586785294/GSE+Runbook#HighJobsWaiting-HIGH
-          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/xOMcgnLnk/yabeda-delayed-job?orgId=1&refresh=10s
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/oChioth7k/yabeda-sidekiq?orgId=1&refresh=10s
       - alert: HighJobFailures (GSE)
-        expr: 'sum(increase(delayed_job_jobs_errored_total{app="school-experience-app-production-delayed_job"}[15m])) > 2'
+        expr: 'sum(increase(sidekiq_jobs_failed_total{app="school-experience-app-production-sidekiq"}[15m])) > 2'
         labels:
           severity: high
         annotations:
           summary: Alerts when there is more than 1 failed job in the space of 15 minutes.
           description: Alerts when there is more than 1 failed job in the space of 15 minutes.
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/3586785294/GSE+Runbook#HighJobFailures-HIGH
-          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/xOMcgnLnk/yabeda-delayed-job?orgId=1&refresh=10s
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/oChioth7k/yabeda-sidekiq?orgId=1&refresh=10s
       - alert: WorkerFailure (GSE)
-        expr: 'sum(increase(gse_delayed_job_heart_beat{app="school-experience-app-production-delayed_job"}[3m])) < 1'
+        expr: 'sum(increase(gse_sidekiq_heart_beat{app="school-experience-app-production-sidekiq"}[3m])) < 1'
         labels:
           severity: high
         annotations:
           summary: Alerts when the heat beat job stops running
           description: Alerts when there have been 0 heart beats over a 3 minute period, indicating that the workers have hung/crashed.
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/3586785294/GSE+Runbook#HighJobFailures-HIGH
-          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/xOMcgnLnk/yabeda-delayed-job?orgId=1&refresh=10s
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/oChioth7k/yabeda-sidekiq?orgId=1&refresh=10s
           


### PR DESCRIPTION
[Trello-641](https://trello.com/c/W6usHTny/641-switch-our-job-processor-to-sidekiq)

We need to update our job alerts to use the Sidekiq metrics as we now run this in production.