### PR TITLE
Update adviser assignment logic

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -336,7 +336,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
 
         private void SetAdviserEligibility(Candidate candidate)
         {
-            var eligibleForAnAdviser = DegreeTypeId == (int)CandidateQualification.DegreeType.Degree || candidate.IsReturningToTeaching();
+            var eligibleForAnAdviser = PhoneCallScheduledAt == null;
             if (eligibleForAnAdviser)
             {
                 candidate.AssignmentStatusId = (int)Candidate.AssignmentStatus.WaitingToBeAssigned;

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -154,9 +154,9 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             candidate.PlanningToRetakeGcseMathsId.Should().Be(request.PlanningToRetakeGcseMathsAndEnglishId);
             candidate.PlanningToRetakeGcseScienceId.Should().Be(request.PlanningToRetakeGcseScienceId);
             candidate.AdviserStatusId.Should().BeNull();
-            candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
-            candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
-            candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
+            candidate.AdviserRequirementId.Should().BeNull();
+            candidate.AdviserEligibilityId.Should().BeNull();
+            candidate.AssignmentStatusId.Should().BeNull();
             candidate.TypeId.Should().Be((int)Candidate.Type.ReturningToTeacherTraining);
             candidate.Email.Should().Be(request.Email);
             candidate.FirstName.Should().Be(request.FirstName);
@@ -387,47 +387,26 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
         }
 
         [Fact]
-        public void Candidate_DegreeTypeDegree_IsEligibleForAdviser()
+        public void Candidate_PhoneCallScheduled_IsNotEligibleForAdviser()
         {
-            var request = new TeacherTrainingAdviserSignUp() { DegreeTypeId = (int)CandidateQualification.DegreeType.Degree };
+            var request = new TeacherTrainingAdviserSignUp() { PhoneCallScheduledAt = DateTime.UtcNow };
 
-            request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
-            request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
-            request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
-        }
-
-        [Fact]
-        public void Candidate_DegreeTypeDegreeEquivalent_IsNotEligibleForAdviser()
-        {
-            var request = new TeacherTrainingAdviserSignUp() { DegreeTypeId = (int)CandidateQualification.DegreeType.DegreeEquivalent };
-
+            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeNull();
             request.Candidate.AssignmentStatusId.Should().BeNull();
             request.Candidate.AdviserEligibilityId.Should().BeNull();
             request.Candidate.AdviserRequirementId.Should().BeNull();
         }
 
         [Fact]
-        public void Candidate_ReturningToTeaching_IsEligibleForAdviser()
+        public void Candidate_PhoneCallNotScheduled_IsEligibleForAdviser()
         {
-            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
+            var request = new TeacherTrainingAdviserSignUp() { PhoneCallScheduledAt = null };
 
-            request.Candidate.IsReturningToTeaching().Should().BeTrue();
+
             request.Candidate.AssignmentStatusId.Should().Be((int)Candidate.AssignmentStatus.WaitingToBeAssigned);
             request.Candidate.AdviserEligibilityId.Should().Be((int)Candidate.AdviserEligibility.Yes);
             request.Candidate.AdviserRequirementId.Should().Be((int)Candidate.AdviserRequirement.Yes);
             request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
-        }
-
-        [Fact]
-        public void Candidate_InterestedInTeaching_IsNotEligibleForAdviser()
-        {
-            var request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.InterestedInTeacherTraining };
-
-            request.Candidate.IsReturningToTeaching().Should().BeFalse();
-            request.Candidate.AssignmentStatusId.Should().BeNull();
-            request.Candidate.AdviserEligibilityId.Should().BeNull();
-            request.Candidate.AdviserRequirementId.Should().BeNull();
-            request.Candidate.StatusIsWaitingToBeAssignedAt.Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-4363](https://trello.com/c/Tg9tgd58/4363-investigate-apply-adviser-sign-up-issues)

Currently, if a candidate has a degree or is returning to teaching we will put them in the queue to be assigned to an adviser. Other candidates (with an equivalent degree) are taken on a journey to schedule a callback on the main TTA service.

If an international candidate signs up from Apply we do not offer the callback service and they aren't put in the queue for an adviser, so they will fall between the cracks. Going forward we want to queue these candidates for an adviser. To that end, the logic around this can be simplified to 'if a candidate has not booked a callback, put them in the queue for an adviser'.