### PR TITLE
Relax ExistingCandidateRequest validation

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -1,27 +1,13 @@
-﻿using System.Linq;
-using FluentValidation;
+﻿using FluentValidation;
 using FluentValidation.Validators;
-using GetIntoTeachingApi.Services;
 
 namespace GetIntoTeachingApi.Models.Validators
 {
     public class ExistingCandidateRequestValidator : AbstractValidator<ExistingCandidateRequest>
     {
-        public ExistingCandidateRequestValidator(IDateTimeProvider dateTime)
+        public ExistingCandidateRequestValidator()
         {
-            RuleFor(request => request.FirstName).MaximumLength(256);
-            RuleFor(request => request.LastName).MaximumLength(256);
             RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(request => request.DateOfBirth).LessThan(request => dateTime.UtcNow);
-            RuleFor(request => request)
-                .Must(SpecifyTwoAdditionalRequiredAttributes)
-                .WithMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
-        }
-
-        private static bool SpecifyTwoAdditionalRequiredAttributes(ExistingCandidateRequest request)
-        {
-            var additionalRequiredAttributes = new object[] { request.DateOfBirth, request.FirstName, request.LastName };
-            return additionalRequiredAttributes.Count(attribute => attribute != null) >= 2;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -14,13 +14,13 @@ namespace GetIntoTeachingApiTests.Models.Validators
 
         public ExistingCandidateRequestValidatorTests()
         {
-            _validator = new ExistingCandidateRequestValidator(new DateTimeProvider());
+            _validator = new ExistingCandidateRequestValidator();
         }
 
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "first", DateOfBirth = DateTime.UtcNow.AddDays(-18) };
+            var request = new ExistingCandidateRequest { Email = "email@address.com" };
 
             var result = _validator.TestValidate(request);
 
@@ -50,73 +50,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = $"{new string('a', 50)}@{new string('a', 50)}.com" });
 
             result.ShouldHaveValidationErrorFor(r => r.Email);
-        }
-
-        [Fact]
-        public void Validate_EmailAddressPresent_HasNoError()
-        {
-            var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = "valid@email.com" });
-
-            result.ShouldNotHaveValidationErrorFor(r => r.Email);
-        }
-
-        [Fact]
-        public void Validate_DateOfBirthInFuture_HasError()
-        {
-            var result = _validator.TestValidate(new ExistingCandidateRequest() { DateOfBirth = DateTime.UtcNow.AddDays(1) });
-
-            result.ShouldHaveValidationErrorFor(r => r.DateOfBirth);
-        }
-
-        [Fact]
-        public void Validate_NameIsTooLong_HasError()
-        {
-            var tooLongName = new string('a', 257);
-            var request = new ExistingCandidateRequest() { FirstName = tooLongName, LastName = tooLongName };
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor(r => r.FirstName);
-            result.ShouldHaveValidationErrorFor(r => r.LastName);
-        }
-
-        [Fact]
-        public void Validate_SpecifyNoAdditionalRequiredAttributes_HasError()
-        {
-            var request = new ExistingCandidateRequest();
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor(request => request).WithErrorMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
-        }
-
-        [Fact]
-        public void Validate_SpecifyOneAdditionalRequiredAttributes_HasError()
-        {
-            var request = new ExistingCandidateRequest { FirstName = "first" };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldHaveValidationErrorFor(request => request).WithErrorMessage("You must specify values for 2 additional attributes (from birthdate, firstname and lastname).");
-        }
-
-        [Fact]
-        public void Validate_SpecifyTwoAdditionalRequiredAttributes_HasNoError()
-        {
-            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last" };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldNotHaveValidationErrorFor(request => request);
-        }
-
-        [Fact]
-        public void Validate_SpecifyThreeAdditionalRequiredAttributes_HasNoError()
-        {
-            var request = new ExistingCandidateRequest { FirstName = "first", LastName = "last", DateOfBirth = DateTime.UtcNow.AddDays(-18) };
-
-            var result = _validator.TestValidate(request);
-
-            result.ShouldNotHaveValidationErrorFor(request => request);
         }
     }
 }


### PR DESCRIPTION
[Trello-4360](https://trello.com/c/IfbKWsDm/4360-investigate-400-error-on-adviser-sign-up-from-apply) 

Historically the matchback was more stringent and required a first/last name or DOB to match as well as email. It has since been updated to fallback to only matching on email address, although all existing services will also send a first/last name.

Now that Apply offers an adviser sign up the matchback can happen without a first/last name and the API raises an error. Relaxing this validation will prevent the error and not change the underlying functionality (as we fallback to an email only matchback anyway).