### PR TITLE
Expose adviser assignment status

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -79,6 +79,8 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         public DateTime? PhoneCallScheduledAt { get; set; }
         [SwaggerSchema(ReadOnly = true)]
         public bool CanSubscribeToTeacherTrainingAdviser { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public int? AssignmentStatusId { get; set; }
 
         [JsonIgnore]
         public Candidate Candidate => CreateCandidate();
@@ -157,6 +159,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             AddressPostcode = candidate.AddressPostcode;
             TypeId = candidate.TypeId;
             AdviserStatusId = candidate.AdviserStatusId;
+            AssignmentStatusId = candidate.AssignmentStatusId;
 
             CanSubscribeToTeacherTrainingAdviser = CanSubscribe(candidate);
 

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -60,6 +60,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
                 PlanningToRetakeGcseMathsId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 PlanningToRetakeGcseScienceId = (int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking,
                 AdviserStatusId = (int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttOffer,
+                AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned,
                 Email = "email@address.com",
                 FirstName = "John",
                 LastName = "Doe",
@@ -85,6 +86,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             response.PlanningToRetakeGcseMathsAndEnglishId.Should().Be((int)Candidate.GcseStatus.HasOrIsPlanningOnRetaking);
             response.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
             response.AdviserStatusId.Should().Be((int)TeacherTrainingAdviserSignUp.ResubscribableAdviserStatus.AcceptedIttOffer);
+            response.AssignmentStatusId.Should().Be(candidate.AssignmentStatusId);
             response.Email.Should().Be(candidate.Email);
             response.FirstName.Should().Be(candidate.FirstName);
             response.LastName.Should().Be(candidate.LastName);


### PR DESCRIPTION
We want to show a different UI to candidates in Apply based on their adviser assignment status; in order to do that we need to expose it from the API.