### PR TITLE
Attempt to make the health check more robust

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Adapters
             // We don't want to try and connect to Dynamics when integration testing.
             if (!env.IsTest)
             {
-                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(15);
                 CdsServiceClient = new ServiceClient(ConnectionString(env));
                 CdsServiceClient.MaxRetryCount = 3;
             }

--- a/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/OrganizationServiceAdapter.cs
@@ -23,7 +23,7 @@ namespace GetIntoTeachingApi.Adapters
         {
             try
             {
-                _client.GetMyUserId();
+                _client.GetEntityDisplayName("contact");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
[Trello-656](https://trello.com/c/LivMzbVO/656-investigate-timeout-exception)

We are seeing errors on the School Experience service where the health check times out on calling the API health check endpoint.

I'm not sure what is causing this, but I expect that the CRM is being slow to respond as we've seen this happen in the past. To work around this we are only going to call out to the CRM once every minute (caching the health check responses in-between). 

I have also changed the CRM method we call to a generic entity name lookup for the `contact` entity; I suspect the other method we were using (`GetMyUserId`) may end up hitting Microsoft Authentication Library (MSAL) which could be a reason it takes longer than expected.