### PR TITLE
Clean up local environment variables

### DIFF
--- a/GetIntoTeachingApi/Properties/launchSettings.json
+++ b/GetIntoTeachingApi/Properties/launchSettings.json
@@ -23,22 +23,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DATABASE_INSTANCE_NAME": "gis",
-        "HANGFIRE_INSTANCE_NAME": "gis",
-        "VCAP_SERVICES": "{\"postgres\": [{\"instance_name\": \"gis\",\"credentials\": {\"host\": \"localhost\",\"name\": \"gis\",\"username\": \"docker\",\"password\": \"docker\",\"port\": 4432}}],\"redis\": [{\"credentials\": {\"host\": \"0.0.0.0\",\"port\": 5379,\"password\": \"docker\",\"tls_enabled\": false}}]}",
-        "VCAP_APPLICATION": "{\"application_name\": \"app-local\",\"organization_name\": \"org-name\",\"space_name\": \"local\"}",
-        "CF_INSTANCE_INDEX": "0",
-        "FIND_APPLY_API_URL": "https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api",
-        "ADMIN_API_KEY": "secret-admin",
-        "GIT_API_KEY": "secret-git",
-        "TTA_API_KEY": "secret-tta",
-        "SE_API_KEY": "secret-se",
-        "TOTP_SECRET_KEY": "def456",
-        "APPLY_API_FEATURE": "on",
-        "APPLY_API_V1_2_FEATURE": "on",
-        "APPLY_ID_MATCHBACK_FEATURE": "on",
-        "GET_INTO_TEACHING_EVENTS_FEATURE": "on"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -50,8 +50,7 @@ namespace GetIntoTeachingApi.Utils
         {
             get
             {
-                var index = Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
-                var success = int.TryParse(index, out int value);
+                var success = int.TryParse(InstanceIndex, out int value);
 
                 return !success || value == 0;
             }
@@ -70,7 +69,7 @@ namespace GetIntoTeachingApi.Utils
         {
             get
             {
-                return AppServices.ApplicationName.Split("-").Last();
+                return AppServices == null ? "local" : AppServices.ApplicationName.Split("-").Last();
             }
         }
 
@@ -95,8 +94,8 @@ namespace GetIntoTeachingApi.Utils
         {
             get
             {
-                return JsonSerializer.Deserialize<ApplicationServices>(
-                    Environment.GetEnvironmentVariable("VCAP_APPLICATION"));
+                var vcapApplication = Environment.GetEnvironmentVariable("VCAP_APPLICATION");
+                return vcapApplication == null ? null : JsonSerializer.Deserialize<ApplicationServices>(vcapApplication);
             }
         }
 

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -184,14 +184,14 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Theory]
-        [InlineData(null, "")]
-        [InlineData("get-into-teaching-test", "test")]
-        [InlineData("get-into-teaching-dev", "dev")]
-        [InlineData("get-into-teaching-prod", "prod")]
-        public void CloudFoundryEnvironmentName_ReturnsCorrectly(string spaceName, string expected)
+        [InlineData(null, "local")]
+        [InlineData($"{{\"application_name\":\"get-into-teaching-test\"}}", "test")]
+        [InlineData($"{{\"application_name\":\"get-into-teaching-dev\"}}", "dev")]
+        [InlineData($"{{\"application_name\":\"get-into-teaching-prod\"}}", "prod")]
+        public void CloudFoundryEnvironmentName_ReturnsCorrectly(string vcapApplication, string expected)
         {
             var previous = Environment.GetEnvironmentVariable("VCAP_APPLICATION");
-            Environment.SetEnvironmentVariable("VCAP_APPLICATION", $"{{\"application_name\":\"{spaceName}\"}}");
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", vcapApplication);
 
             _env.CloudFoundryEnvironmentName.Should().Be(expected);
 


### PR DESCRIPTION
[Trello-4008](https://trello.com/c/Lq1T6CgW/4008-migrate-local-env-vars-from-launchsettingsjson-to-envlocal)

Historically we used `launchSettings.json` to store non-sensitive, local environment variables. We have since introduced dotenv.net to manage our environment variables in `.env` files.

Migrate all local environment variables into `env.local`. Update the `Env` class to default the `CloudFoundryEnvironmentName` to `local` if the `VCAP_APPLICATION` environment variable is not set (this is a bit of a chicken/egg problem as the environment name is determined by the `VCAP_APPLICATION` environment variable, which isn't available until dotenv loads it).

The `ASPNETCORE_ENVIRONMENT` will remain in `launchSettings.json` as it needs to be set prior to the application booting.