### PR TITLE
Pin buildx to 0.9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+        with:
+          version: v0.9.1  # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: vars


### PR DESCRIPTION
New buildx generates a new OCI format with support for provenance. It doesn't work with Cloud foundry.