### PR TITLE
Enable Hangfire dashboard in production

### DIFF
--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -98,7 +98,7 @@ namespace GetIntoTeachingApi.AppStart
 
             app.UseRequestResponseLogging();
 
-            app.ConfigureHangfire(addBasicAuthFilter: _env.IsStaging, _env);
+            app.ConfigureHangfire(addBasicAuthFilter: true, _env);
 
             app.UseSwagger();
 

--- a/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Auth
 
         public bool Authorize(DashboardContext context)
         {
-            return new[] { "Development", "Staging" }.Contains(_env.EnvironmentName);
+            return new[] { "Development", "Staging", "Production" }.Contains(_env.EnvironmentName);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
@@ -33,8 +33,15 @@ namespace GetIntoTeachingApiTests.Auth
             _filter.Authorize(null).Should().BeTrue();
         }
 
+        [Fact]
+        public void Authorize_Production_IsTrue()
+        {
+            _mockEnv.Setup(m => m.EnvironmentName).Returns("Production");
+
+            _filter.Authorize(null).Should().BeTrue();
+        }
+
         [Theory]
-        [InlineData("Production")]
         [InlineData("Development1")]
         [InlineData("prod")]
         [InlineData("")]


### PR DESCRIPTION
We need to cancel a job in-progress; doing this in code is not straight forward so enabling the dashboard (behind authentication) in production to allow us to cancel it.

I've updated the production keyvault with secure credentials. This can be disabled again once we have successfully ran the backfill job.