### PR TITLE
Add a GSE alert for CSRF token errors

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -245,4 +245,12 @@ groups:
           description: Alerts when there have been 0 heart beats over a 3 minute period, indicating that the workers have hung/crashed.
           runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/3586785294/GSE+Runbook#HighJobFailures-HIGH
           dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/oChioth7k/yabeda-sidekiq?orgId=1&refresh=10s
-          
+      - alert: HighCSRFTokenErrors (GSE)
+        expr: 'sum(increase(gse_invalid_authenticity_token{app="school-experience-app-production-sidekiq"}[15m])) > 5'
+        labels:
+          severity: high
+        annotations:
+          summary: Alerts when we see a high number of CSRF token errors
+          description: Alerts when there have been more than 5 CSRF token errors in a 15 minute period.
+          runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/3586785294/GSE+Runbook#HighCSRFTokenErrors-HIGH
+          dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=get-into-teaching-production&var-Applications=school-experience-app-production


### PR DESCRIPTION
We want to be alerted if we experience a high number of CSRF token errors in a short period of time (indicating an underlying issue somewhere).