### PR TITLE
Support Get into Teaching events

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
@@ -32,6 +32,7 @@ namespace GetIntoTeachingApi.Models.Crm
             OnlineEvent = 222750008,
             SchoolOrUniversityEvent = 222750009,
             QuestionTime = 222750007,
+            GetIntoTeaching = 222750012,
         }
 
         [EntityField("dfe_event_type", typeof(OptionSetValue))]

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -179,6 +179,7 @@ namespace GetIntoTeachingApiTests.Services
                 (int)TeachingEvent.EventType.ApplicationWorkshop,
                 (int)TeachingEvent.EventType.SchoolOrUniversityEvent,
                 (int)TeachingEvent.EventType.QuestionTime,
+                (int)TeachingEvent.EventType.GetIntoTeaching,
             };
             var hasTypeCondition = conditions.Where(c => c.AttributeName == "dfe_event_type" &&
                 c.Operator == ConditionOperator.In && c.Values.ToHashSet().IsSubsetOf(types)).Any();


### PR DESCRIPTION
Add support for Get into Teaching events; adding to this enum will result in the new evet types being synced from the CRM. There are currently only Get into Teaching events in the development CRM environment.