### PR TITLE
Updates to support adviser sign up from apply

### DIFF
--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -13,7 +13,7 @@ namespace GetIntoTeachingApi.Controllers
 {
     [Route("api/candidates")]
     [ApiController]
-    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience")]
+    [Authorize(Roles = "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience,Apply")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _accessTokenService;

--- a/GetIntoTeachingApi/Controllers/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/CandidatesController.cs
@@ -92,5 +92,50 @@ namespace GetIntoTeachingApi.Controllers
 
             return NoContent();
         }
+
+        [HttpPost]
+        [Route("matchback")]
+        [SwaggerOperation(
+            Summary = "Perform a matchback operation, returning the match candidate id.",
+            Description = @"Attempts to matchback against a known candidate and returns the candidate id.",
+            OperationId = "MatchbackCandidate",
+            Tags = new[] { "Candidates" })]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), StatusCodes.Status400BadRequest)]
+        public IActionResult Matchback([FromBody, SwaggerRequestBody("Candidate details to matchback.", Required = true)] ExistingCandidateRequest request)
+        {
+            request.Reference ??= User.Identity.Name;
+
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (_appSettings.IsCrmIntegrationPaused)
+            {
+                _logger.LogInformation("CandidatesController - potential duplicate (CRM integration paused)");
+                return NotFound();
+            }
+
+            Candidate candidate;
+
+            try
+            {
+                candidate = _crm.MatchCandidate(request);
+            }
+            catch (Exception e)
+            {
+                _logger.LogInformation("CandidatesController - potential duplicate (CRM exception) - {Message}", e.Message);
+                throw;
+            }
+
+            if (candidate == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new CandidateMatchbackResponse(candidate));
+        }
     }
 }

--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
 {
     [Route("api/teacher_training_adviser/candidates")]
     [ApiController]
-    [Authorize(Roles = "Admin,GetAnAdviser")]
+    [Authorize(Roles = "Admin,GetAnAdviser,Apply")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/Models/CandidateMatchbackResponse.cs
+++ b/GetIntoTeachingApi/Models/CandidateMatchbackResponse.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using GetIntoTeachingApi.Models.Crm;
+
+namespace GetIntoTeachingApi.Models
+{
+	public class CandidateMatchbackResponse
+	{
+		public Guid CandidateId { get; set; }
+
+		public CandidateMatchbackResponse(Candidate candidate)
+		{
+            CandidateId = (Guid) candidate.Id;
+		}
+	}
+}
+

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -56,6 +56,11 @@
         "Endpoint": "POST:/api/teaching_events",
         "Period": "1d",
         "Limit": 60
+      },
+      {
+        "Endpoint": "POST:/api/candidates/matchback",
+        "Period": "1m",
+        "Limit": 60
       }
     ]
   },
@@ -96,6 +101,21 @@
         "Rules": [
           {
             "Endpoint": "POST:/api/candidates/access_tokens",
+            "Period": "1m",
+            "Limit": 500
+          },
+          {
+            "Endpoint": "POST:/api/teacher_training_adviser/candidates",
+            "Period": "1m",
+            "Limit": 250
+          }
+        ]
+      },
+      {
+        "ClientId": "APPLY",
+        "Rules": [
+          {
+            "Endpoint": "POST:/api/candidates/matchback",
             "Period": "1m",
             "Limit": 500
           },

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -42,7 +42,7 @@ namespace GetIntoTeachingApiTests.Controllers
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience");
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetIntoTeaching,GetAnAdviser,SchoolsExperience,Apply");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/CandidatesControllerTests.cs
@@ -134,5 +134,74 @@ namespace GetIntoTeachingApiTests.Controllers
             );
             _mockLogger.VerifyInformationWasCalled("CandidatesController - potential duplicate (CRM integration paused)");
         }
