### PR TITLE
Various dependency updates (inc major version bumps)

### DIFF
--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using AspNetCoreRateLimit;
 using dotenv.net;
+using FluentValidation;
 using FluentValidation.AspNetCore;
 using GetIntoTeachingApi.JsonConverters;
 using GetIntoTeachingApi.ModelBinders;
@@ -46,8 +47,9 @@ namespace GetIntoTeachingApi.AppStart
             services.AddMvc(o => o.Conventions.Add(new CommaSeparatedQueryStringConvention()));
 
             services
+                .AddValidatorsFromAssemblyContaining<Startup>()
+                .AddFluentValidationAutoValidation()
                 .AddControllers(o => o.ModelBinderProviders.Insert(0, new TrimStringModelBinderProvider()))
-                .AddFluentValidation(c => c.RegisterValidatorsFromAssemblyContaining<Startup>())
                 .AddJsonOptions(o =>
                 {
                     o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -11,56 +11,56 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
-		<PackageReference Include="CsvHelper" Version="28.0.1" />
+		<PackageReference Include="CsvHelper" Version="29.0.0" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.31" />
 		<PackageReference Include="Hangfire.Core" Version="1.7.31" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.8" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
 		<PackageReference Include="Npgsql" Version="6.0.7" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.6" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.7" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.21.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.22.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
-		<PackageReference Include="YamlDotNet" Version="12.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
+		<PackageReference Include="YamlDotNet" Version="12.0.2" />
 		<PackageReference Include="Fody" Version="6.6.3">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="3.4.1" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
-		<PackageReference Include="GovukNotify" Version="6.0.0" />
+		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.10" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Serilog" Version="2.11.0" />
+		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Castle.Core" Version="5.1.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -66,7 +66,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.9" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.23" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
 	</ItemGroup>
 

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -43,11 +43,11 @@
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
 		<PackageReference Include="YamlDotNet" Version="12.0.2" />
-		<PackageReference Include="Fody" Version="6.6.3">
+		<PackageReference Include="Fody" Version="6.6.4">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="PropertyChanged.Fody" Version="3.4.1" PrivateAssets="All" />
+		<PackageReference Include="PropertyChanged.Fody" Version="4.0.5" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
 		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -67,7 +67,7 @@
 		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.23" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApi/Mocks/MockModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockModel.cs
@@ -34,8 +34,8 @@ namespace GetIntoTeachingApi.Mocks
         {
         }
 
-        public MockModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public MockModel(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Mocks/MockRelatedModel.cs
+++ b/GetIntoTeachingApi/Mocks/MockRelatedModel.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System;
+using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Services;
@@ -17,8 +18,8 @@ namespace GetIntoTeachingApi.Mocks
         {
         }
 
-        public MockRelatedModel(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public MockRelatedModel(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
@@ -69,8 +69,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationChoice(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationChoice(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -90,8 +90,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationForm(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationForm(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationInterview.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationInterview.cs
@@ -41,8 +41,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationInterview(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationInterview(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationReference.cs
@@ -56,8 +56,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public ApplicationReference(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public ApplicationReference(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CallbackBookingQuota.cs
+++ b/GetIntoTeachingApi/Models/Crm/CallbackBookingQuota.cs
@@ -29,8 +29,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CallbackBookingQuota(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CallbackBookingQuota(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -303,8 +303,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public Candidate(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public Candidate(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
 

--- a/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
@@ -29,8 +29,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidatePastTeachingPosition(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidatePastTeachingPosition(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidatePrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidatePrivacyPolicy.cs
@@ -30,8 +30,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidatePrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidatePrivacyPolicy(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidateQualification.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidateQualification.cs
@@ -44,8 +44,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidateQualification(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidateQualification(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidateSchoolExperience.cs
@@ -45,8 +45,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public CandidateSchoolExperience(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public CandidateSchoolExperience(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
+++ b/GetIntoTeachingApi/Models/Crm/PhoneCall.cs
@@ -49,8 +49,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public PhoneCall(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public PhoneCall(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/PrivacyPolicy.cs
+++ b/GetIntoTeachingApi/Models/Crm/PrivacyPolicy.cs
@@ -24,8 +24,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public PrivacyPolicy(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public PrivacyPolicy(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
@@ -111,8 +111,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEvent(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEvent(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
 

--- a/GetIntoTeachingApi/Models/Crm/TeachingEventBuilding.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventBuilding.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
 using FluentValidation;
@@ -37,8 +38,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEventBuilding(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEventBuilding(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
     }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
@@ -33,8 +33,8 @@ namespace GetIntoTeachingApi.Models.Crm
         {
         }
 
-        public TeachingEventRegistration(Entity entity, ICrmService crm, IValidatorFactory validatorFactory)
-            : base(entity, crm, validatorFactory)
+        public TeachingEventRegistration(Entity entity, ICrmService crm, IServiceProvider serviceProvider)
+            : base(entity, crm, serviceProvider)
         {
         }
 

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -26,11 +26,11 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.7.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.9" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+	<PackageReference Include="FluentAssertions" Version="6.8.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 	<PackageReference Include="Moq" Version="4.18.2" />
-	<PackageReference Include="WireMock.Net" Version="1.5.6" />
+	<PackageReference Include="WireMock.Net" Version="1.5.8" />
 	<PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractTestOrganizationServiceAdapter.cs
@@ -10,76 +10,30 @@ using Moq;
 
 namespace GetIntoTeachingApiTests.Helpers
 {
-    public class ContractTestOrganizationServiceAdapter : IOrganizationServiceAdapter
+    public class ContractTestOrganizationServiceAdapter : MockOrganizationServiceAdapter
     {
         public readonly List<Entity> TrackedEntities = new List<Entity>();
 
-        public string CheckStatus()
+        public override Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context)
         {
-            throw new NotImplementedException();
-        }
-
-        public IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context)
-        {
-            return new List<Entity>().AsQueryable();
-        }
-
-        public IEnumerable<Entity> RetrieveMultiple(QueryBase query)
-        {
-            return new List<Entity>();
-        }
-
-        public void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerable<PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName)
-        {
-            throw new NotImplementedException();
-        }
-
-        public OrganizationServiceContext Context()
-        {
-            return new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
-        }
-
-        public Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context)
-        {
-            var existingEntity = new Entity(entityName, id);
+            var existingEntity = base.BlankExistingEntity(entityName, id, context);
             TrackedEntities.Add(existingEntity);
             return existingEntity;
         }
 
-        public Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
+        public override Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
         {
-            var newEntity = id.HasValue ? new Entity(entityName, id.Value) : new Entity(entityName);
-            newEntity.EntityState = EntityState.Created;
+            var newEntity = base.NewEntity(entityName, id, context);
             TrackedEntities.Add(newEntity);
             return newEntity;
         }
 
-        public void SaveChanges(OrganizationServiceContext context)
-        {
-            // Not required (exposed via TrackedEntities).
-        }
-
-        public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        public override void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
         {
             // Related entities are nested against an already-tracked entity,
             // so they don't need to be tracked explicitly.
             source.Attributes[relationship.SchemaName] = target;
             TrackedEntities.Remove(target);
-        }
-
-        void IOrganizationServiceAdapter.DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/GetIntoTeachingApiTests/Helpers/GitWebApplicationFactory.cs
+++ b/GetIntoTeachingApiTests/Helpers/GitWebApplicationFactory.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
 using AspNetCoreRateLimit;
+using GetIntoTeachingApi.Adapters;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GetIntoTeachingApiTests.Helpers
 {
@@ -16,8 +18,13 @@ namespace GetIntoTeachingApiTests.Helpers
                 services.Remove(services.First(d => d.ServiceType == typeof(IRateLimitCounterStore)));
                 services.Remove(services.First(d => d.ServiceType == typeof(IClientPolicyStore)));
                 services.Remove(services.First(d => d.ServiceType == typeof(IProcessingStrategy)));
+
                 // Use in-memory rate limiting.
                 services.AddInMemoryRateLimiting();
+
+                // Mock out API calls.
+                services.Remove(services.First(d => d.ServiceType == typeof(IOrganizationServiceAdapter)));
+                services.Add(ServiceDescriptor.Describe(typeof(IOrganizationServiceAdapter), provider => new MockOrganizationServiceAdapter(), ServiceLifetime.Singleton));
             });
         }
     }

--- a/GetIntoTeachingApiTests/Helpers/MockOrganizationServiceAdapter.cs
+++ b/GetIntoTeachingApiTests/Helpers/MockOrganizationServiceAdapter.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GetIntoTeachingApi.Adapters;
+using Microsoft.PowerPlatform.Dataverse.Client.Extensions;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+
+namespace GetIntoTeachingApiTests.Helpers
+{
+    public class MockOrganizationServiceAdapter : IOrganizationServiceAdapter
+    {
+        public virtual string CheckStatus()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual IQueryable<Entity> CreateQuery(string entityName, OrganizationServiceContext context)
+        {
+            return new List<Entity>().AsQueryable();
+        }
+
+        public virtual IEnumerable<Entity> RetrieveMultiple(QueryBase query)
+        {
+            return new List<Entity>();
+        }
+
+        public virtual void LoadProperty(Entity entity, Relationship relationship, OrganizationServiceContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual IEnumerable<PickListItem> GetPickListItemsForAttribute(string entityName, string attributeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual IEnumerable<Entity> RelatedEntities(Entity entity, string attributeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public  OrganizationServiceContext Context()
+        {
+            return new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
+        }
+
+        public virtual Entity BlankExistingEntity(string entityName, Guid id, OrganizationServiceContext context)
+        {
+            return new Entity(entityName, id);
+        }
+
+        public virtual Entity NewEntity(string entityName, Guid? id, OrganizationServiceContext context)
+        {
+            var newEntity = id.HasValue ? new Entity(entityName, id.Value) : new Entity(entityName);
+            newEntity.EntityState = EntityState.Created;
+            return newEntity;
+        }
+
+        public virtual void SaveChanges(OrganizationServiceContext context)
+        {
+            // Not required.
+        }
+
+        public virtual void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            // Not required.
+        }
+
+        void IOrganizationServiceAdapter.DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -32,8 +32,8 @@ namespace GetIntoTeachingApiTests.Services
 
         public CrmServiceTests()
         {
-            var mockValidatorFactory = new Mock<IValidatorFactory>();
-            mockValidatorFactory.Setup(m => m.GetValidator(It.IsAny<Type>())).Returns<IValidator>(null);
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(m => m.GetService(It.IsAny<Type>())).Returns<IValidator>(null);
 
             _mockAppSettings = new Mock<IAppSettings>();
             _mockService = new Mock<IOrganizationServiceAdapter>();
@@ -41,7 +41,7 @@ namespace GetIntoTeachingApiTests.Services
             _mockDateTime = new Mock<IDateTimeProvider>();
             _context = new OrganizationServiceContext(new Mock<IOrganizationService>().Object);
             _mockService.Setup(mock => mock.Context()).Returns(_context);
-            _crm = new CrmService(_mockService.Object, mockValidatorFactory.Object, _mockAppSettings.Object, _mockDateTime.Object, _mockLogger.Object);
+            _crm = new CrmService(_mockService.Object, mockServiceProvider.Object, _mockAppSettings.Object, _mockDateTime.Object, _mockLogger.Object);
 
             // Freeze time.
             _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);


### PR DESCRIPTION
WIP

[Trello-3790](https://trello.com/c/hlRw9nZ7/3790-update-property-changed-fluent-validation)

Various dependency updates

```
- CsvHelper 28.0.1 -> 29.0.0
- Microsoft.EntityFrameworkCore 6.0.9 -> 6.0.10
- Microsoft.EntityFrameworkCore.Design 6.0.8 -> 6.0.10
- Microsoft.EntityFrameworkCore.Tools 6.0.8 -> 6.0.10
- Microsoft.VisualStudio.Web.CodeGeneration.Design 6.0.8 -> 6.0.10
- Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite 6.0.6 -> 6.0.7
- Sentry.AspNetCore 3.21.0 -> 3.22.0
- Serilog.Settings.Configuration 3.3.0 -> 3.4.0
- Microsoft.Extensions.Caching.StackExchangeRedis 6.0.9 -> 6.0.10
- YamlDotNet 12.0.1 -> 12.0.2
- GovukNotify 6.0.0 -> 6.1.0
- Microsoft.AspNetCore.DataProtection.StackExchangeRedis 6.0.8 -> 6.0.10
- Microsoft.Extensions.DependencyInjection 6.0.0 -> 6.0.1
- Serilog 2.11.0 -> 2.12.0
- Microsoft.EntityFrameworkCore.Relational 6.0.8 -> 6.0.10
- FluentAssertions 6.7.0 -> 6.8.0
- Microsoft.AspNetCore.Mvc.Testing 6.0.9 -> 6.0.10
- Microsoft.NET.Test.Sdk 12.3.1 -> 17.3.2
- WireMock.Net 1.5.6 -> 1.5.8
```

- Update Fody/PropertyChangedNotification

This is a major version bump; we have extensive tests around the functionality so it _should_ be safe, but I will do manual testing as well.

- Update Dataverse client

We use this to talk to the Dynamics CRM; its a patch up date but I'll do manual testing as well.

- Update FluentValidation

The `IValidationFactory` that we use to validate models coming back from the CRM has been deprecated and removed from the latest version of `FluentValidation`. I haven't found a nice way of doing this validation during reflection with the latest version; we have to inject the whole service provider into the models so that we can lookup the validator dynamically.

I may try refactoring this with a factory pattern in a future PR.

Also mocks out API calls in the rate limiting integration tests; I ended up doing this as part of chasing down a test failure which was actually caused by the validators not auto-registering with the controllers after the upgrade. The fix was to call `AddFluentValidationAutoValidation` during startup, but I'm leaving the mock in place as its more robust if we mock out the API (even though the validation prevents it being it in our current test suite I can see it being used in future tests).