### PR TITLE
Remove unused address fields from adviser sign up

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -74,9 +74,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public string DegreeSubject { get; set; }
         public string AddressTelephone { get; set; }
 
-        public string AddressLine1 { get; set; }
-        public string AddressLine2 { get; set; }
-        public string AddressCity { get; set; }
         public string AddressPostcode { get; set; }
         [SwaggerSchema(WriteOnly = true)]
         public DateTime? PhoneCallScheduledAt { get; set; }
@@ -157,9 +154,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             DateOfBirth = candidate.DateOfBirth;
             TeacherId = candidate.TeacherId;
             AddressTelephone = candidate.AddressTelephone.StripExitCode();
-            AddressLine1 = candidate.AddressLine1;
-            AddressLine2 = candidate.AddressLine2;
-            AddressCity = candidate.AddressCity;
             AddressPostcode = candidate.AddressPostcode;
             TypeId = candidate.TypeId;
             AdviserStatusId = candidate.AdviserStatusId;
@@ -197,9 +191,6 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
                 FirstName = FirstName,
                 LastName = LastName,
                 DateOfBirth = DateOfBirth,
-                AddressLine1 = AddressLine1,
-                AddressLine2 = AddressLine2,
-                AddressCity = AddressCity,
                 AddressPostcode = AddressPostcode.AsFormattedPostcode(),
                 AddressTelephone = AddressTelephone.AsFormattedTelephone(IsOverseas),
                 TeacherId = TeacherId,

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_primary_has_retaking_gcses_overseas.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_primary_has_retaking_gcses_overseas.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": "Edinburgh"
-      },
-      {
-        "Key": "address1_line1",
-        "Value": "5 Main Street"
-      },
-      {
-        "Key": "address1_line2",
-        "Value": "Dalkeith"
-      },
-      {
         "Key": "address1_postalcode",
         "Value": "TE7 5TR"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_secondary_has_gcses_is_in_uk.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_secondary_has_gcses_is_in_uk.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_primary_has_gcses_in_the_uk_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_primary_has_gcses_in_the_uk_and_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": "Edinburgh"
-      },
-      {
-        "Key": "address1_line1",
-        "Value": "5 Main Street"
-      },
-      {
-        "Key": "address1_line2",
-        "Value": "Dalkeith"
-      },
-      {
         "Key": "address1_postalcode",
         "Value": "TE7 5TR"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_secodary_retaking_gcses_overseas_and_no_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_secodary_retaking_gcses_overseas_and_no_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_returning_no_teacher_reference_number_overseas_and_no_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_returning_no_teacher_reference_number_overseas_and_no_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_returning_teacher_reference_number_in_the_uk_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_returning_teacher_reference_number_in_the_uk_and_telephone.json
@@ -4,18 +4,6 @@
     "Id": "00000000-0000-0000-0000-000000000000",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": "Edinburgh"
-      },
-      {
-        "Key": "address1_line1",
-        "Value": "5 Main Street"
-      },
-      {
-        "Key": "address1_line2",
-        "Value": "Dalkeith"
-      },
-      {
         "Key": "address1_postalcode",
         "Value": "TE7 5TR"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_returning_existing_data_change_address.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_returning_existing_data_change_address.json
@@ -4,18 +4,6 @@
     "Id": "271aa675-e6bf-41c5-ad5f-4e1e8de5d7ad",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": "Edinburgh"
-      },
-      {
-        "Key": "address1_line1",
-        "Value": "5 Main Street"
-      },
-      {
-        "Key": "address1_line2",
-        "Value": "Dalkeith"
-      },
-      {
         "Key": "address1_postalcode",
         "Value": "TE7 5TR"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_when_in_a_closed_state_not_returning_existing_data_change_country.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_when_in_a_closed_state_not_returning_existing_data_change_country.json
@@ -4,18 +4,6 @@
     "Id": "371aa675-e6bf-41c5-ad5f-4e1e8de5d7ad",
     "Attributes": [
       {
-        "Key": "address1_city",
-        "Value": null
-      },
-      {
-        "Key": "address1_line1",
-        "Value": null
-      },
-      {
-        "Key": "address1_line2",
-        "Value": null
-      },
-      {
         "Key": "address1_postalcode",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -66,9 +66,6 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 DateOfBirth = DateTime.UtcNow,
                 AddressTelephone = "001234567",
                 TeacherId = "abc123",
-                AddressLine1 = "Address 1",
-                AddressLine2 = "Address 2",
-                AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
                 Qualifications = qualifications,
                 PastTeachingPositions = pastTeachingPositions,
@@ -93,9 +90,6 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.LastName.Should().Be(candidate.LastName);
             response.TeacherId.Should().Be(candidate.TeacherId);
             response.AddressTelephone.Should().Be(candidate.AddressTelephone[2..]);
-            response.AddressLine1.Should().Be(candidate.AddressLine1);
-            response.AddressLine2.Should().Be(candidate.AddressLine2);
-            response.AddressCity.Should().Be(candidate.AddressCity);
             response.AddressPostcode.Should().Be(candidate.AddressPostcode);
 
             response.QualificationId.Should().Be(latestQualification.Id);
@@ -140,9 +134,6 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 AddressTelephone = "1234567",
                 TeacherId = "abc123",
                 DegreeSubject = "Maths",
-                AddressLine1 = "Address 1",
-                AddressLine2 = "Address 2",
-                AddressCity = "City",
                 AddressPostcode = "KY11 9YU",
                 PhoneCallScheduledAt = DateTime.UtcNow,
             };
@@ -172,9 +163,6 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.AddressTelephone.Should().Be("00" + request.AddressTelephone);
             candidate.TeacherId.Should().Be(request.TeacherId);
-            candidate.AddressLine1.Should().Be(request.AddressLine1);
-            candidate.AddressLine2.Should().Be(request.AddressLine2);
-            candidate.AddressCity.Should().Be(request.AddressCity);
             candidate.AddressPostcode.Should().Be(request.AddressPostcode);
             candidate.ChannelId.Should().BeNull();
             candidate.EligibilityRulesPassed.Should().Be("true");


### PR DESCRIPTION
[Trello-4151](https://trello.com/c/cYOL1Few/4151-clean-up-adviser-funnel-address-postcode-fields)

We no longer ask for the address line 1/2 and city as part of the adviser sign up; these fields can be removed.