### PR TITLE
Clean up BaseModel hooks

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/Crm/BaseModel.cs
@@ -81,11 +81,6 @@ namespace GetIntoTeachingApi.Models.Crm
 
         public virtual Entity ToEntity(ICrmService crm, OrganizationServiceContext context)
         {
-            if (!ShouldMap(crm))
-            {
-                return null;
-            }
-
             var entity = MappableEntity(LogicalName(GetType()), crm, context);
             MapFieldAttributesToEntity(entity);
             FinaliseEntity(entity, crm, context);
@@ -111,12 +106,6 @@ namespace GetIntoTeachingApi.Models.Crm
 
             Id = Guid.NewGuid();
             HasUpfrontId = true;
-        }
-
-        protected virtual bool ShouldMap(ICrmService crm)
-        {
-            // Hook.
-            return true;
         }
 
         protected virtual void FinaliseEntity(Entity source, ICrmService crm, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Models/Crm/BaseModel.cs
+++ b/GetIntoTeachingApi/Models/Crm/BaseModel.cs
@@ -113,12 +113,6 @@ namespace GetIntoTeachingApi.Models.Crm
             HasUpfrontId = true;
         }
 
-        protected virtual bool ShouldMapRelationship(string propertyName, dynamic value, ICrmService crm)
-        {
-            // Hook.
-            return true;
-        }
-
         protected virtual bool ShouldMap(ICrmService crm)
         {
             // Hook.

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -351,19 +351,5 @@ namespace GetIntoTeachingApi.Models.Crm
 
             return base.ShouldMap(crm);
         }
-
-        protected override bool ShouldMapRelationship(string propertyName, dynamic value, ICrmService crm)
-        {
-            if (value == null)
-            {
-                return false;
-            }
-
-            return propertyName switch
-            {
-                "PrivacyPolicy" when Id != null => crm.CandidateYetToAcceptPrivacyPolicy((Guid)Id, value.AcceptedPolicyId),
-                _ => true,
-            };
-        }
     }
 }

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -335,21 +335,5 @@ namespace GetIntoTeachingApi.Models.Crm
 
         public bool MagicLinkTokenExpired() => MagicLinkTokenExpiresAt == null || MagicLinkTokenExpiresAt < DateTime.UtcNow;
         public bool MagicLinkTokenAlreadyExchanged() => MagicLinkTokenStatusId == (int)MagicLinkTokenStatus.Exchanged;
-
-        protected override bool ShouldMap(ICrmService crm)
-        {
-            IsNewRegistrant = Id == null;
-
-            var changingEventSubscriptionType = !IsNewRegistrant && EventsSubscriptionTypeId != null;
-
-            if (changingEventSubscriptionType && crm.CandidateAlreadyHasLocalEventSubscriptionType((Guid)Id))
-            {
-                // Never down-grade to a 'single event' subscription type from
-                // a 'local event' subscription type.
-                EventsSubscriptionTypeId = (int)SubscriptionType.LocalEvent;
-            }
-
-            return base.ShouldMap(crm);
-        }
     }
 }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEventRegistration.cs
@@ -37,17 +37,5 @@ namespace GetIntoTeachingApi.Models.Crm
             : base(entity, crm, serviceProvider)
         {
         }
-
-        protected override bool ShouldMap(ICrmService crm)
-        {
-            var alreadyRegistered = !crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
-
-            if (alreadyRegistered)
-            {
-                return false;
-            }
-
-            return base.ShouldMap(crm);
-        }
     }
 }

--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -4,6 +4,7 @@ using GetIntoTeachingApi.Jobs;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using YamlDotNet.Core.Tokens;
 
 namespace GetIntoTeachingApi.Services
 {
@@ -201,6 +202,12 @@ namespace GetIntoTeachingApi.Services
         private void SavePrivacyPolicy(CandidatePrivacyPolicy privacyPolicy, Candidate candidate)
         {
             if (privacyPolicy == null)
+            {
+                return;
+            }
+
+            // Ignore if they have already accepted this privacy policy.
+            if (candidate.Id != null && !_crm.CandidateYetToAcceptPrivacyPolicy((Guid)candidate.Id, privacyPolicy.AcceptedPolicyId))
             {
                 return;
             }

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -203,55 +203,6 @@ namespace GetIntoTeachingApiTests.Models.Crm
         }
 
         [Fact]
-        public void ToEntity_WhenChangingEventSubscriptionFromSingleToLocal_RetainsLocalSubscription()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { Id = Guid.NewGuid(), EventsSubscriptionTypeId = (int)Candidate.SubscriptionType.SingleEvent };
-            var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(candidateEntity);
-            mockCrm.Setup(m => m.CandidateAlreadyHasLocalEventSubscriptionType((Guid)candidate.Id)).Returns(true);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            candidateEntity.GetAttributeValue<bool>("dfe_newregistrant").Should().BeFalse();
-
-            candidateEntity.GetAttributeValue<OptionSetValue>("dfe_gitiseventsservicesubscriptiontype")
-                .Value.Should().Be((int)Candidate.SubscriptionType.LocalEvent);
-        }
-
-        [Fact]
-        public void ToEntity_WithNullId_SetsIsNewRegistrantToTrue()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { Id = null };
-            var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.NewEntity("contact", null, context)).Returns(candidateEntity);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            candidateEntity.GetAttributeValue<bool>("dfe_newregistrant").Should().BeTrue();
-        }
-
-        [Fact]
-        public void ToEntity_WithId_SetsIsNewRegistrantToFalse()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { Id = Guid.NewGuid() };
-            var candidateEntity = new Entity("contact");
-            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(candidateEntity);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            candidateEntity.GetAttributeValue<bool>("dfe_newregistrant").Should().BeFalse();
-        }
-
-        [Fact]
         public void FullName_ReturnsCorrectly()
         {
             var candidate = new Candidate() { FirstName = "John", LastName = "Doe" };

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -203,45 +203,6 @@ namespace GetIntoTeachingApiTests.Models.Crm
         }
 
         [Fact]
