### PR TITLE
Increase CdsSeviceClient timeout

### DIFF
--- a/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
+++ b/GetIntoTeachingApi/Adapters/CdsServiceClientWrapper.cs
@@ -14,9 +14,11 @@ namespace GetIntoTeachingApi.Adapters
             // We don't want to try and connect to Dynamics when integration testing.
             if (!env.IsTest)
             {
-                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(15);
-                CdsServiceClient = new ServiceClient(ConnectionString(env));
-                CdsServiceClient.MaxRetryCount = 3;
+                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+                CdsServiceClient = new ServiceClient(ConnectionString(env))
+                {
+                    MaxRetryCount = 3
+                };
             }
         }
 


### PR DESCRIPTION
We're seeing the current timeout of 15s being reached occasionally in production; increasing to 30s to see if it reduces the number of errors we get.