### PR TITLE
Remove feature flags

### DIFF
--- a/GetIntoTeachingApi/Models/Country.cs
+++ b/GetIntoTeachingApi/Models/Country.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.Xrm.Sdk;
-using GetIntoTeachingApi.Utils;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GetIntoTeachingApi.Models
@@ -22,11 +21,7 @@ namespace GetIntoTeachingApi.Models
         {
             Id = entity.Id;
             Value = entity.GetAttributeValue<string>("dfe_name");
-
-            if (new Env().IsFeatureOn("COUNTRY_CODES"))
-            {
-                IsoCode = entity.GetAttributeValue<string>("dfe_countrykey");
-            }
+            IsoCode = entity.GetAttributeValue<string>("dfe_countrykey");
         }
     }
 }

--- a/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationForm.cs
@@ -58,13 +58,13 @@ namespace GetIntoTeachingApi.Models.Crm
         public DateTime UpdatedAt { get; set; }
         [EntityField("dfe_submittedatdate")]
         public DateTime? SubmittedAt { get; set; }
-        [EntityField("dfe_qualificationscompleted", null, null, new[] { "APPLY_CANDIDATE_API_V1_2" })]
+        [EntityField("dfe_qualificationscompleted")]
         public bool? QualificationsCompleted { get; set; }
-        [EntityField("dfe_referencescompleted", null, null, new[] { "APPLY_CANDIDATE_API_V1_2" })]
+        [EntityField("dfe_referencescompleted")]
         public bool? ReferencesCompleted { get; set; }
-        [EntityField("dfe_applicationchoicescompleted", null, null, new[] { "APPLY_CANDIDATE_API_V1_2" })]
+        [EntityField("dfe_applicationchoicescompleted")]
         public bool? ApplicationChoicesCompleted { get; set; }
-        [EntityField("dfe_personalstatementcompleted", null, null, new[] { "APPLY_CANDIDATE_API_V1_2" })]
+        [EntityField("dfe_personalstatementcompleted")]
         public bool? PersonalStatementCompleted { get; set; }
         [EntityField("dfe_name")]
         public string Name

--- a/GetIntoTeachingApi/Models/Crm/Candidate.cs
+++ b/GetIntoTeachingApi/Models/Crm/Candidate.cs
@@ -153,19 +153,19 @@ namespace GetIntoTeachingApi.Models.Crm
         public int? AdviserStatusId { get; set; }
         [EntityField("dfe_candidatereregisterstatus", typeof(OptionSetValue))]
         public int? RegistrationStatusId { get; set; }
-        [EntityField("dfe_candidateapplystatus", typeof(OptionSetValue), null, new[] { "APPLY_CANDIDATE_API" })]
+        [EntityField("dfe_candidateapplystatus", typeof(OptionSetValue))]
         public int? ApplyStatusId { get; set; }
-        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue), null, new[] { "APPLY_CANDIDATE_API" })]
+        [EntityField("dfe_candidateapplyphase", typeof(OptionSetValue))]
         public int? ApplyPhaseId { get; set; }
         [EntityField("dfe_waitingtobeassigneddate")]
         public DateTime? StatusIsWaitingToBeAssignedAt { get; set; }
         [EntityField("merged")]
         public bool Merged { get; set; }
-        [EntityField("dfe_applyid", null, null, new[] { "APPLY_CANDIDATE_API" })]
+        [EntityField("dfe_applyid")]
         public string ApplyId { get; set; }
-        [EntityField("dfe_applylastmodifiedon", null, null, new[] { "APPLY_CANDIDATE_API" })]
+        [EntityField("dfe_applylastmodifiedon")]
         public DateTime? ApplyUpdatedAt { get; set; }
-        [EntityField("dfe_applycreatedon", null, null, new[] { "APPLY_CANDIDATE_API" })]
+        [EntityField("dfe_applycreatedon")]
         public DateTime? ApplyCreatedAt { get; set; }
         [EntityField("emailaddress1")]
         public string Email { get; set; }

--- a/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
+++ b/GetIntoTeachingApi/Models/Crm/TeachingEvent.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
-using FluentValidation;
 using GetIntoTeachingApi.Attributes;
 using GetIntoTeachingApi.Services;
 using Microsoft.Xrm.Sdk;
