### PR TITLE
Disable Apply API integration

### DIFF
--- a/GetIntoTeachingApi/env.dev
+++ b/GetIntoTeachingApi/env.dev
@@ -1,5 +1,5 @@
-﻿APPLY_API_FEATURE=true
-APPLY_API_V1_2_FEATURE=true
+﻿APPLY_API_FEATURE=false
+APPLY_API_V1_2_FEATURE=false
 APPLY_ID_MATCHBACK_FEATURE=true
 GET_INTO_TEACHING_EVENTS_FEATURE=true
 FIND_APPLY_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api


### PR DESCRIPTION
We are experiencing issues on the dev environment (its overloading the dev Apply candidate API). Disabling until we can fix it.