### PR TITLE
Remove redundant array

### DIFF
--- a/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
+++ b/GetIntoTeachingApi/Jobs/ClaimCallbackBookingSlotJob.cs
@@ -63,7 +63,7 @@ namespace GetIntoTeachingApi.Jobs
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"ClaimCallbackBookingSlotJob" }).Observe(duration);
+            _metrics.HangfireJobQueueDuration.WithLabels("ClaimCallbackBookingSlotJob").Observe(duration);
         }
     }
 }

--- a/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/LocationSyncJob.cs
@@ -131,7 +131,7 @@ namespace GetIntoTeachingApi.Jobs
                 return;
             }
 
-            var parameters = batch.SelectMany((location, index) => DbParameters(location, index));
+            var parameters = batch.SelectMany(DbParameters);
             var values = string.Join(", ", batch.Select((_, index) => $"(@postcode{index}, @coordinate{index}, @source{index})"));
 
             await _dbContext.Database.ExecuteSqlRawAsync(

--- a/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
@@ -63,7 +63,7 @@ namespace GetIntoTeachingApi.Jobs
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"UpsertApplicationFormJob" }).Observe(duration);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Observe(duration);
         }
 
         private void SaveApplicationForm(ApplicationForm form)

--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -75,7 +75,7 @@ namespace GetIntoTeachingApi.Jobs
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Observe(duration);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertCandidateJob").Observe(duration);
         }
 
         private static string Signature(Candidate candidate)

--- a/GetIntoTeachingApi/Jobs/UpsertModelWithCandidateIdJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertModelWithCandidateIdJob.cs
@@ -78,7 +78,7 @@ namespace GetIntoTeachingApi.Jobs
             }
 
             var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { $"UpsertModelJob<{typeName}>" }).Observe(duration);
+            _metrics.HangfireJobQueueDuration.WithLabels($"UpsertModelJob<{typeName}>").Observe(duration);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ClaimCallbackBookingSlotJobTests.cs
@@ -35,7 +35,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _mockCrm.Object,
                 _metrics, _mockLogger.Object, _mockAppSettings.Object);
 
-            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "ClaimCallbackBookingSlotJob" });
+            _metrics.HangfireJobQueueDuration.RemoveLabelled("ClaimCallbackBookingSlotJob");
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
 
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
@@ -57,7 +57,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger.VerifyInformationWasCalled("ClaimCallbackBookingSlotJob - Started (1/24)");
             _mockLogger.VerifyInformationWasCalled($"ClaimCallbackBookingSlotJob - Payload {_scheduledAt}");
             _mockLogger.VerifyInformationWasCalled($"ClaimCallbackBookingSlotJob - Succeeded - {_scheduledAt}");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "ClaimCallbackBookingSlotJob" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("ClaimCallbackBookingSlotJob").Count.Should().Be(1);
         }
 
 

--- a/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
@@ -38,7 +38,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _metrics, _mockCrm.Object,
                 _mockLogger.Object, _mockAppSettings.Object);
 
-            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertApplicationFormJob" });
+            _metrics.HangfireJobQueueDuration.RemoveLabelled("UpsertApplicationFormJob");
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
 
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
@@ -93,7 +93,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (1/24)");
             _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Payload {Redactor.RedactJson(json)}");
             _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Succeeded - {_form.Id}");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertApplicationFormJob" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace GetIntoTeachingApiTests.Jobs
 
             _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Deleted");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertApplicationFormJob" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertCandidateJobTests.cs
@@ -46,7 +46,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _job = new UpsertCandidateJob(new Env(), mockRedis.Object, _mockUpserter.Object, _mockNotifyService.Object,
                 _mockContext.Object, _metrics, _mockLogger.Object, _mockAppSettings.Object);
 
-            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertCandidateJob" });
+            _metrics.HangfireJobQueueDuration.RemoveLabelled("UpsertCandidateJob");
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
 
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
@@ -66,7 +66,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (1/24)");
             _mockLogger.VerifyInformationWasCalled($"UpsertCandidateJob - Payload {Redactor.RedactJson(json)}");
             _mockLogger.VerifyInformationWasCalled($"UpsertCandidateJob - Succeeded - {_candidate.Id}");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertCandidateJob").Count.Should().Be(1);
             _mockDatabase.Verify(m => m.StringSet(key, true, TimeSpan.FromSeconds(5), false, When.Always, CommandFlags.None));
         }
 
@@ -82,7 +82,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 NotifyService.CandidateRegistrationFailedEmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("UpsertCandidateJob - Deleted");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertCandidateJob" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertCandidateJob").Count.Should().Be(1);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Jobs/UpsertModelWithCandidateIdJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertModelWithCandidateIdJobTests.cs
@@ -38,7 +38,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _mockCrm.Object,
                 _metrics, _mockLogger.Object, _mockAppSettings.Object, _mockNotifyService.Object);
 
-            _metrics.HangfireJobQueueDuration.RemoveLabelled(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" });
+            _metrics.HangfireJobQueueDuration.RemoveLabelled("UpsertModelJob<CandidatePrivacyPolicy>");
             _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
 
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
@@ -56,7 +56,7 @@ namespace GetIntoTeachingApiTests.Jobs
             _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Started (1/24)");
             _mockLogger.VerifyInformationWasCalled($"UpsertModelJob<CandidatePrivacyPolicy> - Payload {Redactor.RedactJson(json)}");
             _mockLogger.VerifyInformationWasCalled($"UpsertModelJob<CandidatePrivacyPolicy> - Succeeded - {_policy.Id}");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertModelJob<CandidatePrivacyPolicy>").Count.Should().Be(1);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace GetIntoTeachingApiTests.Jobs
                 NotifyService.SignUpPartiallyFailedTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
             _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Started (24/24)");
             _mockLogger.VerifyInformationWasCalled("UpsertModelJob<CandidatePrivacyPolicy> - Deleted");
-            _metrics.HangfireJobQueueDuration.WithLabels(new[] { "UpsertModelJob<CandidatePrivacyPolicy>" }).Count.Should().Be(1);
+            _metrics.HangfireJobQueueDuration.WithLabels("UpsertModelJob<CandidatePrivacyPolicy>").Count.Should().Be(1);
         }
 
         [Fact]


### PR DESCRIPTION
Flagged by CodeClimate; the array here is redundant and we can just pass the labels directly.