-        public void ToEntity_WhenPrivacyPolicyAlreadyAccepted_DoesNotCreatePrivacyPolicyEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-
-            var candidate = new Candidate()
-            {
-                Id = Guid.NewGuid(),
-                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = Guid.NewGuid() }
-            };
-
-            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(new Entity("contact"));
-            mockCrm.Setup(m => m.CandidateYetToAcceptPrivacyPolicy((Guid)candidate.Id,
-                candidate.PrivacyPolicy.AcceptedPolicyId)).Returns(false);
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", null, context), Times.Never);
-        }
-
-        [Fact]
-        public void ToEntity_WhenPrivacyPolicyIsNull_DoesNotCreatePrivacyPolicyEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var candidate = new Candidate() { Id = Guid.NewGuid(), PrivacyPolicy = null };
-
-            mockCrm.Setup(m => m.BlankExistingEntity("contact", candidate.Id.Value, context)).Returns(new Entity("contact"));
-
-            candidate.ToEntity(mockCrm.Object, context);
-
-            mockCrm.Verify(m => m.CandidateYetToAcceptPrivacyPolicy(
-                It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
-            mockService.Verify(m => m.NewEntity("dfe_candidateprivacypolicy", null, context), Times.Never);
-        }
-
-        [Fact]
         public void ToEntity_WhenChangingEventSubscriptionFromSingleToLocal_RetainsLocalSubscription()
         {
             var mockService = new Mock<IOrganizationServiceAdapter>();

--- a/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/TeachingEventRegistrationTests.cs
@@ -33,37 +33,5 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("RegistrationNotificationSeen").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "msevtmgt_registrationnotificationseen");
         }
-
-        [Fact]
-        public void ToEntity_WhenAlreadyRegisteredForEvent_DoesNotCreateTeachingEventRegistrationEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var registration = new TeachingEventRegistration() { CandidateId = Guid.NewGuid(), EventId = Guid.NewGuid() };
-
-            mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent(registration.CandidateId, registration.EventId)).Returns(false);
-
-            var entity = registration.ToEntity(mockCrm.Object, context);
-
-            entity.Should().BeNull();
-            mockService.Verify(m => m.NewEntity("msevtmgt_eventregistration", null, context), Times.Never);
-        }
-
-        [Fact]
-        public void ToEntity_WhenNotAlreadyRegisteredForEvent_CreatesATeachingEventRegistrationEntity()
-        {
-            var mockService = new Mock<IOrganizationServiceAdapter>();
-            var context = mockService.Object.Context();
-            var mockCrm = new Mock<ICrmService>();
-            var registration = new TeachingEventRegistration() { CandidateId = Guid.NewGuid(), EventId = Guid.NewGuid() };
-
-            mockCrm.Setup(m => m.NewEntity("msevtmgt_eventregistration", null, context)).Returns(new Entity("msevtmgt_eventregistration"));
-            mockCrm.Setup(m => m.CandidateYetToRegisterForTeachingEvent(registration.CandidateId, registration.EventId)).Returns(true);
-
-            registration.ToEntity(mockCrm.Object, context);
-
-            mockCrm.Verify(m => m.NewEntity("msevtmgt_eventregistration", null, context), Times.Once);
-        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ public List<CandidateQualification> Qualifications { get; set; }
 
 ### Customising the Mapping Behaviour
 
-Occasionally it can be useful to hook into the mapping behaviour that is encapsulated in the `BaseModel`. An example of this may be to prevent mapping to an entity if we know that it will create a duplicate in the CRM. We do this as part of `TeachingEventRegistration` to ensure we don't register the same candidate as an attendee of the event more than once:
+Occasionally it can be useful to hook into the mapping behaviour that is encapsulated in the `BaseModel`. An example of this may be to delete a related entity from the CRM, for example:
 
 ```
-protected override bool ShouldMap(ICrmService crm)
+protected override void FinaliseEntity(Entity source, ICrmService crm, OrganizationServiceContext context)
 {
-    return crm.CandidateYetToRegisterForTeachingEvent(CandidateId, EventId);
+    DeleteLink(source, crm, context, someModel, nameof(someModel));
 }
 ```


### PR DESCRIPTION
[Trello-4304](https://trello.com/c/gjjriiec/4304-clean-up-basemodel-hooks-shift-into-candidateupserter)

- Remove ShouldMapRelationship hook

The `BaseModel` is complex and more so due to the available hooks. We have since centralised the candidate updating to the `CandidateUpserter` which makes the hooks redundant. Port the privacy policy hook over to the candidate upserter.

- Remove ShouldMap hook from BaseModel

The logic currently in the `ShouldMap` hooks can be moved into the `CandidateUpserter` to avoid overcomplicating an already complex class.

The only hook remaining in `BaseModel` is the `FinaliseEntity` hook, which can't be removed as it operates on the encapsulated CRM entity.