### PR TITLE
Matchback on apply ID if available

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApi.Jobs
         public void SyncCandidate(Candidate findApplyCandidate)
         {
             var candidate = findApplyCandidate.ToCrmModel();
-            var match = _crm.MatchCandidate(candidate.Email);
+            var match = _crm.MatchCandidate(candidate.Email, findApplyCandidate.Id);
 
             _logger.LogInformation("FindApplyCandidateSyncJob - {Status} - {Id}", match == null ? "Miss" : "Hit", findApplyCandidate.Id);
 

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PickListItem> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
-        Candidate MatchCandidate(string email);
+        Candidate MatchCandidate(string email, string findApplyId);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
         IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);

--- a/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
@@ -172,9 +172,9 @@ namespace GetIntoTeachingApiTests.Helpers
             return _crmService.MatchCandidate(request);
         }
 
-        public Candidate MatchCandidate(string email)
+        public Candidate MatchCandidate(string email, string findApplyId)
         {
-            return Candidates.FirstOrDefault(c => c.Email == email);
+            return Candidates.FirstOrDefault(c => c.Email == email || c.FindApplyId == findApplyId);
         }
 
         public IEnumerable<Candidate> MatchCandidates(string magicLinkToken)

--- a/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/FindApplyCandidateSyncJobTests.cs
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApiTests.Jobs
         {
             var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns(match);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns(match);
 
             _job.Run(_candidate);
 
@@ -148,7 +148,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_OnSuccessWithNewCandidate_SetsChannelAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email)).Returns<Candidate>(null);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns<Candidate>(null);
 
             _job.Run(_candidate);
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -139,34 +139,42 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         
-        private static bool VerifyMatchCandidatesWithEmailExpression(QueryExpression query, string email)
+        private static bool VerifyMatchCandidatesWithFindApplyIdAndEmailExpression(QueryExpression query, string findApplyId, string email)
         {
             var hasEntityName = query.EntityName == "contact";
-            var conditions = query.Criteria.Conditions;
+            var andConditions = query.Criteria.Conditions;
+            var orConditions = query.Criteria.Filters.First().Conditions;
             var orders = query.Orders;
 
-            var hasStateCodeCondition = conditions.Any(c => c.AttributeName == "statecode" &&
+            var hasStateCodeCondition = andConditions.Any(c => c.AttributeName == "statecode" &&
                 c.Operator == ConditionOperator.Equal && (int)c.Values[0] == (int)Candidate.Status.Active);
-            var hasEmailAddressCondition = conditions.Any(c => c.AttributeName == "emailaddress1" &&
-                c.Operator == ConditionOperator.Equal && c.Values[0].ToString() == email);
 
+            var hasEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress1" &&
+                c.Operator == ConditionOperator.Equal && c.Values[0].ToString() == email);
+            var hasFindApplyCondition = findApplyId == null ||
+                    orConditions.Any(c => c.AttributeName == "dfe_applyid" && c.Operator == ConditionOperator.Equal && c.Values[0].ToString() == findApplyId);
+
+            var hasFindApplyIdSortOrder = findApplyId == null ||
+                    orders.Any(o => o.AttributeName == "dfe_applyid" && o.OrderType == OrderType.Descending);
             var hasDuplicateScoreOrder = orders.Any(o => o.AttributeName == "dfe_duplicatescorecalculated" && o.OrderType == OrderType.Descending);
             var hasModifiedOnOrder = orders.Any(o => o.AttributeName == "modifiedon" && o.OrderType == OrderType.Descending);
 
             var hasTopCount = query.TopCount == 1;
 
-            return hasEntityName && hasStateCodeCondition && hasEmailAddressCondition && hasDuplicateScoreOrder && hasModifiedOnOrder && hasTopCount;
+            return hasEntityName && hasStateCodeCondition && hasEmailAddressCondition && hasFindApplyCondition
+                && hasDuplicateScoreOrder && hasFindApplyIdSortOrder && hasModifiedOnOrder && hasTopCount;
         }
 
         private static bool VerifyMatchCandidatesWithExistingCandidateRequestExpression(QueryExpression query, string email)
         {
             var hasEntityName = query.EntityName == "contact";
-            var conditions = query.Criteria.Conditions;
+            var andConditions = query.Criteria.Conditions;
+            var orConditions = query.Criteria.Filters.First().Conditions;
             var orders = query.Orders;
 
-            var hasStateCodeCondition = conditions.Any(c => c.AttributeName == "statecode" &&
+            var hasStateCodeCondition = andConditions.Any(c => c.AttributeName == "statecode" &&
                 c.Operator == ConditionOperator.Equal && (int)c.Values[0] == (int)Candidate.Status.Active);
-            var hasEmailAddressCondition = conditions.Any(c => c.AttributeName == "emailaddress1" &&
+            var hasEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress1" &&
                 c.Operator == ConditionOperator.Equal && c.Values[0].ToString() == email);
 
             var hasDuplicateScoreOrder = orders.Any(o => o.AttributeName == "dfe_duplicatescorecalculated" && o.OrderType == OrderType.Descending);
@@ -521,21 +529,28 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Theory]
-        [InlineData("john@doe.com", "New John")]
-        [InlineData("jane@doe.com", "Jane")]
-        [InlineData("bob@doe.com", null)]
-        [InlineData("inactive@doe.com", null)]
-        public void MatchCandidate_WithEmail_MatchesOnNewsetActiveByDuplicateScoreWithEmail(string email, string expectedFirstName)
+        [InlineData("applyjohn", "john@doe.com", "New John")]
+        [InlineData(null, "jane@doe.com", "Jane")]
+        [InlineData("applybob", "bob@doe.com", null)]
+        [InlineData(null, "inactive@doe.com", null)]
+        public void MatchCandidate_WithFindApplyIdAndEmail_MatchesOnFindApplyIdThenNewsetActiveByDuplicateScoreWithEmail(string findApplyId, string email, string expectedFirstName)
         {
             var candidates = MockCandidates().Where(c => c.GetAttributeValue<int>("statecode") == (int)Candidate.Status.Active
                 && c.GetAttributeValue<string>("emailaddress1").Equals(email));
 
             _mockService.Setup(mock => mock.RetrieveMultiple(It.Is<QueryExpression>(
-                q => VerifyMatchCandidatesWithEmailExpression(q, email)))).Returns(candidates);
+                q => VerifyMatchCandidatesWithFindApplyIdAndEmailExpression(q, findApplyId, email)))).Returns(candidates);
 
