### PR TITLE
[701] Pin github actions to major version

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -82,7 +82,7 @@ runs:
 
              fi
 
-       - uses: hashicorp/setup-terraform@v2.0.0
+       - uses: hashicorp/setup-terraform@v2
          with:
               terraform_version: 1.2.8
 

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -36,14 +36,14 @@ jobs:
         run: echo ::set-output name=sha_short::$(echo $GITHUB_SHA | cut -c -7)
 
       - name: Login to GitHub Container Repository
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build docker image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           tags: ${{ env.DOCKER_REPOSITORY }}:master
           load: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,14 +49,14 @@ jobs:
              ${{ runner.os }}-buildx-
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           push: ${{ github.ref == 'refs/heads/master' }}
           builder: ${{ steps.buildx.outputs.name }}
@@ -120,7 +120,7 @@ jobs:
        - name: Create a GitHub Release
          id: release
          if:   steps.tag_version.outputs.pr_found == 1
-         uses: actions/create-release@v1.1.4
+         uses: actions/create-release@v1
          env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          with:


### PR DESCRIPTION
## What
Pin github actions to major version and let it pick the latest minor version automatically. This is to avoid creating many distracting dependabot PRs