### PR TITLE
Add RegionId to TeachingEvent

### DIFF
--- a/GetIntoTeachingApi/Controllers/PickListItemsController.cs
+++ b/GetIntoTeachingApi/Controllers/PickListItemsController.cs
@@ -241,6 +241,18 @@ namespace GetIntoTeachingApi.Controllers
         }
 
         [HttpGet]
+        [Route("teaching_event/regions")]
+        [SwaggerOperation(
+            Summary = "Retrieves the list of teaching event regions.",
+            OperationId = "GetTeachingEventRegions",
+            Tags = new[] { "Pick List Items" })]
+        [ProducesResponseType(typeof(IEnumerable<PickListItem>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetTeachingEventRegions()
+        {
+            return Ok(await _store.GetPickListItems("msevtmgt_event", "dfe_eventregion").ToListAsync());
+        }
+
+        [HttpGet]
         [Route("teaching_event/status")]
         [SwaggerOperation(
             Summary = "Retrieves the list of teaching event status.",

--- a/GetIntoTeachingApi/Migrations/20220915115624_AddRegionIdToTeachingEvent.Designer.cs
+++ b/GetIntoTeachingApi/Migrations/20220915115624_AddRegionIdToTeachingEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GetIntoTeachingApi.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GetIntoTeachingApi.Migrations
 {
     [DbContext(typeof(GetIntoTeachingDbContext))]
-    partial class GetIntoTeachingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220915115624_AddRegionIdToTeachingEvent")]
+    partial class AddRegionIdToTeachingEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GetIntoTeachingApi/Migrations/20220915115624_AddRegionIdToTeachingEvent.cs
+++ b/GetIntoTeachingApi/Migrations/20220915115624_AddRegionIdToTeachingEvent.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GetIntoTeachingApi.Migrations
+{
+    public partial class AddRegionIdToTeachingEvent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RegionId",
+                table: "TeachingEvents",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RegionId",
+                table: "TeachingEvents");
+        }
+    }
+}

--- a/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
@@ -39,6 +39,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public int TypeId { get; set; }
         [EntityField("dfe_eventstatus", typeof(OptionSetValue))]
         public int StatusId { get; set; }
+        [EntityField("dfe_eventregion", typeof(OptionSetValue), null, new[] { "GET_INTO_TEACHING_EVENTS" })]
+        public int? RegionId { get; set; }
         [EntityField("dfe_websiteeventpartialurl")]
         public string ReadableId { get; set; }
         [EntityField("dfe_eventwebfeedid")]

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -36,7 +36,8 @@
         "SE_API_KEY": "secret-se",
         "TOTP_SECRET_KEY": "def456",
         "APPLY_API_FEATURE": "on",
-        "APPLY_API_V1_2_FEATURE": "on"
+        "APPLY_API_V1_2_FEATURE": "on",
+        "GET_INTO_TEACHING_EVENTS_FEATURE": "on"
       }
     }
   }

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -274,6 +274,11 @@ namespace GetIntoTeachingApi.Services
                 await SyncPickListItem("dfe_applyapplicationchoice", "dfe_applicationchoicestatus");
                 await SyncPickListItem("dfe_applyreference", "dfe_referencefeedbackstatus");
             }
+
+            if (_env.IsFeatureOn("GET_INTO_TEACHING_EVENTS"))
+            {
+                await SyncPickListItem("msevtmgt_event", "dfe_eventregion");
+            }
         }
 
         private async Task SyncModels<T>(IEnumerable<T> models, IQueryable<T> dbSet)

--- a/GetIntoTeachingApi/env.dev
+++ b/GetIntoTeachingApi/env.dev
@@ -1,3 +1,4 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=true
+GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/env.prod
+++ b/GetIntoTeachingApi/env.prod
@@ -1,3 +1,4 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
+GET_INTO_TEACHING_EVENTS_FEATURE=false
 FIND_APPLY_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/env.test
+++ b/GetIntoTeachingApi/env.test
@@ -1,3 +1,4 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
+GET_INTO_TEACHING_EVENTS_FEATURE=false
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/PickListItemsControllerTests.cs
@@ -253,6 +253,18 @@ namespace GetIntoTeachingApiTests.Controllers
         }
 
         [Fact]
+        public async void GetTeachingEventRegions_ReturnsAllRegions()
+        {
+            var mockItems = MockPickListItems();
+            _mockStore.Setup(mock => mock.GetPickListItems("msevtmgt_event", "dfe_eventregion")).Returns(mockItems.AsAsyncQueryable());
+
+            var response = await _controller.GetTeachingEventRegions();
+
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeEquivalentTo(mockItems);
+        }
+
+        [Fact]
         public async void GetTeachingEventStatus_ReturnsAllStatus()
         {
             var mockItems = MockPickListItems();

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -334,6 +334,18 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SyncAsync_WhenGetIntoTeachingEventsFeatureIsOn_InsertsRegionIdPickListItem()
+        {
+            _mockEnv.Setup(m => m.IsFeatureOn("GET_INTO_TEACHING_EVENTS")).Returns(true);
+
+            _mockCrm.Setup(m => m.GetPickListItems("msevtmgt_event", "dfe_eventregion")).Returns(Array.Empty<PickListItem>()).Verifiable();
+
+            await _store.SyncAsync();
+
+            _mockCrm.Verify();
+        }
+      
+        [Fact]
         public async void SyncAsync_DeletesOrphanedPickListItems()
         {
             var years = (await SeedMockInitialTeacherTrainingYearsAsync()).ToList();


### PR DESCRIPTION
[Trello-3649](https://trello.com/c/543WVKAS/3649-update-api-to-support-get-into-teaching-events)

The new Get into Teaching events will have a specific region assigned to them, so we can show 'all events in the North West', for example.

Add support for `RegionId` on `TeachingEvent`. The CRM attribute is currently only enabled in the `development` CRM environment.