-            var result = _crm.MatchCandidate(email);
+            var result = _crm.MatchCandidate(email, findApplyId);
 
-            result?.FirstName.Should().Be(expectedFirstName);
+            if (result == null)
+            {
+                expectedFirstName.Should().BeNull();
+            }
+            else
+            {
+                result.FirstName.Should().Be(expectedFirstName);
+            }
         }
 
         [Theory]
@@ -848,6 +863,7 @@ namespace GetIntoTeachingApiTests.Services
             };
             candidate1["contactid"] = new EntityReference("contactid", JaneDoeGuid);
             candidate1["statecode"] = Candidate.Status.Active;
+            candidate1["dfe_applyid"] = "applyjane";
             candidate1["emailaddress1"] = "jane@doe.com";
             candidate1["firstname"] = "Jane";
             candidate1["lastname"] = "Doe";
@@ -863,6 +879,7 @@ namespace GetIntoTeachingApiTests.Services
             };
             candidate2["contactid"] = new EntityReference("contactid", JohnDoeGuid);
             candidate2["statecode"] = Candidate.Status.Active;
+            candidate2["dfe_applyid"] = "applyjohn";
             candidate2["emailaddress1"] = "john@doe.com";
             candidate2["firstname"] = "New John";
             candidate2["lastname"] = "Doe";


### PR DESCRIPTION
[Trello-3971](https://trello.com/c/7VSR35YO/3971-update-apply-api-matchback-to-use-apply-id-as-first-match-parameter)

When we sync candidates from the Apply service into the CRM we currently only matchback on email address. We need to do this initially, but once the candidate is in the CRM we could also matchback on the Apply candidate ID.

Going forward we want to matchback on the Apply candidate ID with precedence over the email address.

I've raised a separate ticket to clean up/automate some of our manual mock object creation. Testing interactions with the CRM is difficult enough as it is (we have to assert on the query expressions as we can't mock a Dynamics instance) and automating the mock creation should simplify the test cases a bit.

I'm not sure why the code coverage is reporting 0% of new lines covered; they definitely are. I'll raise a ticket to investigate the sonarqube integration. It may be related to bumping the .NET Core version recently.