### PR TITLE
Ensure CRM email takes precedence over Apply

### DIFF
--- a/GetIntoTeachingApi/Jobs/ApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/ApplyCandidateSyncJob.cs
@@ -60,6 +60,9 @@ namespace GetIntoTeachingApi.Jobs
             if (match != null)
             {
                 candidate.Id = match.Id;
+                // The existing email address in the CRM should always
+                // take presedence over the email from the Apply candidate.
+                candidate.Email = match.Email;
             }
             else
             {

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using FluentValidation;
 using GetIntoTeachingApi.Attributes;
-using GetIntoTeachingApi.Models.SchoolsExperience;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Microsoft.Xrm.Sdk;
@@ -171,6 +169,8 @@ namespace GetIntoTeachingApi.Models.Crm
         public DateTime? ApplyCreatedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }
+        [EntityField("emailaddress2")]
+        public string SecondaryEmail { get; set; }
         [EntityField("firstname")]
         public string FirstName { get; set; }
         [EntityField("lastname")]

--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -17,6 +17,7 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
             RuleFor(candidate => candidate.FirstName).MaximumLength(256);
             RuleFor(candidate => candidate.LastName).MaximumLength(256);
             RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+            RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
             RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
             RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(25).Matches(@"^[^a-zA-Z]+$");
             RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);

--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Utils
         {
             "password",
             "email",
+            "secondaryEmail",
             "fullName",
             "firstName",
             "lastName",

--- a/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
@@ -88,7 +88,7 @@ namespace GetIntoTeachingApiTests.Jobs
         [Fact]
         public void Run_OnSuccessWithExistingCandidate_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = _candidate.Attributes.Email };
+            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns(match);
 
@@ -128,7 +128,7 @@ namespace GetIntoTeachingApiTests.Jobs
             {
                 Id = match.Id,
                 ApplyId = _candidate.Id,
-                Email = _attributes.Email,
+                Email = match.Email,
                 ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
                 ApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
                 ApplyCreatedAt = _attributes.CreatedAt,

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -83,6 +83,7 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("ApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon" && a.Features.Contains("APPLY_CANDIDATE_API"));
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
+            type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");
             type.GetProperty("FirstName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "firstname");
             type.GetProperty("LastName").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "lastname");
             type.GetProperty("DateOfBirth").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "birthdate");

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -218,30 +218,33 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         public void Validate_EmailAddressInvalid_HasError()
         {
             var invalidEmail = "invalid-email@";
-            var candidate = new Candidate() { Email = invalidEmail };
+            var candidate = new Candidate() { Email = invalidEmail, SecondaryEmail = invalidEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_EmailAddressTooLong_HasError()
         {
             var tooLongEmail = $"{new string('a', 50)}@{new string('a', 50)}.com";
-            var candidate = new Candidate() { Email = tooLongEmail };
+            var candidate = new Candidate() { Email = tooLongEmail, SecondaryEmail = tooLongEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldHaveValidationErrorFor(c => c.Email);
+            result.ShouldHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]
         public void Validate_EmailAddressIsValid_HasNoError()
         {
             var validEmail = "valid@email.com";
-            var candidate = new Candidate() { Email = validEmail };
+            var candidate = new Candidate() { Email = validEmail, SecondaryEmail = validEmail };
             var result = _validator.TestValidate(candidate);
 
             result.ShouldNotHaveValidationErrorFor(c => c.Email);
+            result.ShouldNotHaveValidationErrorFor(c => c.SecondaryEmail);
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-4007](https://trello.com/c/U0JoQPO0/4007-dont-overwrite-contact-email-when-matching-on-apply-id)

When we matchback a candidate from the Apply service we use the Apply ID to ensure we get the correct CRM contact even if the email is different. Currently, we would overwrite the contact email address with the value from the Apply candidate, however going forward we want to give the CRM contact email precedence and retain it.

If the Apply candidate has a different email and there is no `SecondaryEmail` on the candidate we will write the Apply email to the `SecondaryEmail` field.