+
+        [Fact]
+        public void Matchback_InvalidRequest_RespondsWithValidationErrors()
+        {
+            var request = new ExistingCandidateRequest { Email = "invalid-email@", Reference = "Ref" };
+            _controller.ModelState.AddModelError("Email", "Email is invalid.");
+
+            var response = _controller.Matchback(request);
+
+            request.Reference.Should().Be("Ref");
+            var badRequest = response.Should().BeOfType<BadRequestObjectResult>().Subject;
+            var errors = badRequest.Value.Should().BeOfType<SerializableError>().Subject;
+            errors.Should().ContainKey("Email").WhoseValue.Should().BeOfType<string[]>().Which.Should().Contain("Email is invalid.");
+        }
+
+        [Fact]
+        public void Matchback_ValidRequest_ReturnsCandidateMatchbackResponse()
+        {
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            var candidate = new Candidate { Id = Guid.NewGuid(), Email = request.Email, FirstName = request.FirstName, LastName = request.LastName };
+            _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns(candidate);
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+
+            var response = _controller.Matchback(request);
+
+            request.Reference.Should().Be("Client");
+            var ok = response.Should().BeOfType<OkObjectResult>().Subject;
+            var matchbackResponse = (CandidateMatchbackResponse) ok.Value;
+            matchbackResponse.CandidateId.Should().Be((Guid)candidate.Id);
+        }
+
+        [Fact]
+        public void Matchback_MismatchedCandidate_ReturnsNotFound()
+        {
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockCrm.Setup(mock => mock.MatchCandidate(request)).Returns<Candidate>(null);
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+
+            var response = _controller.Matchback(request);
+
+            response.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public void Matchback_CrmThrowsException_LogsAndReRaises()
+        {
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockCrm.Setup(m => m.MatchCandidate(request)).Throws(new Exception("Error"));
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+
+            _controller.Invoking(c => c.Matchback(request))
+                .Should().Throw<Exception>()
+                .WithMessage("Error");
+
+            _mockLogger.VerifyInformationWasCalled("CandidatesController - potential duplicate (CRM exception) - Error");
+        }
+
+        [Fact]
+        public void Matchback_CrmIntegrationIsPaused_ReturnsNotFound()
+        {
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
+            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+
+            var response = _controller.Matchback(request);
+
+            response.Should().BeOfType<NotFoundResult>();
+
+            _mockLogger.VerifyInformationWasCalled("CandidatesController - potential duplicate (CRM integration paused)");
+        }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -44,7 +44,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser");
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser,Apply");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -23,6 +23,7 @@ namespace GetIntoTeachingApiTests.Integration
             Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
             Environment.SetEnvironmentVariable($"TTA_API_KEY", "tta-secret");
             Environment.SetEnvironmentVariable($"SE_API_KEY", "se-secret");
+            Environment.SetEnvironmentVariable($"APPLY_API_KEY", "apply-secret");
             Environment.SetEnvironmentVariable($"ADMIN_API_KEY", "admin-secret");
 
             var factory = new GitWebApplicationFactory<Startup>();
@@ -38,6 +39,8 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/get_into_teaching/callbacks", "GIT", 250)]
         [InlineData("/api/candidates/access_tokens", "TTA", 500)]
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
+        [InlineData("/api/candidates/matchback", "APPLY", 500)]
+        [InlineData("/api/teacher_training_adviser/candidates", "APPLY", 250)]
         [InlineData("/api/candidates/access_tokens", "SE", 500)]
         [InlineData("/api/schools_experience/candidates", "SE", 250)]
         [InlineData("/api/candidates/access_tokens", "ADMIN", 60)]

--- a/GetIntoTeachingApiTests/Models/CandidateMatchbackResponseTests.cs
+++ b/GetIntoTeachingApiTests/Models/CandidateMatchbackResponseTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using GetIntoTeachingApi.Models;
+using System;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+using GetIntoTeachingApi.Models.Crm;
+
+namespace GetIntoTeachingApiTests.Models
+{
+    public class CandidateMatchbackResponseTests
+    {
+        private readonly CandidateMatchbackResponse _response;
+        private readonly Candidate _candidate;
+
+        public CandidateMatchbackResponseTests()
+        {
+            _candidate = new Candidate() { Id = Guid.NewGuid() };
+            _response = new CandidateMatchbackResponse(_candidate);
+        }
+
+        [Fact]
+        public void CandidateId_ReturnsCandidateId()
+        {
+            _response.CandidateId.Should().Be((Guid)_candidate.Id);
+        }
+    }
+}


### PR DESCRIPTION
[Trello-gOZOyWn1/4041](https://trello.com/c/gOZOyWn1/4041-spike-submitting-tta-applications-from-the-apply-service?filter=member:rossoliver15)

- Grant Apply access to adviser sign up

We are going to be accepting TTA sign ups from the Apply service going forward.

Grant access to the Apply service for TTA sign ups and candidate information.

- Add endpoint to retrieve existing candidate id

When a candidate signs up for a TTA via the Apply service they will already be 'authenticated' against the candidate email so we will not need to issue them a TOTP. Instead, we want to obtain a candidate id by providing matchback information.

- Setup rate limits for Apply service

Add rate limits for the adviser sign up from Apply service and also the new matchback endpoint as we're hitting the CRM.