### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -13,41 +13,41 @@
 		<PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
 		<PackageReference Include="CsvHelper" Version="30.0.1" />
 		<PackageReference Include="GeocodeSharp" Version="2.0.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.32" />
-		<PackageReference Include="Hangfire.Core" Version="1.7.32" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.33" />
+		<PackageReference Include="Hangfire.Core" Version="1.7.33" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.1">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.3">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.4" />
 		<PackageReference Include="morelinq" Version="3.3.2" />
-		<PackageReference Include="Npgsql" Version="7.0.1" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="7.0.1" />
+		<PackageReference Include="Npgsql" Version="7.0.2" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="7.0.3" />
 		<PackageReference Include="Otp.NET" Version="1.3.0" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
-		<PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.25.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.28.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
 		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="dotenv.net" Version="3.1.2" />
-		<PackageReference Include="YamlDotNet" Version="12.3.1" />
+		<PackageReference Include="YamlDotNet" Version="13.0.1" />
 		<PackageReference Include="Fody" Version="6.6.4">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
 		<PackageReference Include="GovukNotify" Version="6.1.0" />
 		<PackageReference Include="Flurl.Http" Version="3.2.4" />
 		<PackageReference Include="AspNetCoreRateLimit.Redis" Version="2.0.0" />
@@ -58,12 +58,12 @@
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Castle.Core" Version="5.1.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3" />
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.26" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -26,11 +26,11 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="FluentAssertions" Version="6.8.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+	<PackageReference Include="FluentAssertions" Version="6.10.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 	<PackageReference Include="Moq" Version="4.18.4" />
-	<PackageReference Include="WireMock.Net" Version="1.5.13" />
+	<PackageReference Include="WireMock.Net" Version="1.5.16" />
 	<PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This is re-rolling out the following updates, sans `Hangfire.Postgres` which has an issue in the latest release - its addressed in the next version but that hasn't made it to Nuget yet.

- Hangfire.AspNetCore 1.7.32 -> 1.7.33
- Hangfire.Core 1.7.32 -> 1.7.33
- Microsoft.EntityFrameworkCore 7.0.2 -> 7.0.3
- Microsoft.EntityFrameworkCore.Design 7.0.1 -> 7.0.3
- Microsoft.EntityFrameworkCore.Tools 7.0.1 -> 7.0.3
- Microsoft.VisualStudio.Web.CodeGeneration.Design 7.0.1 -> 7.0.4
- Npgsql 7.0.1 -> 7.0.3
- Npgsql.EntityFrameworkCore.PostgreSQL 7.0.1 -> 7.0.3
- Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite 7.0.1 -> 7.0.3
- Sentry.AspNetCore 3.25.0 -> 3.28.1
- YamlDotNet 12.3.1 -> 13.0.1
- Microsoft.IO.RecyclableMemoryStream 2.2.1 -> 2.3.1
- Microsoft.EntityFrameworkCore.Relational 7.0.1 -> 7.0.3
- Microsoft.Extensions.Caching.StackExchangeRedis 7.0.2 -> 7.0.3
- Microsoft.AspNetCore.DataProtection.StackExchangeRedis 7.0.1 -> 7.0.3
- FluentAssertions 6.8.0 -> 6.10.0
- Microsoft.AspNetCore.Mvc.Testing 7.0.2 -> 7.0.3
- Microsoft.NET.Test.Sdk 17.4.1 -> 17.5.0
- WireMock.Net 1.5.13 -> 1.5.16
