### PR TITLE
Enable Get into Teaching events in test/production

### DIFF
--- a/GetIntoTeachingApi/env.prod
+++ b/GetIntoTeachingApi/env.prod
@@ -1,4 +1,4 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
-GET_INTO_TEACHING_EVENTS_FEATURE=false
+GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/env.test
+++ b/GetIntoTeachingApi/env.test
@@ -1,4 +1,4 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
-GET_INTO_TEACHING_EVENTS_FEATURE=false
+GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api


### PR DESCRIPTION
The schema changes are now in the CRM production instance.

Enable in production will cause Get into Teaching events to sync and the `RegionId` to be exposed on `TeachingEvent`.