### PR TITLE
Increase memory capacity for monitoring

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -59,10 +59,6 @@
 		<PackageReference Include="Castle.Core" Version="5.1.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-		</PackageReference>
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.26" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />

--- a/terraform/paas/monitoring.tf
+++ b/terraform/paas/monitoring.tf
@@ -43,7 +43,7 @@ module "prometheus" {
   grafana_google_jwt                = lookup(local.monitoring_secrets, "GOOGLE_JWT", "")
   grafana_runtime_version           = "8.3.2"
   grafana_anonymous_auth            = true
-  prometheus_memory                 = 5120
+  prometheus_memory                 = 6144
   prometheus_disk_quota             = 5120
   internal_apps                     = var.monitor_scrape_applications
   influxdb_service_plan             = var.influxdb_1_plan


### PR DESCRIPTION
We are getting high memory warnings on the monitoring instance; increasing the available memory to give it some headroom.