### PR TITLE
Queue GSE sign up when CRM is offline

### DIFF
--- a/GetIntoTeachingApi/Database/DbConfiguration.cs
+++ b/GetIntoTeachingApi/Database/DbConfiguration.cs
@@ -56,19 +56,19 @@ namespace GetIntoTeachingApi.Database
             return builder.ConnectionString;
         }
 
-        internal class VcapServices
+        internal sealed class VcapServices
         {
             public IEnumerable<VcapPostgres> Postgres { get; set; }
         }
 
-        internal class VcapPostgres
+        internal sealed class VcapPostgres
         {
             [JsonPropertyName("instance_name")]
             public string InstanceName { get; set; }
             public VcapCredentials Credentials { get; set; }
         }
 
-        internal class VcapCredentials
+        internal sealed class VcapCredentials
         {
             public string Host { get; set; }
             public string Name { get; set; }

--- a/GetIntoTeachingApi/Redis/RedisConfiguration.cs
+++ b/GetIntoTeachingApi/Redis/RedisConfiguration.cs
@@ -25,17 +25,17 @@ namespace GetIntoTeachingApi.Redis
             };
         }
 
-        internal class VcapServices
+        internal sealed class VcapServices
         {
             public IEnumerable<VcapRedis> Redis { get; set; }
         }
 
-        internal class VcapRedis
+        internal sealed class VcapRedis
         {
             public VcapCredentials Credentials { get; set; }
         }
 
-        internal class VcapCredentials
+        internal sealed class VcapCredentials
         {
             public string Host { get; set; }
             public string Password { get; set; }

--- a/GetIntoTeachingApi/Services/HangfirePrometheusExporter.cs
+++ b/GetIntoTeachingApi/Services/HangfirePrometheusExporter.cs
@@ -54,7 +54,7 @@ namespace GetIntoTeachingApi.Services
             };
         }
 
-        internal class HangfireJobStatistics
+        internal sealed class HangfireJobStatistics
         {
             public long Deleted { get; set; }
             public long Enqueued { get; set; }


### PR DESCRIPTION
[Trello-643](https://trello.com/c/jl71Wn2O/643-implement-a-fallback-for-when-the-crm-is-sending-errors-when-gse-tries-to-write-a-record)

By default we create GSE candidates in-band as the service needs the created `contact.id` from the CRM in order to match up the GSE candidate with the CRM contact.

When the CRM integration is paused (this happens for maintenance occasionally) we don't want to prevent GSE sign ups, so we fallback to generating a `contact.id` ahead of persisting it in the CRM and we queue the upsert operation.

We had an incident a number of weeks ago where the CRM was offline unexpectedly for a period of time without being 'paused' (which the CRM team do manually prior to scheduled maintenance). During this time GSE sign ups were failing as the CRM could not be reached. Instead, we want to detect when the CRM is having issues and is _not_ in a paused state so that we can fallback to generating the `contact.id` ahead of time and queueing the upsert operation so that it can run when the CRM recovers.

The reason we don't generate the `contact.id` for all GSE sign up requests is that its better to rely on the auto-generated, sequential UUIDs that the CRM will create by default.