### PR TITLE
Remove terraform from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,23 +2,18 @@
 
 version: 2
 updates:
- 
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
-      
-  - package-ecosystem: terraform
-    directory: /terraform/paas/
-    schedule:
-      interval: daily
-      
+
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
 
   - package-ecosystem: nuget
-    directory: / 
+    directory: /
     schedule:
-      interval: daily    
+      interval: daily


### PR DESCRIPTION
### Context
Dependabot checks would fail for Terraform providers depending on the pinned version of Terraform used by dependabot-core. Removing these checks until the issue is addressed or workaround found.
See: https://github.com/dependabot/dependabot-core/issues/5797

### Changes proposed in this pull request
Remove Terraform from dependabot checks

### Guidance to review
terraform package ecosystem removed from dependabot.yml