### PR TITLE
Upgrade to .NET Core 7

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '7.0'
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
 
       - name: Install dotnet-sonarscanner
-        run:  dotnet tool install --global dotnet-sonarscanner --version 5.4
+        run:  dotnet tool install --global dotnet-sonarscanner --version 5.8
 
       - name: Install dependencies
         run:  dotnet restore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet-core
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 WORKDIR /source
 ARG GIT_COMMIT_SHA
 ENV ASPNETCORE_URLS=http://+:8080
@@ -16,7 +16,7 @@ WORKDIR /source/GetIntoTeachingApi
 RUN dotnet publish -c release -o /app --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 WORKDIR /app
 COPY --from=build /app ./

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -11,10 +11,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
-		<PackageReference Include="CsvHelper" Version="30.0.0" />
+		<PackageReference Include="CsvHelper" Version="30.0.1" />
 		<PackageReference Include="GeocodeSharp" Version="1.5.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.31" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.31" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.32" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.32" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
@@ -34,7 +34,7 @@
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.23.1" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.24.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
@@ -47,14 +47,14 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="PropertyChanged.Fody" Version="4.0.5" PrivateAssets="All" />
+		<PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
 		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.10" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Serilog" Version="2.12.0" />
@@ -66,7 +66,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.23" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.26" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
 	</ItemGroup>
 

--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisMode>Recommended</AnalysisMode>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -17,20 +17,20 @@
 		<PackageReference Include="Hangfire.Core" Version="1.7.32" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.10">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="6.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.7" />
+		<PackageReference Include="Npgsql" Version="7.0.0" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="7.0.0" />
 		<PackageReference Include="Otp.NET" Version="1.2.2" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
@@ -41,7 +41,7 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
 		<PackageReference Include="YamlDotNet" Version="12.0.2" />
 		<PackageReference Include="Fody" Version="6.6.4">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -51,17 +51,17 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
 		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.0" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
 		<PackageReference Include="Hangfire.Dashboard.Basic.Authentication" Version="5.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Castle.Core" Version="5.1.0" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22518.1">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -28,9 +28,9 @@
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.8.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 	<PackageReference Include="Moq" Version="4.18.2" />
-	<PackageReference Include="WireMock.Net" Version="1.5.9" />
+	<PackageReference Include="WireMock.Net" Version="1.5.10" />
 	<PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -27,7 +27,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.8.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 	<PackageReference Include="Moq" Version="4.18.2" />
 	<PackageReference Include="WireMock.Net" Version="1.5.10" />


### PR DESCRIPTION
[Trello-3958](https://trello.com/c/H470nG27/3958-upgrade-api-to-net-core-7)

- Various dependency updates

```
- CsvHelper 30.0.0 -> 30.0.1
- Hangfire.AspNetCore 1.7.31 -> 1.7.32
- Hangfire.Core 1.7.31 -> 1.7.32
- Sentry.AspNetCore 3.23.1 -> 3.24.0
- PropertyChanged.Fody 4.0.5 -> 4.1.0
- Newtonsoft.Json 13.0.1 -> 13.0.2
- Microsoft.PowerPlatform.Dataverse.Client 1.0.23 -> 1.0.26
- Microsoft.NET.Test.Sdk 17.3.2 -> 17.4.0
- WireMock.Net 1.5.0 -> 1.5.10
```

- Upgrade to .NET Core 7

Updates to the latest version of .NET Core. The only pre-release package we are using is for static code analysis and it looks like they're close to releasing the version with v7 support.