### PR TITLE
Fix error on email query from Dynamics

### DIFF
--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -364,7 +364,8 @@ namespace GetIntoTeachingApi.Services
 
         private QueryExpression MatchBackQuery(string email, string applyId = null)
         {
-            var emails = EmailReconciler.EquivalentEmails(email);
+            // The ToList() is important or Dynamics throws an error.
+            var emails = EmailReconciler.EquivalentEmails(email).ToList();
             var query = new QueryExpression("contact");
             query.ColumnSet.AddColumns(BaseModel.EntityFieldAttributeNames(typeof(Candidate)));
 

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -168,9 +168,9 @@ namespace GetIntoTeachingApiTests.Services
                 c.Operator == ConditionOperator.Equal && (int)c.Values[0] == (int)Candidate.Status.Active);
 
             var hasEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress1" &&
-                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values[0] as IEnumerable<string>, emails));
+                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values, emails));
             var hasSecondaryEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress2" &&
-                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values[0] as IEnumerable<string>, emails));
+                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values, emails));
 
             var hasApplyCondition = applyId == null ||
                     orConditions.Any(c => c.AttributeName == "dfe_applyid" && c.Operator == ConditionOperator.Equal && c.Values[0].ToString() == applyId);
@@ -199,9 +199,9 @@ namespace GetIntoTeachingApiTests.Services
                 c.Operator == ConditionOperator.Equal && (int)c.Values[0] == (int)Candidate.Status.Active);
 
             var hasEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress1" &&
-                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values[0] as IEnumerable<string>, emails));
+                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values, emails));
             var hasSecondaryEmailAddressCondition = orConditions.Any(c => c.AttributeName == "emailaddress2" &&
-                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values[0] as IEnumerable<string>, emails));
+                c.Operator == ConditionOperator.In && Enumerable.SequenceEqual(c.Values, emails));
 
             var hasDuplicateScoreOrder = orders.Any(o => o.AttributeName == "dfe_duplicatescorecalculated" && o.OrderType == OrderType.Descending);
             var hasModifiedOnOrder = orders.Any(o => o.AttributeName == "modifiedon" && o.OrderType == OrderType.Descending);


### PR DESCRIPTION
I'm not sure why but Dynamics doesn't like `IEnumerable` to be used as a condition value even though the method accepts it; it appears to need a concrete type so we call `ToList()` to avoid it throwing an error.