### PR TITLE
Address code climate warnings

### DIFF
--- a/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/SchoolsExperience/CandidatesController.cs
@@ -26,22 +26,19 @@ namespace GetIntoTeachingApi.Controllers.SchoolsExperience
         private readonly ICandidateUpserter _upserter;
         private readonly IBackgroundJobClient _jobClient;
         private readonly IDateTimeProvider _dateTime;
-        private readonly IEnv _env;
 
         public CandidatesController(
             ICandidateAccessTokenService tokenService,
             ICrmService crm,
             ICandidateUpserter upserter,
             IBackgroundJobClient jobClient,
-            IDateTimeProvider dateTime,
-            IEnv env)
+            IDateTimeProvider dateTime)
         {
             _crm = crm;
             _upserter = upserter;
             _tokenService = tokenService;
             _jobClient = jobClient;
             _dateTime = dateTime;
-            _env = env;
         }
 
         [HttpPost]

--- a/GetIntoTeachingApi/Program.cs
+++ b/GetIntoTeachingApi/Program.cs
@@ -5,8 +5,6 @@ using GetIntoTeachingApi.Database;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using Serilog.Events;
-using Serilog.Formatting.Compact;
 
 namespace GetIntoTeachingApi
 {
@@ -14,6 +12,9 @@ namespace GetIntoTeachingApi
     {
         public static async Task Main(string[] args)
         {
+            // Set global Regex timeout.
+            AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromMilliseconds(500));
+
             GetIntoTeachingDbContext.ConfigureNpgsql();
 
             var webHost = CreateHostBuilder(args).Build();

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -61,12 +61,12 @@ namespace GetIntoTeachingApi.Services
 
         public IEnumerable<Country> GetCountries()
         {
-            return _service.CreateQuery("dfe_country", Context()).ToList().Select((entity) => new Country(entity));
+            return _service.CreateQuery("dfe_country", Context()).AsEnumerable().Select((entity) => new Country(entity));
         }
 
         public IEnumerable<TeachingSubject> GetTeachingSubjects()
         {
-            return _service.CreateQuery("dfe_teachingsubjectlist", Context()).ToList().Select((entity) => new TeachingSubject(entity));
+            return _service.CreateQuery("dfe_teachingsubjectlist", Context()).AsEnumerable().Select((entity) => new TeachingSubject(entity));
         }
 
         public IEnumerable<PickListItem> GetPickListItems(string entityName, string attributeName)
@@ -82,7 +82,7 @@ namespace GetIntoTeachingApi.Services
                                    entity.GetAttributeValue<DateTime>("dfe_starttime") < _dateTime.UtcNow.AddDays(MaximumCallbackBookingQuotaDaysInAdvance))
                 .OrderBy((entity) => entity.GetAttributeValue<DateTime>("dfe_starttime"))
                 .Select((entity) => new CallbackBookingQuota(entity, this, _serviceProvider))
-                .ToList()
+                .AsEnumerable()
                 .Where((quota) => quota.IsAvailable); // Doing this in the Dynamics query throws an exception, though I'm not sure why.
         }
 

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -34,7 +34,7 @@ namespace GetIntoTeachingApi.Utils
         {
             get
             {
-                var url = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL"); ;
+                var url = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL");
 
                 if (IsFeatureOn("APPLY_CANDIDATE_API_V1_2"))
                 {

--- a/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/SchoolsExperience/CandidatesControllerTests.cs
@@ -27,7 +27,6 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
         private readonly Mock<IBackgroundJobClient> _mockJobClient;
         private readonly Mock<ICandidateUpserter> _mockUpserter;
         private readonly Mock<IDateTimeProvider> _mockDateTime;
-        private readonly Mock<IEnv> _mockEnv;
         private readonly CandidatesController _controller;
         private readonly ExistingCandidateRequest _request;
 
@@ -38,7 +37,6 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
             _mockJobClient = new Mock<IBackgroundJobClient>();
             _mockUpserter = new Mock<ICandidateUpserter>();
             _mockDateTime = new Mock<IDateTimeProvider>();
-            _mockEnv = new Mock<IEnv>();
             _request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "John", LastName = "Doe" };
 
             _controller = new CandidatesController(
@@ -46,8 +44,7 @@ namespace GetIntoTeachingApiTests.Controllers.SchoolsExperience
                 _mockCrm.Object,
                 _mockUpserter.Object,
                 _mockJobClient.Object,
-                _mockDateTime.Object,
-                _mockEnv.Object);
+                _mockDateTime.Object);
             _controller.MockUser("SE");
         }
 


### PR DESCRIPTION
- Set global Regex timeout to 500ms to prevent potential DoS attack
- Swap `ToList` for `AsEnumerable`
- Remove redundant code