### PR TITLE
Stop using set-output in workflows

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -1,116 +1,116 @@
 name: Deploy to PaaS
 
 inputs:
-      environment:
-        description: The environment to deploy to Development/Test/Production/Review/Speed/UR etc
-        required: true
-      sha:
-        description: Commit sha to be deployed
-        required: true
-      pr:
-        description: Pull Request Reference
-        required: false
-      AZURE_CREDENTIALS:
-        required: true
-      KEY_VAULT:
-        required: true
-      ARM_ACCESS_KEY:
-        required: true
+  environment:
+    description: The environment to deploy to Development/Test/Production/Review/Speed/UR etc
+    required: true
+  sha:
+    description: Commit sha to be deployed
+    required: true
+  pr:
+    description: Pull Request Reference
+    required: false
+  AZURE_CREDENTIALS:
+    required: true
+  KEY_VAULT:
+    required: true
+  ARM_ACCESS_KEY:
+    required: true
 
 runs:
   using: composite
   steps:
-       - name: Checkout
-         uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
-       - name: set-up-environment
-         uses: DFE-Digital/github-actions/set-up-environment@master
+    - name: set-up-environment
+      uses: DFE-Digital/github-actions/set-up-environment@master
 
-       - uses: azure/login@v1
-         with:
-           creds: ${{ inputs.AZURE_CREDENTIALS }}
+    - uses: azure/login@v1
+      with:
+        creds: ${{ inputs.AZURE_CREDENTIALS }}
 
-       - name: Validate Key Vault Secrets
-         uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
-         with:
-           KEY_VAULT: ${{ inputs.KEY_VAULT }}
-           SECRETS: |
-             MONITORING-KEYS
-             API-KEYS
-             INFRA-KEYS
+    - name: Validate Key Vault Secrets
+      uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+      with:
+        KEY_VAULT: ${{ inputs.KEY_VAULT }}
+        SECRETS: |
+          MONITORING-KEYS
+          API-KEYS
+          INFRA-KEYS
 
-       - uses: DfE-Digital/keyvault-yaml-secret@v1
-         id:  keyvault-yaml-secret
-         with:
-           keyvault: ${{ inputs.KEY_VAULT}}
-           secret: INFRA-KEYS
-           key: LOGIT-API
+    - uses: DfE-Digital/keyvault-yaml-secret@v1
+      id: keyvault-yaml-secret
+      with:
+        keyvault: ${{ inputs.KEY_VAULT}}
+        secret: INFRA-KEYS
+        key: LOGIT-API
 
-       - name: Get Short SHA
-         id: sha
-         shell: bash
-         run: echo ::set-output name=short::$(echo "${{ inputs.sha }}" | cut -c -7)
+    - name: Get Short SHA
+      id: sha
+      shell: bash
+      run: echo "short=$(echo "${{ inputs.sha }}" | cut -c -7)" >> $GITHUB_OUTPUT
 
-       - name: Setup Environment Variables
-         id:  variables
-         shell: bash
-         run: |
-             if [ "${{inputs.environment }}" == "Development" ]
-             then
-                 echo ::set-output name=control::$(echo "dev" )
-                 echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-dev" )
-                 echo ::set-output name=key::"api.dev.terraform"
-                 echo ::set-output name=docker_image::"${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}"
+    - name: Setup Environment Variables
+      id: variables
+      shell: bash
+      run: |
+        if [ "${{inputs.environment }}" == "Development" ]
+        then
+            echo "control=dev" >> $GITHUB_OUTPUT
+            echo "healthcheck=${{env.PAAS_APPLICATION_NAME}}-dev" >> $GITHUB_OUTPUT
+            echo "key=api.dev.terraform" >> $GITHUB_OUTPUT
+            echo "docker_image=${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}" >> $GITHUB_OUTPUT
 
-             fi
+        fi
 
-             if [ "${{inputs.environment }}" == "Test" ]
-             then
-                 echo ::set-output name=control::$(echo "test" )
-                 echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-test" )
-                 echo ::set-output name=key::"api.test.terraform"
-                 echo ::set-output name=docker_image::"${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}"
+        if [ "${{inputs.environment }}" == "Test" ]
+        then
+            echo "control=test" >> $GITHUB_OUTPUT
+            echo "healthcheck=${{env.PAAS_APPLICATION_NAME}}-test" >> $GITHUB_OUTPUT
+            echo "key=api.test.terraform" >> $GITHUB_OUTPUT
+            echo "docker_image=${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}" >> $GITHUB_OUTPUT
 
-             fi
+        fi
 