@@ -39,7 +38,7 @@ namespace GetIntoTeachingApi.Models.Crm
         public int TypeId { get; set; }
         [EntityField("dfe_eventstatus", typeof(OptionSetValue))]
         public int StatusId { get; set; }
-        [EntityField("dfe_eventregion", typeof(OptionSetValue), null, new[] { "GET_INTO_TEACHING_EVENTS" })]
+        [EntityField("dfe_eventregion", typeof(OptionSetValue))]
         public int? RegionId { get; set; }
         [EntityField("dfe_websiteeventpartialurl")]
         public string ReadableId { get; set; }

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -360,7 +360,7 @@ namespace GetIntoTeachingApi.Services
                 .Select((entity) => new TeachingEventBuilding(entity, this, _serviceProvider)).ToList();
         }
 
-        private QueryExpression MatchBackQuery(string email, string applyId = null)
+        private static QueryExpression MatchBackQuery(string email, string applyId = null)
         {
             // The ToList() is important or Dynamics throws an error.
             var emails = EmailReconciler.EquivalentEmails(email).ToList();
@@ -371,11 +371,7 @@ namespace GetIntoTeachingApi.Services
 
             var filter = new FilterExpression(LogicalOperator.Or);
             filter.AddCondition(new ConditionExpression("emailaddress1", ConditionOperator.In, emails));
-
-            if (_env.IsFeatureOn("SECONDARY_EMAIL_MATCHBACK"))
-            {
-                filter.AddCondition(new ConditionExpression("emailaddress2", ConditionOperator.In, emails));
-            }
+            filter.AddCondition(new ConditionExpression("emailaddress2", ConditionOperator.In, emails));
 
             if (applyId != null)
             {

--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -255,35 +255,30 @@ namespace GetIntoTeachingApi.Services
             await SyncPickListItem("contact", "dfe_gitismlservicesubscriptionchannel");
             await SyncPickListItem("contact", "dfe_gitiseventsservicesubscriptionchannel");
             await SyncPickListItem("contact", "dfe_gitisttaservicesubscriptionchannel");
+            await SyncPickListItem("contact", "dfe_candidateapplystatus");
+            await SyncPickListItem("contact", "dfe_candidateapplyphase");
+
             await SyncPickListItem("dfe_candidatequalification", "dfe_degreestatus");
             await SyncPickListItem("dfe_candidatequalification", "dfe_ukdegreegrade");
             await SyncPickListItem("dfe_candidatequalification", "dfe_type");
+
             await SyncPickListItem("dfe_candidatepastteachingposition", "dfe_educationphase");
+
             await SyncPickListItem("msevtmgt_event", "dfe_event_type");
             await SyncPickListItem("msevtmgt_event", "dfe_eventstatus");
+            await SyncPickListItem("msevtmgt_event", "dfe_eventregion");
+
             await SyncPickListItem("msevtmgt_eventregistration", "dfe_channelcreation");
+
             await SyncPickListItem("phonecall", "dfe_channelcreation");
+
             await SyncPickListItem("dfe_servicesubscription", "dfe_servicesubscriptiontype");
 
-            if (_env.IsFeatureOn("APPLY_CANDIDATE_API"))
-            {
-                await SyncPickListItem("contact", "dfe_candidateapplystatus");
-                await SyncPickListItem("contact", "dfe_candidateapplyphase");
-                await SyncPickListItem("dfe_applyapplicationform", "dfe_applyphase");
-                await SyncPickListItem("dfe_applyapplicationform", "dfe_applystatus");
-                await SyncPickListItem("dfe_applyapplicationform", "dfe_recruitmentyear");
-            }
-
-            if (_env.IsFeatureOn("APPLY_CANDIDATE_API_V1_2"))
-            {
-                await SyncPickListItem("dfe_applyapplicationchoice", "dfe_applicationchoicestatus");
-                await SyncPickListItem("dfe_applyreference", "dfe_referencefeedbackstatus");
-            }
-
-            if (_env.IsFeatureOn("GET_INTO_TEACHING_EVENTS"))
-            {
-                await SyncPickListItem("msevtmgt_event", "dfe_eventregion");
-            }
+            await SyncPickListItem("dfe_applyapplicationform", "dfe_applyphase");
+            await SyncPickListItem("dfe_applyapplicationform", "dfe_applystatus");
+            await SyncPickListItem("dfe_applyapplicationform", "dfe_recruitmentyear");
+            await SyncPickListItem("dfe_applyapplicationchoice", "dfe_applicationchoicestatus");
+            await SyncPickListItem("dfe_applyreference", "dfe_referencefeedbackstatus");     
         }
 
         private async Task SyncModels<T>(IEnumerable<T> models, IQueryable<T> dbSet)

--- a/GetIntoTeachingApi/Utils/EmailReconciler.cs
+++ b/GetIntoTeachingApi/Utils/EmailReconciler.cs
@@ -36,12 +36,6 @@ namespace GetIntoTeachingApi.Utils
         public static IEnumerable<string> EquivalentEmails(string email)
 		{
             var env = new Env();
-
-            if (!env.IsFeatureOn("RECONCILE_EMAILS"))
-            {
-                return new string[] {  email };
-            }
-
             var address = new MailAddress(email);
             var hosts = new List<string> { address.Host };
 

--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -26,24 +26,10 @@ namespace GetIntoTeachingApi.Utils
         public string NotifyApiKey => Environment.GetEnvironmentVariable("NOTIFY_API_KEY");
         public string GoogleApiKey => Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
         public string ApplyCandidateApiKey => Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_KEY");
+        public string ApplyCandidateApiUrl => Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL");
         public string AppName => AppServices.ApplicationName;
         public string Organization => AppServices.OrganizationName;
         public string Space => AppServices.SpaceName;
-
-        public string ApplyCandidateApiUrl
-        {
-            get
-            {
-                var url = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL");
-
-                if (IsFeatureOn("APPLY_CANDIDATE_API_V1_2"))
-                {
-                    url += "/v1.2";
-                }
-
-                return url;
-            }
-        }
 
         // The master instance boots first on deploy.
         public bool IsMasterInstance

--- a/GetIntoTeachingApi/env.dev
+++ b/GetIntoTeachingApi/env.dev
@@ -1,8 +1,1 @@
-﻿APPLY_CANDIDATE_API_FEATURE=true
-APPLY_CANDIDATE_API_V1_2_FEATURE=true
-APPLY_ID_MATCHBACK_FEATURE=true
-RECONCILE_EMAILS_FEATURE=true
-SECONDARY_EMAIL_MATCHBACK_FEATURE=true
-GET_INTO_TEACHING_EVENTS_FEATURE=true
-APPLY_CANDIDATE_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api
-COUNTRY_CODES_FEATURE=true
+﻿APPLY_CANDIDATE_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api/v1.2

--- a/GetIntoTeachingApi/env.prod
+++ b/GetIntoTeachingApi/env.prod
@@ -4,5 +4,5 @@ APPLY_ID_MATCHBACK_FEATURE=true
 RECONCILE_EMAILS_FEATURE=true
 SECONDARY_EMAIL_MATCHBACK_FEATURE=true
 GET_INTO_TEACHING_EVENTS_FEATURE=true
-APPLY_CANDIDATE_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api
+APPLY_CANDIDATE_API_URL=https://www.apply-for-teacher-training.service.gov.uk/candidate-api/v1.2
 COUNTRY_CODES_FEATURE=true

--- a/GetIntoTeachingApi/env.test
+++ b/GetIntoTeachingApi/env.test
@@ -1,9 +1,1 @@
-﻿APPLY_CANDIDATE_API_FEATURE=true
-APPLY_CANDIDATE_API_V1_2_FEATURE=true
-APPLY_ID_MATCHBACK_FEATURE=true
-RECONCILE_EMAILS_FEATURE=true
-SECONDARY_EMAIL_MATCHBACK_FEATURE=true
-GET_INTO_TEACHING_EVENTS_FEATURE=true
-APPLY_CANDIDATE_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api
-COUNTRY_CODES_FEATURE=true
-
+﻿APPLY_CANDIDATE_API_URL=https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api/v1.2

--- a/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
@@ -13,9 +13,6 @@ namespace GetIntoTeachingApiTests.Contracts
     {
         public ApplyCandidateApiTests(DatabaseFixture databaseFixture) : base(databaseFixture)
         {
-            Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_FEATURE", "on");
-            Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_V1_2_FEATURE", "on");
-            Environment.SetEnvironmentVariable($"APPLY_ID_MATCHBACK_FEATURE", "on");
         }
 
         [Theory]

--- a/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
@@ -86,11 +86,11 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_OnSuccessWithExistingCandidate_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
+        public void Run_OnSuccessWithExistingCandidateHavingSecondaryEmail_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
+            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com", SecondaryEmail = "other@email.com" };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns(match);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns(match);
 
             _job.Run(_candidate);
 
@@ -150,7 +150,7 @@ namespace GetIntoTeachingApiTests.Jobs
         public void Run_OnSuccessWithNewCandidate_SetsChannelAndQueuesUpsertJobForCandidateWithApplicationForms()
         {
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns<Candidate>(null);
+            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns<Candidate>(null);
 
             _job.Run(_candidate);
 
@@ -203,10 +203,8 @@ namespace GetIntoTeachingApiTests.Jobs
         }
 
         [Fact]
-        public void Run_WhenApplyIdMatchbackFeatureIsOn_MatchesBackOnApplyIdAsWellAsEmailAndWritesApplyEmailToSecondaryEmail()
+        public void Run_MatchesBackOnApplyIdAsWellAsEmailAndWritesApplyEmailToSecondaryEmail()
         {
-            _mockEnv.Setup(m => m.IsFeatureOn("APPLY_ID_MATCHBACK")).Returns(true);
-
             var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
             _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
             _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns(match);

--- a/GetIntoTeachingApiTests/Models/CountryTests.cs
+++ b/GetIntoTeachingApiTests/Models/CountryTests.cs
@@ -33,33 +33,13 @@ namespace GetIntoTeachingApiTests.Models
         }
 
         [Fact]
-        public void Constructor_WithEntity_WhenCountryCodeFeatureIsOn_SetsCountryCode()
+        public void Constructor_WithEntity_MapsCorrectly()
         {
-            var previousFeature = Environment.GetEnvironmentVariable("COUNTRY_CODES_FEATURE");
-            Environment.SetEnvironmentVariable("COUNTRY_CODES_FEATURE", "true");
-
             var country = new Country(_entity);
 
             country.Id.Should().Be(_entity.Id);
             country.Value.Should().Be(_entity.GetAttributeValue<string>("dfe_name"));
             country.IsoCode.Should().Be(_entity.GetAttributeValue<string>("dfe_countrykey"));
-
-            Environment.SetEnvironmentVariable("COUNTRY_CODES_FEATURE", previousFeature);
-        }
-
-        [Fact]
-        public void Constructor_WithEntity_WhenCountryCodeFeatureIsOff_DoesNotSetCountryCode()
-        {
-            var previousFeature = Environment.GetEnvironmentVariable("COUNTRY_CODES_FEATURE");
-            Environment.SetEnvironmentVariable("COUNTRY_CODES_FEATURE", "false");
-
-            var country = new Country(_entity);
-
-            country.Id.Should().Be(_entity.Id);
-            country.Value.Should().Be(_entity.GetAttributeValue<string>("dfe_name"));
-            country.IsoCode.Should().BeNull();
-
-            Environment.SetEnvironmentVariable("COUNTRY_CODES_FEATURE", previousFeature);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/ApplicationFormTests.cs
@@ -32,10 +32,10 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("UpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_modifiedon");
             type.GetProperty("SubmittedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_submittedatdate");
             type.GetProperty("Name").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_name");
-            type.GetProperty("QualificationsCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_qualificationscompleted" && a.Features.Contains("APPLY_CANDIDATE_API_V1_2"));
-            type.GetProperty("ReferencesCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_referencescompleted" && a.Features.Contains("APPLY_CANDIDATE_API_V1_2"));
-            type.GetProperty("ApplicationChoicesCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationchoicescompleted" && a.Features.Contains("APPLY_CANDIDATE_API_V1_2"));
-            type.GetProperty("PersonalStatementCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_personalstatementcompleted" && a.Features.Contains("APPLY_CANDIDATE_API_V1_2"));
+            type.GetProperty("QualificationsCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_qualificationscompleted");
+            type.GetProperty("ReferencesCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_referencescompleted");
+            type.GetProperty("ApplicationChoicesCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applicationchoicescompleted");
+            type.GetProperty("PersonalStatementCompleted").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_personalstatementcompleted");
 
             type.GetProperty("Choices").Should().BeDecoratedWith<EntityRelationshipAttribute>(
                 a => a.Name == "dfe_applyapplicationform_dfe_applyapplicationchoice_applyapplicationform" &&

--- a/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/CandidateTests.cs
@@ -74,13 +74,13 @@ namespace GetIntoTeachingApiTests.Models.Crm
             type.GetProperty("RegistrationStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
                 a => a.Name == "dfe_candidatereregisterstatus" && a.Type == typeof(OptionSetValue));
             type.GetProperty("ApplyStatusId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_candidateapplystatus" && a.Type == typeof(OptionSetValue) && a.Features.Contains("APPLY_CANDIDATE_API"));
+                a => a.Name == "dfe_candidateapplystatus" && a.Type == typeof(OptionSetValue));
             type.GetProperty("ApplyPhaseId").Should().BeDecoratedWith<EntityFieldAttribute>(
-                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue) && a.Features.Contains("APPLY_CANDIDATE_API"));
+                a => a.Name == "dfe_candidateapplyphase" && a.Type == typeof(OptionSetValue));
 
-            type.GetProperty("ApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid" && a.Features.Contains("APPLY_CANDIDATE_API"));
-            type.GetProperty("ApplyUpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applylastmodifiedon" && a.Features.Contains("APPLY_CANDIDATE_API"));
-            type.GetProperty("ApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon" && a.Features.Contains("APPLY_CANDIDATE_API"));
+            type.GetProperty("ApplyId").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applyid");
+            type.GetProperty("ApplyUpdatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applylastmodifiedon");
+            type.GetProperty("ApplyCreatedAt").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "dfe_applycreatedon");
             type.GetProperty("Merged").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "merged");
             type.GetProperty("Email").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress1");
             type.GetProperty("SecondaryEmail").Should().BeDecoratedWith<EntityFieldAttribute>(a => a.Name == "emailaddress2");

