### PR TITLE
Feature switch matchback on Apply ID

### DIFF
--- a/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/FindApplyCandidateSyncJob.cs
@@ -44,7 +44,16 @@ namespace GetIntoTeachingApi.Jobs
         public void SyncCandidate(Candidate findApplyCandidate)
         {
             var candidate = findApplyCandidate.ToCrmModel();
-            var match = _crm.MatchCandidate(candidate.Email, findApplyCandidate.Id);
+            Models.Crm.Candidate match;
+
+            if (Env.IsFeatureOn("APPLY_ID_MATCHBACK"))
+            {
+                match = _crm.MatchCandidate(candidate.Email, findApplyCandidate.Id);
+            }
+            else
+            {
+                match = _crm.MatchCandidate(candidate.Email);
+            }
 
             _logger.LogInformation("FindApplyCandidateSyncJob - {Status} - {Id}", match == null ? "Miss" : "Hit", findApplyCandidate.Id);
 

--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -37,6 +37,7 @@
         "TOTP_SECRET_KEY": "def456",
         "APPLY_API_FEATURE": "on",
         "APPLY_API_V1_2_FEATURE": "on",
+        "APPLY_ID_MATCHBACK_FEATURE": "on",
         "GET_INTO_TEACHING_EVENTS_FEATURE": "on"
       }
     }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -149,7 +149,7 @@ namespace GetIntoTeachingApi.Services
             return new Candidate(entity, this, _serviceProvider);
         }
 
-        public Candidate MatchCandidate(string email, string findApplyId)
+        public Candidate MatchCandidate(string email, string findApplyId = null)
         {
             var query = MatchBackQuery(email, findApplyId);
             query.TopCount = 1;

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -14,7 +14,7 @@ namespace GetIntoTeachingApi.Services
         IEnumerable<PickListItem> GetPickListItems(string entityName, string attributeName);
         IEnumerable<PrivacyPolicy> GetPrivacyPolicies();
         Candidate MatchCandidate(ExistingCandidateRequest request);
-        Candidate MatchCandidate(string email, string findApplyId);
+        Candidate MatchCandidate(string email, string findApplyId = null);
         IEnumerable<Candidate> MatchCandidates(string magicLinkToken);
         Candidate GetCandidate(Guid id);
         IEnumerable<Candidate> GetCandidates(IEnumerable<Guid> ids);

--- a/GetIntoTeachingApi/env.dev
+++ b/GetIntoTeachingApi/env.dev
@@ -1,4 +1,5 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=true
+APPLY_ID_MATCHBACK_FEATURE=true
 GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/env.prod
+++ b/GetIntoTeachingApi/env.prod
@@ -1,4 +1,5 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
+APPLY_ID_MATCHBACK_FEATURE=false
 GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApi/env.test
+++ b/GetIntoTeachingApi/env.test
@@ -1,4 +1,5 @@
 ﻿APPLY_API_FEATURE=true
 APPLY_API_V1_2_FEATURE=false
+APPLY_ID_MATCHBACK_FEATURE=false
 GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api

--- a/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
@@ -15,6 +15,7 @@ namespace GetIntoTeachingApiTests.Contracts
         {
             Environment.SetEnvironmentVariable($"APPLY_API_FEATURE", "on");
             Environment.SetEnvironmentVariable($"APPLY_API_V1_2_FEATURE", "on");
+            Environment.SetEnvironmentVariable($"APPLY_ID_MATCHBACK_FEATURE", "on");
         }
 
         [Theory]


### PR DESCRIPTION
We don't want to matchback on Apply ID in production yet as there are still some open questions around which email we should take.

Wrap functionality in a feature switch and disable in production.

I noticed we're still using `launchSettings.json` to manage some local environment variables (such as feature switches). I've created a ticket to migrate these into the local dotenv, which is what we should be using going forward.