-             if [ "${{inputs.environment }}" == "Production" ]
-             then
-                 echo ::set-output name=control::$(echo "production" )
-                 echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-prod" )
-                 echo ::set-output name=key::"api.production.terraform"
-                 echo ::set-output name=docker_image::"${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}"
+        if [ "${{inputs.environment }}" == "Production" ]
+        then
+            echo "control=production" >> $GITHUB_OUTPUT
+            echo "healthcheck=${{env.PAAS_APPLICATION_NAME}}-prod" >> $GITHUB_OUTPUT
+            echo "key=api.production.terraform" >> $GITHUB_OUTPUT
+            echo "docker_image=${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}" >> $GITHUB_OUTPUT
 
-             fi
+        fi
 
-       - uses: hashicorp/setup-terraform@v2
-         with:
-              terraform_version: 1.2.8
+    - uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.2.8
 
-       - name: Terraform ( ${{inputs.environment}} )
-         shell: bash
-         run: |
-             cd terraform/paas && pwd
-             terraform init -backend-config=${{steps.variables.outputs.control}}.bk.vars -backend-config="key=${{steps.variables.outputs.key}}.tfstate"
-             terraform apply -var-file=${{steps.variables.outputs.control}}.env.tfvars -auto-approve
-         env:
-             ARM_ACCESS_KEY:               ${{ inputs.ARM_ACCESS_KEY  }}
-             TF_VAR_AZURE_CREDENTIALS:     ${{ inputs.AZURE_CREDENTIALS }}
-             TF_VAR_paas_api_docker_image: ${{ steps.variables.outputs.docker_image}}
+    - name: Terraform ( ${{inputs.environment}} )
+      shell: bash
+      run: |
+        cd terraform/paas && pwd
+        terraform init -backend-config=${{steps.variables.outputs.control}}.bk.vars -backend-config="key=${{steps.variables.outputs.key}}.tfstate"
+        terraform apply -var-file=${{steps.variables.outputs.control}}.env.tfvars -auto-approve
+      env:
+        ARM_ACCESS_KEY: ${{ inputs.ARM_ACCESS_KEY  }}
+        TF_VAR_AZURE_CREDENTIALS: ${{ inputs.AZURE_CREDENTIALS }}
+        TF_VAR_paas_api_docker_image: ${{ steps.variables.outputs.docker_image}}
 
-       - name: Smoke tests
-         shell: bash
-         run: |
-             tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "${{ steps.sha.outputs.short }}"
+    - name: Smoke tests
+      shell: bash
+      run: |
+        tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "${{ steps.sha.outputs.short }}"
 
-       - name: Log Deployment
-         if: always()
-         uses: DFE-Digital/github-actions/SendToLogit@master
-         with:
-            LOGIT-API-KEY: ${{ steps.keyvault-yaml-secret.outputs.LOGIT-API }}
-            logtype: "github"
-            JSON: |
-                '{"Application" : "${{env.PAAS_APPLICATION_NAME}}",
-                  "Status"      : "${{ job.status }}",
-                  "Action"      : "Deploy",
-                  "Environment" : "${{inputs.environment}}",
-                  "Version"     : "${{ inputs.sha }}" }'
+    - name: Log Deployment
+      if: always()
+      uses: DFE-Digital/github-actions/SendToLogit@master
+      with:
+        LOGIT-API-KEY: ${{ steps.keyvault-yaml-secret.outputs.LOGIT-API }}
+        logtype: "github"
+        JSON: |
+          '{"Application" : "${{env.PAAS_APPLICATION_NAME}}",
+            "Status"      : "${{ job.status }}",
+            "Action"      : "Deploy",
+            "Environment" : "${{inputs.environment}}",
+            "Version"     : "${{ inputs.sha }}" }'

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get Short SHA
         id: vars
-        run: echo ::set-output name=sha_short::$(echo $GITHUB_SHA | cut -c -7)
+        run: echo "sha_short=$(echo $GITHUB_SHA | cut -c -7)" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Repository
         uses: docker/login-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get Short SHA
         id: vars
         run: |
-             echo ::set-output name=sha_short::$(echo $GITHUB_SHA | cut -c -7)
+             echo "sha_short=$(echo $GITHUB_SHA | cut -c -7)" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
         uses: actions/cache@v3


### PR DESCRIPTION
### Trello card
https://trello.com/c/3s3iC7UV

### Context
The set-output command is being deprecated soon.

### Changes proposed in this pull request
Resolution is to use $GITHUB_OUTPUT as per the workflow commands docs.

### Guidance to review
Confirm updated workflows tested where possible:

- [ ] Deploy Other env (e.g. development)
- [ ] Build
- [ ] Build No Cache