--- a/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
+++ b/GetIntoTeachingApiTests/Services/CrmServiceTests.cs
@@ -48,8 +48,6 @@ namespace GetIntoTeachingApiTests.Services
 
             // Freeze time.
             _mockDateTime.Setup(m => m.UtcNow).Returns(DateTime.UtcNow);
-
-            mockEnv.Setup(m => m.IsFeatureOn("SECONDARY_EMAIL_MATCHBACK")).Returns(true);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/StoreTests.cs
+++ b/GetIntoTeachingApiTests/Services/StoreTests.cs
@@ -306,25 +306,12 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async void SyncAsync_WhenApplyApiFeatureIsOn_InsertsApplyPickListItems()
+        public async void SyncAsync_InsertsApplyPickListItems()
         {
-            _mockEnv.Setup(m => m.IsFeatureOn("APPLY_CANDIDATE_API")).Returns(true);
-
             _mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_candidateapplystatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
             _mockCrm.Setup(m => m.GetPickListItems("contact", "dfe_candidateapplyphase")).Returns(Array.Empty<PickListItem>()).Verifiable();
             _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationform", "dfe_applyphase")).Returns(Array.Empty<PickListItem>()).Verifiable();
             _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationform", "dfe_applystatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
-
-            await _store.SyncAsync();
-
-            _mockCrm.Verify();
-        }
-
-        [Fact]
-        public async void SyncAsync_WhenApplyApiV1_2FeatureIsOn_InsertsApplyPickListItems()
-        {
-            _mockEnv.Setup(m => m.IsFeatureOn("APPLY_CANDIDATE_API_V1_2")).Returns(true);
-
             _mockCrm.Setup(m => m.GetPickListItems("dfe_applyapplicationchoice", "dfe_applicationchoicestatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
             _mockCrm.Setup(m => m.GetPickListItems("dfe_applyreference", "dfe_referencefeedbackstatus")).Returns(Array.Empty<PickListItem>()).Verifiable();
 
@@ -334,10 +321,8 @@ namespace GetIntoTeachingApiTests.Services
         }
 
         [Fact]
-        public async void SyncAsync_WhenGetIntoTeachingEventsFeatureIsOn_InsertsRegionIdPickListItem()
+        public async void SyncAsync_InsertsRegionIdPickListItem()
         {
-            _mockEnv.Setup(m => m.IsFeatureOn("GET_INTO_TEACHING_EVENTS")).Returns(true);
-
             _mockCrm.Setup(m => m.GetPickListItems("msevtmgt_event", "dfe_eventregion")).Returns(Array.Empty<PickListItem>()).Verifiable();
 
             await _store.SyncAsync();

--- a/GetIntoTeachingApiTests/Utils/EmailReconcilerTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EmailReconcilerTests.cs
@@ -13,41 +13,18 @@ namespace GetIntoTeachingApiTests.Utils
         [InlineData("john@domain.com", new string[] { "john@domain.com" })]
         public void EquivalentEmails_WithEmail_ReturnsEquivalent(string email, string[] expectedEquivalentEmails)
         {
-            var previous = Environment.GetEnvironmentVariable("RECONCILE_EMAILS_FEATURE");
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", "true");
-
             var equivalentEmails = EmailReconciler.EquivalentEmails(email);
 
             equivalentEmails.Should().BeEquivalentTo(expectedEquivalentEmails);
-
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", previous);
         }
 
         [Fact]
         public void EquivalentEmails_WithInvalidEmail_Throws()
         {
-            var previous = Environment.GetEnvironmentVariable("RECONCILE_EMAILS_FEATURE");
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", "true");
-
             var action = () => EmailReconciler.EquivalentEmails("invalid@email@domain.com");
 
             action.Should().Throw<FormatException>()
                 .WithMessage("An invalid character was found in the mail header: '@'.");
-
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", previous);
-        }
-
-        [Fact]
-        public void EquivalentEmails_WhenFeatureIsOff_ReturnsSingleEmail()
-        {
-            var previous = Environment.GetEnvironmentVariable("RECONCILE_EMAILS_FEATURE");
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", "false");
-
-            var equivalentEmails = EmailReconciler.EquivalentEmails("john@gmail.com");
-
-            equivalentEmails.Should().BeEquivalentTo(new string[] { "john@gmail.com" });
-
-            Environment.SetEnvironmentVariable("RECONCILE_EMAILS_FEATURE", previous);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -199,32 +199,14 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Fact]
-        public void ApplyCandidateApiUrl_WhenV1_2FeatureIsOff_ReturnsCorrectly()
+        public void ApplyCandidateApiUrl_ReturnsCorrectly()
         {
             var previousUrl = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL");
-            var previousFeature = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE");
-
             Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_URL", "apply-api-url");
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE", "false");
 
             _env.ApplyCandidateApiUrl.Should().Be("apply-api-url");
 
             Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_URL", previousUrl);
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE", previousFeature);
-        }
-
-        [Fact]
-        public void ApplyCandidateApiUrl_WhenV1_2FeatreIsOn_ReturnsCorrectly()
-        {
-            var previousUrl = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_URL");
-            var previousFeature = Environment.GetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE");
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_URL", "apply-api-url");
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE", "true");
-
-            _env.ApplyCandidateApiUrl.Should().Be("apply-api-url/v1.2");
-
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_URL", previousUrl);
-            Environment.SetEnvironmentVariable("APPLY_CANDIDATE_API_V1_2_FEATURE", previousFeature);
         }
 
         [Fact]


### PR DESCRIPTION
[Trello-4366](https://trello.com/c/VGMplzV4/4366-remove-feature-switching-around-matchback-and-apply-api-sync)

These feature flags are now enabled in all environments and are safe to remove. Also pins the apply endpoint version in all environments to `1.2`.