### PR TITLE
Add API client for Apply service

### DIFF
--- a/GetIntoTeachingApi/Fixtures/clients.yml
+++ b/GetIntoTeachingApi/Fixtures/clients.yml
@@ -30,3 +30,8 @@
   description: "A service that allows candidates to book school experience"
   api_key_prefix: SE
   role: SchoolsExperience
+-
+  name: Apply
+  description: "A service that allows candidates to apply for teacher training"
+  api_key_prefix: APPLY
+  role: Apply


### PR DESCRIPTION
The Apply service will be calling out to the API in order to sign up an Apply candidate for an adviser.

Add a client to the API configuration to support the Apply service. The relevant keys have already been added to the Azure keyvault for this client.