### PR TITLE
Make phone call/telephone optional for equivalent degrees

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ ENV ASPNETCORE_URLS=http://+:8080
 COPY *.sln .
 COPY GetIntoTeachingApi/*.csproj ./GetIntoTeachingApi/
 COPY GetIntoTeachingApiTests/*.csproj ./GetIntoTeachingApiTests/
-RUN dotnet restore -r linux-x64
 
 # copy everything else and build app
 COPY GetIntoTeachingApi/. ./GetIntoTeachingApi/
 WORKDIR /source/GetIntoTeachingApi
-RUN dotnet publish -c release -o /app --no-restore
+RUN dotnet publish -c release -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -101,15 +101,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators
                     RuleFor(request => request.UkDegreeGradeId).NotNull()
                         .WithMessage("Must be set when candidate has a degree or is studying for a degree (predicted grade).");
                 });
-
-                When(request => request.DegreeTypeId == (int)CandidateQualification.DegreeType.DegreeEquivalent, () =>
-                {
-                    RuleFor(request => request.AddressTelephone).NotNull()
-                        .WithMessage("Must be set for candidates with an equivalent degree.");
-                    RuleFor(request => request.PhoneCallScheduledAt).NotNull()
-                        .When(request => request.CountryId == LookupItem.UnitedKingdomCountryId)
-                        .WithMessage("Must be set for candidate with UK equivalent degree.");
-                });
             });
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -424,41 +424,13 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
             }
 
             [Fact]
-            public void Validate_WhenTelephoneIsNull_AndDegreeTypeIsDegreeEquivalent_HasError()
-            {
-                _request.AddressTelephone = null;
-                _request.DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent;
-
-                var result = _validator.TestValidate(_request);
-
-                result.ShouldHaveValidationErrorFor(request => request.AddressTelephone)
-                    .WithErrorMessage("Must be set for candidates with an equivalent degree.");
-
-                _request.AddressTelephone = "123456789";
-
-                result = _validator.TestValidate(_request);
-
-                result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
-
-                _request.AddressTelephone = null;
-                _request.DegreeTypeId = (int)CandidateQualification.DegreeType.Degree;
-
-                result = _validator.TestValidate(_request);
-
-                result.ShouldNotHaveValidationErrorFor(request => request.AddressTelephone);
-            }
-
-            [Fact]
-            public void Validate_WhenPhoneCallScheduledAtIsNullOrInPast_AndDegreeTypeIsDegreeEquivalent_AndCountryIdIsUk_HasError()
+            public void Validate_WhenPhoneCallScheduledAtIsInPast_AndDegreeTypeIsDegreeEquivalent_AndCountryIdIsUk_HasError()
             {
                 _request.PhoneCallScheduledAt = null;
                 _request.CountryId = LookupItem.UnitedKingdomCountryId;
                 _request.DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent;
 
                 var result = _validator.TestValidate(_request);
-
-                result.ShouldHaveValidationErrorFor(request => request.PhoneCallScheduledAt)
-                    .WithErrorMessage("Must be set for candidate with UK equivalent degree.");
 
                 _request.PhoneCallScheduledAt = DateTime.UtcNow.AddDays(-1);
 


### PR DESCRIPTION
[Trello-4062](https://trello.com/c/n5iRbaIL/4062-review-callback-quota-fallback-functionality-in-light-of-increased-demand)

Currently, if a candidate has an equivalent degree we require them to schedule a callback with an adviser. Going forward, we are allowing these candidates to sign up without a callback in the event that there are no available callback booking slots available.

Trying to enforce the validation rules for when there are no callback slots available would be error prone, given that the availability dynamically updates. Instead, we are going to relax the validation in the API and ensure its enforced in the client services.