### PR TITLE
Allow event search with radius but without postcode

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidator.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching.Validators
                 .NotEmpty()
                 .MaximumLength(40)
                 .Matches(Location.OutwardOrFullPostcodeRegex)
-                .Unless(request => request.Postcode == null && request.Radius == null);
+                .Unless(request => request.Postcode == null);
             RuleForEach(request => request.TypeIds)
                 .SetValidator(new PickListItemIdValidator<TeachingEventSearchRequest>("msevtmgt_event", "dfe_event_type", store))
                 .Unless(request => request.TypeIds == null);

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -127,7 +127,7 @@ namespace GetIntoTeachingApi.Services
                 teachingEvents = teachingEvents.Where(te => te.IsOnline == request.Online);
             }
 
-            if (request.Radius == null)
+            if (request.Radius == null || request.Postcode == null)
             {
                 return await teachingEvents.ToListAsync();
             }

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/TeachingEventSearchRequestValidatorTests.cs
@@ -88,20 +88,6 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators
         }
 
         [Fact]
-        public void Validate_RadiusIsNotNullAndPostcodeIsNull_HasError()
-        {
-            var request = new TeachingEventSearchRequest()
-            {
-                Radius = 10,
-                Postcode = null,
-            };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor(request => request.Postcode);
-        }
-
-        [Fact]
         public void Validate_TypeIdIsInvalid_HasError()
         {
             var result = _validator.TestValidate(new TeachingEventSearchRequest() { TypeIds = new int[] { 123 } });

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -510,6 +510,20 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
+        public async void SearchTeachingEvents_FilteredByRadiusWithoutPostcode_ReturnsAll()
+        {
+            SeedMockLocations();
+            await SeedMockTeachingEventsAndBuildingsAsync();
+            var request = new TeachingEventSearchRequest() { Radius = 15 };
+
+            var result = await _store.SearchTeachingEventsAsync(request);
+
+            result.Select(e => e.Name).Should().BeEquivalentTo(
+                new string[] { "Event 7", "Event 2", "Event 4", "Event 1", "Event 3", "Event 5", "Event 6" },
+                options => options.WithStrictOrdering());
+        }
+
+        [Fact]
         public async void SearchTeachingEvents_FilteredByRadiusWithOutwardOnlyPostcode_ReturnsMatchingAndOnlineEvents()
         {
             SeedMockLocations();


### PR DESCRIPTION
[Trello-3784](https://trello.com/c/pzop8GSN/3784-address-500-errors-served-on-event-search)

The validation is a bit strict at the moment; if you provide a radius but no postcode we throw an error. The front-end currently allows this scenario and it makes sense to allow it from a users perspective as well.

Relax validation to return all results if filtering by radius without specifying a postcode (so treating it as if they haven't filtered by distance in this use case).