### PR TITLE
Update dotnet-sonarscanner

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -33,7 +33,7 @@ jobs:
           dotnet-version: '7.0'
 
       - name: Install dotnet-sonarscanner
-        run:  dotnet tool install --global dotnet-sonarscanner --version 5.8
+        run:  dotnet tool install --global dotnet-sonarscanner --version 5.9.1
 
       - name: Install dependencies
         run:  dotnet restore
@@ -66,7 +66,7 @@ jobs:
             /d:sonar.verbose=true \
             /d:sonar.log.level="DEBUG"
              dotnet build
-             dotnet test --no-build --logger:trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+             dotnet test --no-build --logger:trx -e:CollectCoverage=true -e:CoverletOutputFormat=opencover
              dotnet sonarscanner end /d:sonar.login="${{ steps.keyvault-yaml-secret.outputs.SONAR-TOKEN }}"
 
       - name: Slack Notification


### PR DESCRIPTION
[Trello-4019](https://trello.com/c/kj85nxV7/4019-fix-sonarqube-not-finding-coverage-on-api-prs)

Update for compatibility with the latest version of .NET Core. There is also a breaking change whereby parameters given to `dotnet test` are no longer being forwarded to MSBuild so we need to pass them as environment variables instead.