### PR TITLE
Allow zero callback booking quotas to be returned

### DIFF
--- a/GetIntoTeachingApi/Services/CallbackBookingService.cs
+++ b/GetIntoTeachingApi/Services/CallbackBookingService.cs
@@ -25,7 +25,7 @@ namespace GetIntoTeachingApi.Services
 
         public IEnumerable<CallbackBookingQuota> GetCallbackBookingQuotas()
         {
-            IEnumerable<CallbackBookingQuota> quotas = null;
+            IEnumerable<CallbackBookingQuota> quotas;
 
             try
             {
@@ -34,16 +34,12 @@ namespace GetIntoTeachingApi.Services
             catch
             {
                 _logger.LogError("GetCallbackBookingQuotas: failed to reach CRM");
-            }
-
-            if (quotas == null || !quotas.Any())
-            {
                 _logger.LogWarning("GetCallbackBookingQuotas: returning fallback quotas");
 
                 quotas = FallbackBookingQuotas();
             }
 
-            return quotas;
+            return quotas ?? Array.Empty<CallbackBookingQuota>();
         }
 
         private static bool IsWeekend(DateTime date)

--- a/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CallbackBookingServiceTests.cs
@@ -49,27 +49,23 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public void GetCallbackBookingQuotas_WhenCrmReturnsEmpty_ReturnsFallbackQuotas()
+        public void GetCallbackBookingQuotas_WhenCrmReturnsEmpty_ReturnsEmpty()
         {
             _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Returns(new List<CallbackBookingQuota>());
 
             var quotas = _service.GetCallbackBookingQuotas();
 
-            VerifyFallbackQuotas(quotas);
-
-            _mockLogger.VerifyWarningWasCalled("GetCallbackBookingQuotas: returning fallback quotas");
+            quotas.Should().BeEmpty();
         }
 
         [Fact]
-        public void GetCallbackBookingQuotas_WhenCrmReturnsNull_ReturnsFallbackQuotas()
+        public void GetCallbackBookingQuotas_WhenCrmReturnsNull_ReturnsEmpty()
         {
             _mockCrm.Setup(m => m.GetCallbackBookingQuotas()).Returns<IEnumerable<CallbackBookingQuota>>(null);
 
             var quotas = _service.GetCallbackBookingQuotas();
 
-            VerifyFallbackQuotas(quotas);
-
-            _mockLogger.VerifyWarningWasCalled("GetCallbackBookingQuotas: returning fallback quotas");
+            quotas.Should().BeEmpty();
         }
 
         private static IEnumerable<CallbackBookingQuota> MockQuotas()


### PR DESCRIPTION
[Trello-4062](https://trello.com/c/n5iRbaIL/4062-review-callback-quota-fallback-functionality-in-light-of-increased-demand)

Currently we have fallback logic so that if the CRM is offline or 0 callback slots are available we are still going to return a default set of slots that will allow candidates to continue their sign up.

We recently had an unexpected influx of TTA sign ups that were being offered callback booking slots and found we had no way to stem the flow of bookings (if we mark all slots as available the default slots would then be offered). We currently offer 14 days in advance, so the likelihood of all slots being booked are slim, but we want to account for the scenario in case it does happen in the future.

Update the callback service to only return fallback slots when the CRM is offline. If the CRM is indicating there are no available slots we want to surface this on the websites and so we will now return 0 slots available.