### PR TITLE
Fix bug in CandidateUpserter

### DIFF
--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -127,7 +127,7 @@ namespace GetIntoTeachingApi.Services
 
         private void UpdateEventSubscriptionType(Candidate candidate)
         {
-            var changingEventSubscriptionType = !candidate.IsNewRegistrant && candidate.EventsSubscriptionTypeId != null;
+            var changingEventSubscriptionType = candidate.Id != null && candidate.EventsSubscriptionTypeId != null;
 
             if (changingEventSubscriptionType && _crm.CandidateAlreadyHasLocalEventSubscriptionType((Guid)candidate.Id))
             {


### PR DESCRIPTION
We are checking the `IsNewRegistrant` field before it is set and so we occasionally see an error where the `candidate.Id` is `null` and we try and cast it to a `Guid`.