### PR TITLE
Clear down all apply jobs

### DIFF
--- a/GetIntoTeachingApi/Jobs/ApplyBackfillJob.cs
+++ b/GetIntoTeachingApi/Jobs/ApplyBackfillJob.cs
@@ -36,11 +36,12 @@ namespace GetIntoTeachingApi.Jobs
         [DisableConcurrentExecution(timeoutInSeconds: 60 * 60)]
         public async Task RunAsync(DateTime updatedSince)
         {
-            _appSettings.IsApplyBackfillInProgress = true;
-            _logger.LogInformation("ApplyBackfillJob - Started");
-            await QueueCandidateSyncJobs(updatedSince);
-            _logger.LogInformation("ApplyBackfillJob - Succeeded");
-            _appSettings.IsApplyBackfillInProgress = false;
+            await Task.FromResult(true);
+            //_appSettings.IsApplyBackfillInProgress = true;
+            //_logger.LogInformation("ApplyBackfillJob - Started");
+            //await QueueCandidateSyncJobs(updatedSince);
+            //_logger.LogInformation("ApplyBackfillJob - Succeeded");
+            //_appSettings.IsApplyBackfillInProgress = false;
         }
 
         private async Task QueueCandidateSyncJobs(DateTime updatedSince)

--- a/GetIntoTeachingApi/Jobs/ApplyCandidateSyncJob.cs
+++ b/GetIntoTeachingApi/Jobs/ApplyCandidateSyncJob.cs
@@ -31,14 +31,14 @@ namespace GetIntoTeachingApi.Jobs
 
         public void Run(Candidate applyCandidate)
         {
-            if (_appSettings.IsCrmIntegrationPaused)
-            {
-                throw new InvalidOperationException("ApplyCandidateSyncJob - Aborting (CRM integration paused).");
-            }
+            //if (_appSettings.IsCrmIntegrationPaused)
+            //{
+            //    throw new InvalidOperationException("ApplyCandidateSyncJob - Aborting (CRM integration paused).");
+            //}
 
-            _logger.LogInformation("ApplyCandidateSyncJob - Started - {Id}", applyCandidate.Id);
-            SyncCandidate(applyCandidate);
-            _logger.LogInformation("ApplyCandidateSyncJob - Succeeded - {Id}", applyCandidate.Id);
+            //_logger.LogInformation("ApplyCandidateSyncJob - Started - {Id}", applyCandidate.Id);
+            //SyncCandidate(applyCandidate);
+            //_logger.LogInformation("ApplyCandidateSyncJob - Succeeded - {Id}", applyCandidate.Id);
         }
 
         public void SyncCandidate(Candidate applyCandidate)

--- a/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertApplicationFormJob.cs
@@ -39,31 +39,31 @@ namespace GetIntoTeachingApi.Jobs
 
         public void Run(string json, PerformContext context)
         {
-            var form = json.DeserializeChangeTracked<ApplicationForm>();
+            //var form = json.DeserializeChangeTracked<ApplicationForm>();
 
-            if (_appSettings.IsCrmIntegrationPaused)
-            {
-                throw new InvalidOperationException("UpsertApplicationFormJob - Aborting (CRM integration paused).");
-            }
+            //if (_appSettings.IsCrmIntegrationPaused)
+            //{
+            //    throw new InvalidOperationException("UpsertApplicationFormJob - Aborting (CRM integration paused).");
+            //}
 
-            _logger.LogInformation("UpsertApplicationFormJob - Started ({Attempt})", AttemptInfo(context, _contextAdapter));
-            _logger.LogInformation("UpsertApplicationFormJob - Payload {Payload}", Redactor.RedactJson(json));
+            //_logger.LogInformation("UpsertApplicationFormJob - Started ({Attempt})", AttemptInfo(context, _contextAdapter));
+            //_logger.LogInformation("UpsertApplicationFormJob - Payload {Payload}", Redactor.RedactJson(json));
 
-            if (IsLastAttempt(context, _contextAdapter))
-            {
-                _logger.LogInformation("UpsertApplicationFormJob - Deleted");
-            }
-            else
-            {
-                SaveApplicationForm(form);
-                SaveApplicationReferences(form.References, (Guid)form.Id);
-                SaveApplicationChoices(form.Choices, (Guid)form.Id);
+            //if (IsLastAttempt(context, _contextAdapter))
+            //{
+            //    _logger.LogInformation("UpsertApplicationFormJob - Deleted");
+            //}
+            //else
+            //{
+            //    SaveApplicationForm(form);
+            //    SaveApplicationReferences(form.References, (Guid)form.Id);
+            //    SaveApplicationChoices(form.Choices, (Guid)form.Id);
 
-                _logger.LogInformation("UpsertApplicationFormJob - Succeeded - {Id}", form.Id);
-            }
+            //    _logger.LogInformation("UpsertApplicationFormJob - Succeeded - {Id}", form.Id);
+            //}
 
-            var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
-            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Observe(duration);
+            //var duration = (DateTime.UtcNow - _contextAdapter.GetJobCreatedAt(context)).TotalSeconds;
+            //_metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Observe(duration);
         }
 
         private void SaveApplicationForm(ApplicationForm form)

--- a/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
+++ b/GetIntoTeachingApiTests/Contracts/ApplyCandidateApiTests.cs
@@ -8,31 +8,31 @@ using Xunit;
 
 namespace GetIntoTeachingApiTests.Contracts
 {
-    [Collection("Database")]
-    public class ApplyCandidateApiTests : BaseTests
-    {
-        public ApplyCandidateApiTests(DatabaseFixture databaseFixture) : base(databaseFixture)
-        {
-            Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_FEATURE", "on");
-            Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_V1_2_FEATURE", "on");
-            Environment.SetEnvironmentVariable($"APPLY_ID_MATCHBACK_FEATURE", "on");
-        }
+    //[Collection("Database")]
+    //public class ApplyCandidateApiTests : BaseTests
+    //{
+    //    public ApplyCandidateApiTests(DatabaseFixture databaseFixture) : base(databaseFixture)
+    //    {
+    //        Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_FEATURE", "on");
+    //        Environment.SetEnvironmentVariable($"APPLY_CANDIDATE_API_V1_2_FEATURE", "on");
+    //        Environment.SetEnvironmentVariable($"APPLY_ID_MATCHBACK_FEATURE", "on");
+    //    }
 
-        [Theory]
-        [ContractTestInputs("./Contracts/Input/ApplyCandidateApi")]
-        public async void Contract(string scenario)
-        {
-            await Setup();
+    //    [Theory]
+    //    [ContractTestInputs("./Contracts/Input/ApplyCandidateApi")]
+    //    public async void Contract(string scenario)
+    //    {
+    //        await Setup();
 
-            var candidate = ConstructCandidate(ReadInput(scenario));
-            JobClient.Enqueue<ApplyCandidateSyncJob>(c => c.Run(candidate));
+    //        var candidate = ConstructCandidate(ReadInput(scenario));
+    //        JobClient.Enqueue<ApplyCandidateSyncJob>(c => c.Run(candidate));
 
-            await AssertRequestMatchesSnapshot(scenario);
-        }
+    //        await AssertRequestMatchesSnapshot(scenario);
+    //    }
 
-        private static Candidate ConstructCandidate(string json)
-        {
-            return JsonConvert.DeserializeObject<Candidate>(json);
-        }
-    }
+    //    private static Candidate ConstructCandidate(string json)
+    //    {
+    //        return JsonConvert.DeserializeObject<Candidate>(json);
+    //    }
+    //}
 }

--- a/GetIntoTeachingApiTests/Jobs/ApplyBackfillJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ApplyBackfillJobTests.cs
@@ -21,104 +21,104 @@ namespace GetIntoTeachingApiTests.Jobs
 {
     public class ApplyBackfillJobTests
     {
-        private readonly Mock<ILogger<ApplyBackfillJob>> _mockLogger;
-        private readonly Mock<IBackgroundJobClient> _mockJobClient;
-        private readonly Mock<IEnv> _mockEnv;
-        private readonly Mock<IAppSettings> _mockAppSettings;
-        private readonly ApplyBackfillJob _job;
+        //    private readonly Mock<ILogger<ApplyBackfillJob>> _mockLogger;
+        //    private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        //    private readonly Mock<IEnv> _mockEnv;
+        //    private readonly Mock<IAppSettings> _mockAppSettings;
+        //    private readonly ApplyBackfillJob _job;
 
-        public ApplyBackfillJobTests()
-        {
-            _mockLogger = new Mock<ILogger<ApplyBackfillJob>>();
-            _mockJobClient = new Mock<IBackgroundJobClient>();
-            _mockEnv = new Mock<IEnv>();
-            _mockAppSettings = new Mock<IAppSettings>();
+        //    public ApplyBackfillJobTests()
+        //    {
+        //        _mockLogger = new Mock<ILogger<ApplyBackfillJob>>();
+        //        _mockJobClient = new Mock<IBackgroundJobClient>();
+        //        _mockEnv = new Mock<IEnv>();
+        //        _mockAppSettings = new Mock<IAppSettings>();
 
-            _mockEnv.Setup(m => m.ApplyCandidateApiUrl).Returns("https://test.apply.api/candidates-api");
-            _mockEnv.Setup(m => m.ApplyCandidateApiKey).Returns("1234567");
+        //        _mockEnv.Setup(m => m.ApplyCandidateApiUrl).Returns("https://test.apply.api/candidates-api");
+        //        _mockEnv.Setup(m => m.ApplyCandidateApiKey).Returns("1234567");
 
-            _job = new ApplyBackfillJob(
-                _mockEnv.Object,
-                new Mock<IRedisService>().Object,
-                _mockJobClient.Object,
-                _mockLogger.Object,
-                _mockAppSettings.Object);
-        }
+        //        _job = new ApplyBackfillJob(
+        //            _mockEnv.Object,
+        //            new Mock<IRedisService>().Object,
+        //            _mockJobClient.Object,
+        //            _mockLogger.Object,
+        //            _mockAppSettings.Object);
+        //    }
 
-        [Fact]
-        public void DisableConcurrentExecutionAttribute()
-        {
-            var type = typeof(ApplyBackfillJob);
+        //    [Fact]
+        //    public void DisableConcurrentExecutionAttribute()
+        //    {
+        //        var type = typeof(ApplyBackfillJob);
 
-            type.GetMethod("RunAsync").Should().BeDecoratedWith<DisableConcurrentExecutionAttribute>();
-        }
+        //        type.GetMethod("RunAsync").Should().BeDecoratedWith<DisableConcurrentExecutionAttribute>();
+        //    }
 
-        [Fact]
-        public async void RunAsync_WhenMultiplePagesAvailable_QueuesCandidateJobsForEachPage()
-        {
-            var updatedSince = DateTime.MinValue;
-            var candidates1 = new Candidate[]
-            {
-                new Candidate() { Id = "11111", Attributes = new CandidateAttributes() { Email = "email1@address.com" } },
-            };
-            var candidates2 = new Candidate[]
-            {
-                new Candidate() { Id = "11111", Attributes = new CandidateAttributes() { Email = "email1@address.com" } },
-            };
+        //    [Fact]
+        //    public async void RunAsync_WhenMultiplePagesAvailable_QueuesCandidateJobsForEachPage()
+        //    {
+        //        var updatedSince = DateTime.MinValue;
+        //        var candidates1 = new Candidate[]
+        //        {
+        //            new Candidate() { Id = "11111", Attributes = new CandidateAttributes() { Email = "email1@address.com" } },
+        //        };
+        //        var candidates2 = new Candidate[]
+        //        {
+        //            new Candidate() { Id = "11111", Attributes = new CandidateAttributes() { Email = "email1@address.com" } },
+        //        };
 
-            using (var httpTest = new HttpTest())
-            {
-                MockResponse(httpTest, new Response<IEnumerable<Candidate>>() { Data = candidates1 }, 1, 2);
-                MockResponse(httpTest, new Response<IEnumerable<Candidate>>() { Data = candidates2 }, 2, 2);
-                await _job.RunAsync(updatedSince);
-            }
+        //        using (var httpTest = new HttpTest())
+        //        {
+        //            MockResponse(httpTest, new Response<IEnumerable<Candidate>>() { Data = candidates1 }, 1, 2);
+        //            MockResponse(httpTest, new Response<IEnumerable<Candidate>>() { Data = candidates2 }, 2, 2);
+        //            await _job.RunAsync(updatedSince);
+        //        }
 
-            _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(ApplyCandidateSyncJob) && job.Method.Name == "Run"),
-               It.IsAny<ScheduledState>()), Times.Exactly(candidates1.Length + candidates2.Length));
+        //        _mockJobClient.Verify(x => x.Create(
+        //           It.Is<Job>(job => job.Type == typeof(ApplyCandidateSyncJob) && job.Method.Name == "Run"),
+        //           It.IsAny<ScheduledState>()), Times.Exactly(candidates1.Length + candidates2.Length));
 
-            _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = true, Times.Once);
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Started");
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 1 Candidates");
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 1 Candidates");
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Succeeded");
-            _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = false, Times.Once);
-        }
+        //        _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = true, Times.Once);
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Started");
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 1 Candidates");
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 1 Candidates");
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Succeeded");
+        //        _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = false, Times.Once);
+        //    }
 
-        [Fact]
-        public async void RunAsync_WithNoCandidates_DoesNotQueueJobs()
-        {
-            var updatedSince = DateTime.MinValue;
-            using (var httpTest = new HttpTest())
-            {
-                var response = new Response<IEnumerable<Candidate>>() { Data = Array.Empty<Candidate>() };
-                MockResponse(httpTest, response);
-                await _job.RunAsync(updatedSince);
-            }
+        //    [Fact]
+        //    public async void RunAsync_WithNoCandidates_DoesNotQueueJobs()
+        //    {
+        //        var updatedSince = DateTime.MinValue;
+        //        using (var httpTest = new HttpTest())
+        //        {
+        //            var response = new Response<IEnumerable<Candidate>>() { Data = Array.Empty<Candidate>() };
+        //            MockResponse(httpTest, response);
+        //            await _job.RunAsync(updatedSince);
+        //        }
 
-            _mockJobClient.Verify(x => x.Create(
-               It.Is<Job>(job => job.Type == typeof(ApplyCandidateSyncJob)),
-               It.IsAny<ScheduledState>()), Times.Never);
+        //        _mockJobClient.Verify(x => x.Create(
+        //           It.Is<Job>(job => job.Type == typeof(ApplyCandidateSyncJob)),
+        //           It.IsAny<ScheduledState>()), Times.Never);
 
-            _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = true, Times.Once);
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Started");
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 0 Candidates");
-            _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Succeeded");
-            _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = false, Times.Once);
-        }
+        //        _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = true, Times.Once);
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Started");
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Syncing 0 Candidates");
+        //        _mockLogger.VerifyInformationWasCalled("ApplyBackfillJob - Succeeded");
+        //        _mockAppSettings.VerifySet(m => m.IsApplyBackfillInProgress = false, Times.Once);
+        //    }
 
-        private void MockResponse(HttpTest httpTest, Response<IEnumerable<Candidate>> response, int page = 1, int totalPages = 1)
-        {
-            var json = JsonConvert.SerializeObject(response);
-            var headers = new Dictionary<string, int>() { { "Total-Pages", totalPages }, { "Current-Page", page } };
+        //    private void MockResponse(HttpTest httpTest, Response<IEnumerable<Candidate>> response, int page = 1, int totalPages = 1)
+        //    {
+        //        var json = JsonConvert.SerializeObject(response);
+        //        var headers = new Dictionary<string, int>() { { "Total-Pages", totalPages }, { "Current-Page", page } };
 
-            httpTest
-                    .ForCallsTo($"{_mockEnv.Object.ApplyCandidateApiUrl}/candidates")
-                    .WithVerb("GET")
-                    .WithQueryParam("page", page)
-                    .WithQueryParam("updated_since", DateTime.MinValue)
-                    .WithHeader("Authorization", $"Bearer {_mockEnv.Object.ApplyCandidateApiKey}")
-                    .RespondWith(json, 200, headers);
-        }
+        //        httpTest
+        //                .ForCallsTo($"{_mockEnv.Object.ApplyCandidateApiUrl}/candidates")
+        //                .WithVerb("GET")
+        //                .WithQueryParam("page", page)
+        //                .WithQueryParam("updated_since", DateTime.MinValue)
+        //                .WithHeader("Authorization", $"Bearer {_mockEnv.Object.ApplyCandidateApiKey}")
+        //                .RespondWith(json, 200, headers);
+        //    }
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/ApplyCandidateSyncJobTests.cs
@@ -17,238 +17,238 @@ namespace GetIntoTeachingApiTests.Jobs
 {
     public class ApplyCandidateSyncJobTests
     {
-        private readonly Mock<GetIntoTeachingApi.Models.IAppSettings> _mockAppSettings;
-        private readonly Mock<ILogger<ApplyCandidateSyncJob>> _mockLogger;
-        private readonly Mock<ICrmService> _mockCrm;
-        private readonly Mock<IEnv> _mockEnv;
-        private readonly Mock<IBackgroundJobClient> _mockJobClient;
-        private readonly ApplyCandidateSyncJob _job;
-        private readonly Candidate _candidate;
-        private readonly CandidateAttributes _attributes;
-        private readonly IList<ApplicationForm> _forms;
+        //private readonly Mock<GetIntoTeachingApi.Models.IAppSettings> _mockAppSettings;
+        //private readonly Mock<ILogger<ApplyCandidateSyncJob>> _mockLogger;
+        //private readonly Mock<ICrmService> _mockCrm;
+        //private readonly Mock<IEnv> _mockEnv;
+        //private readonly Mock<IBackgroundJobClient> _mockJobClient;
+        //private readonly ApplyCandidateSyncJob _job;
+        //private readonly Candidate _candidate;
+        //private readonly CandidateAttributes _attributes;
+        //private readonly IList<ApplicationForm> _forms;
 
-        public ApplyCandidateSyncJobTests()
-        {
-            _mockEnv = new Mock<IEnv>();
-            _mockLogger = new Mock<ILogger<ApplyCandidateSyncJob>>();
-            _mockAppSettings = new Mock<GetIntoTeachingApi.Models.IAppSettings>();
-            _mockCrm = new Mock<ICrmService>();
-            _mockJobClient = new Mock<IBackgroundJobClient>();
-            _job = new ApplyCandidateSyncJob(
-                _mockEnv.Object,
-                new Mock<IRedisService>().Object,
-                _mockLogger.Object,
-                _mockCrm.Object,
-                _mockJobClient.Object,
-                _mockAppSettings.Object);
-            _forms = new List<ApplicationForm>()
-            {
-                new ApplicationForm()
-                {
-                    Id = 2,
-                    CreatedAt = new DateTime(2021, 1, 3),
-                    UpdatedAt = new DateTime(2021, 1, 3),
-                    ApplicationStatus = "awaiting_candidate_response",
-                    ApplicationPhase = "apply_1",
-                    RecruitmentCycleYear = 2021,
-                    ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
-                    References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
-                    Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
-                    PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
-                },
-                new ApplicationForm()
-                {
-                    Id = 1,
-                    CreatedAt = new DateTime(2021, 1, 4),
-                    UpdatedAt = new DateTime(2021, 1, 5),
-                    SubmittedAt = new DateTime(2021, 1, 6),
-                    ApplicationStatus = "never_signed_in",
-                    ApplicationPhase = "apply_2",
-                    RecruitmentCycleYear = 2022,
-                    ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
-                    References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
-                    Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
-                    PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
-                },
-            };
-            _attributes = new CandidateAttributes()
-            {
-                Email = "email@address.com",
-                CreatedAt = new DateTime(2021, 1, 1, 10, 0, 0),
-                UpdatedAt = new DateTime(2021, 1, 2, 11, 12, 13),
-                ApplicationForms = _forms,
-            };
-            _candidate = new Candidate()
-            {
-                Id = "12345",
-                Attributes = _attributes
-            };
-        }
+        //public ApplyCandidateSyncJobTests()
+        //{
+        //    _mockEnv = new Mock<IEnv>();
+        //    _mockLogger = new Mock<ILogger<ApplyCandidateSyncJob>>();
+        //    _mockAppSettings = new Mock<GetIntoTeachingApi.Models.IAppSettings>();
+        //    _mockCrm = new Mock<ICrmService>();
+        //    _mockJobClient = new Mock<IBackgroundJobClient>();
+        //    _job = new ApplyCandidateSyncJob(
+        //        _mockEnv.Object,
+        //        new Mock<IRedisService>().Object,
+        //        _mockLogger.Object,
+        //        _mockCrm.Object,
+        //        _mockJobClient.Object,
+        //        _mockAppSettings.Object);
+        //    _forms = new List<ApplicationForm>()
+        //    {
+        //        new ApplicationForm()
+        //        {
+        //            Id = 2,
+        //            CreatedAt = new DateTime(2021, 1, 3),
+        //            UpdatedAt = new DateTime(2021, 1, 3),
+        //            ApplicationStatus = "awaiting_candidate_response",
+        //            ApplicationPhase = "apply_1",
+        //            RecruitmentCycleYear = 2021,
+        //            ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
+        //            References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
+        //            Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
+        //            PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
+        //        },
+        //        new ApplicationForm()
+        //        {
+        //            Id = 1,
+        //            CreatedAt = new DateTime(2021, 1, 4),
+        //            UpdatedAt = new DateTime(2021, 1, 5),
+        //            SubmittedAt = new DateTime(2021, 1, 6),
+        //            ApplicationStatus = "never_signed_in",
+        //            ApplicationPhase = "apply_2",
+        //            RecruitmentCycleYear = 2022,
+        //            ApplicationChoices = new ApplicationResponse<IEnumerable<ApplicationChoice>>() { Completed = false },
+        //            References = new ApplicationResponse<IEnumerable<Reference>>() { Completed = false },
+        //            Qualifications = new ApplicationResponse<IEnumerable<object>>() { Completed = true },
+        //            PersonalStatement = new ApplicationResponse<IEnumerable<object>>() { Completed = null },
+        //        },
+        //    };
+        //    _attributes = new CandidateAttributes()
+        //    {
+        //        Email = "email@address.com",
+        //        CreatedAt = new DateTime(2021, 1, 1, 10, 0, 0),
+        //        UpdatedAt = new DateTime(2021, 1, 2, 11, 12, 13),
+        //        ApplicationForms = _forms,
+        //    };
+        //    _candidate = new Candidate()
+        //    {
+        //        Id = "12345",
+        //        Attributes = _attributes
+        //    };
+        //}
 
-        [Fact]
-        public void Run_OnSuccessWithExistingCandidate_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
-        {
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns(match);
+        //[Fact]
+        //public void Run_OnSuccessWithExistingCandidate_SetsIdAndQueuesUpsertJobForCandidateWithApplicationForms()
+        //{
+        //    var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        //    _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns(match);
 
-            _job.Run(_candidate);
+        //    _job.Run(_candidate);
 
-            var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
-            {
-                ApplyId = _forms[1].Id.ToString(),
-                CreatedAt = _forms[1].CreatedAt,
-                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
-                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
-                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
-                UpdatedAt = _forms[1].UpdatedAt,
-                SubmittedAt = _forms[1].SubmittedAt,
-                ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
-                ReferencesCompleted = _forms[1].References.Completed,
-                PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
-                QualificationsCompleted = _forms[1].Qualifications.Completed,
-            };
+        //    var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+        //    {
+        //        ApplyId = _forms[1].Id.ToString(),
+        //        CreatedAt = _forms[1].CreatedAt,
+        //        PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+        //        StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+        //        RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
+        //        UpdatedAt = _forms[1].UpdatedAt,
+        //        SubmittedAt = _forms[1].SubmittedAt,
+        //        ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
+        //        ReferencesCompleted = _forms[1].References.Completed,
+        //        PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
+        //        QualificationsCompleted = _forms[1].Qualifications.Completed,
+        //    };
 
-            var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
-            {
-                ApplyId = _forms[0].Id.ToString(),
-                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
-                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
-                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
-                CreatedAt = _forms[0].CreatedAt,
-                UpdatedAt = _forms[0].UpdatedAt,
-                SubmittedAt = null,
-                ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
-                ReferencesCompleted = _forms[0].References.Completed,
-                PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
-                QualificationsCompleted = _forms[0].Qualifications.Completed,
-            };
+        //    var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+        //    {
+        //        ApplyId = _forms[0].Id.ToString(),
+        //        PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
+        //        StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
+        //        RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
+        //        CreatedAt = _forms[0].CreatedAt,
+        //        UpdatedAt = _forms[0].UpdatedAt,
+        //        SubmittedAt = null,
+        //        ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
+        //        ReferencesCompleted = _forms[0].References.Completed,
+        //        PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
+        //        QualificationsCompleted = _forms[0].Qualifications.Completed,
+        //    };
 
-            var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
-            {
-                Id = match.Id,
-                ApplyId = _candidate.Id,
-                Email = _attributes.Email,
-                ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
-                ApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
-                ApplyCreatedAt = _attributes.CreatedAt,
-                ApplyUpdatedAt = _attributes.UpdatedAt,
-                ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form2, form1 },
-            };
+        //    var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
+        //    {
+        //        Id = match.Id,
+        //        ApplyId = _candidate.Id,
+        //        Email = _attributes.Email,
+        //        ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+        //        ApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+        //        ApplyCreatedAt = _attributes.CreatedAt,
+        //        ApplyUpdatedAt = _attributes.UpdatedAt,
+        //        ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form2, form1 },
+        //    };
 
-            _mockJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-                IsMatch(candidate, (string)job.Args[0])),
-                It.IsAny<EnqueuedState>()));
+        //    _mockJobClient.Verify(x => x.Create(
+        //        It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+        //        IsMatch(candidate, (string)job.Args[0])),
+        //        It.IsAny<EnqueuedState>()));
 
-            _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Started - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Hit - {_candidate.Id}");
-            _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
-        }
+        //    _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Started - {_candidate.Id}");
+        //    _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Hit - {_candidate.Id}");
+        //    _mockLogger.VerifyInformationWasCalled($"ApplyCandidateSyncJob - Succeeded - {_candidate.Id}");
+        //}
 
-        [Fact]
-        public void Run_OnSuccessWithNewCandidate_SetsChannelAndQueuesUpsertJobForCandidateWithApplicationForms()
-        {
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns<Candidate>(null);
+        //[Fact]
+        //public void Run_OnSuccessWithNewCandidate_SetsChannelAndQueuesUpsertJobForCandidateWithApplicationForms()
+        //{
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        //    _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, null)).Returns<Candidate>(null);
 
-            _job.Run(_candidate);
+        //    _job.Run(_candidate);
 
-            var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
-            {
-                ApplyId = _forms[1].Id.ToString(),
-                CreatedAt = _forms[1].CreatedAt,
-                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
-                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
-                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
-                UpdatedAt = _forms[1].UpdatedAt,
-                SubmittedAt = _forms[1].SubmittedAt,
-                ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
-                ReferencesCompleted = _forms[1].References.Completed,
-                PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
-                QualificationsCompleted = _forms[1].Qualifications.Completed,
-            };
+        //    var form1 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+        //    {
+        //        ApplyId = _forms[1].Id.ToString(),
+        //        CreatedAt = _forms[1].CreatedAt,
+        //        PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+        //        StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+        //        RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2022,
+        //        UpdatedAt = _forms[1].UpdatedAt,
+        //        SubmittedAt = _forms[1].SubmittedAt,
+        //        ApplicationChoicesCompleted = _forms[1].ApplicationChoices.Completed,
+        //        ReferencesCompleted = _forms[1].References.Completed,
+        //        PersonalStatementCompleted = _forms[1].PersonalStatement.Completed,
+        //        QualificationsCompleted = _forms[1].Qualifications.Completed,
+        //    };
 
-            var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
-            {
-                ApplyId = _forms[0].Id.ToString(),
-                PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
-                StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
-                RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
-                CreatedAt = _forms[0].CreatedAt,
-                UpdatedAt = _forms[0].UpdatedAt,
-                SubmittedAt = null,
-                ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
-                ReferencesCompleted = _forms[0].References.Completed,
-                PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
-                QualificationsCompleted = _forms[0].Qualifications.Completed,
-            };
+        //    var form2 = new GetIntoTeachingApi.Models.Crm.ApplicationForm()
+        //    {
+        //        ApplyId = _forms[0].Id.ToString(),
+        //        PhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply1,
+        //        StatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.AwaitingCandidateResponse,
+        //        RecruitmentCycleYearId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.RecruitmentCycleYear.Year2021,
+        //        CreatedAt = _forms[0].CreatedAt,
+        //        UpdatedAt = _forms[0].UpdatedAt,
+        //        SubmittedAt = null,
+        //        ApplicationChoicesCompleted = _forms[0].ApplicationChoices.Completed,
+        //        ReferencesCompleted = _forms[0].References.Completed,
+        //        PersonalStatementCompleted = _forms[0].PersonalStatement.Completed,
+        //        QualificationsCompleted = _forms[0].Qualifications.Completed,
+        //    };
 
-            var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
-            {
-                ApplyId = _candidate.Id,
-                Email = _attributes.Email,
-                ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
-                ApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
-                ApplyCreatedAt = _attributes.CreatedAt,
-                ApplyUpdatedAt = _attributes.UpdatedAt,
-                ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form2, form1 },
-                ChannelId = (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining,
-            };
+        //    var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
+        //    {
+        //        ApplyId = _candidate.Id,
+        //        Email = _attributes.Email,
+        //        ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+        //        ApplyPhaseId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Phase.Apply2,
+        //        ApplyCreatedAt = _attributes.CreatedAt,
+        //        ApplyUpdatedAt = _attributes.UpdatedAt,
+        //        ApplicationForms = new List<GetIntoTeachingApi.Models.Crm.ApplicationForm>() { form2, form1 },
+        //        ChannelId = (int)GetIntoTeachingApi.Models.Crm.Candidate.Channel.ApplyForTeacherTraining,
+        //    };
 
-            _mockJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-                IsMatch(candidate, (string)job.Args[0])),
-                It.IsAny<EnqueuedState>()));
-        }
+        //    _mockJobClient.Verify(x => x.Create(
+        //        It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+        //        IsMatch(candidate, (string)job.Args[0])),
+        //        It.IsAny<EnqueuedState>()));
+        //}
 
-        [Fact]
-        public void Run_WhenApplyIdMatchbackFeatureIsOn_MatchesBackOnApplyIdAsWellAsEmailAndWritesApplyEmailToSecondaryEmail()
-        {
-            _mockEnv.Setup(m => m.IsFeatureOn("APPLY_ID_MATCHBACK")).Returns(true);
+        //[Fact]
+        //public void Run_WhenApplyIdMatchbackFeatureIsOn_MatchesBackOnApplyIdAsWellAsEmailAndWritesApplyEmailToSecondaryEmail()
+        //{
+        //    _mockEnv.Setup(m => m.IsFeatureOn("APPLY_ID_MATCHBACK")).Returns(true);
 
-            var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
-            _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns(match);
-            _candidate.Attributes.ApplicationForms = Array.Empty<ApplicationForm>();
+        //    var match = new GetIntoTeachingApi.Models.Crm.Candidate() { Id = Guid.NewGuid(), Email = "different@email.com" };
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        //    _mockCrm.Setup(m => m.MatchCandidate(_candidate.Attributes.Email, _candidate.Id)).Returns(match);
+        //    _candidate.Attributes.ApplicationForms = Array.Empty<ApplicationForm>();
 
-            _job.Run(_candidate);
+        //    _job.Run(_candidate);
 
-            var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
-            {
-                Id = match.Id,
-                ApplyId = _candidate.Id,
-                Email = _attributes.Email,
-                SecondaryEmail = _candidate.Attributes.Email,
-                ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
-                ApplyCreatedAt = _attributes.CreatedAt,
-                ApplyUpdatedAt = _attributes.UpdatedAt,
-            };
+        //    var candidate = new GetIntoTeachingApi.Models.Crm.Candidate()
+        //    {
+        //        Id = match.Id,
+        //        ApplyId = _candidate.Id,
+        //        Email = _attributes.Email,
+        //        SecondaryEmail = _candidate.Attributes.Email,
+        //        ApplyStatusId = (int)GetIntoTeachingApi.Models.Crm.ApplicationForm.Status.NeverSignedIn,
+        //        ApplyCreatedAt = _attributes.CreatedAt,
+        //        ApplyUpdatedAt = _attributes.UpdatedAt,
+        //    };
 
-            _mockJobClient.Verify(x => x.Create(
-                It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
-                IsMatch(candidate, (string)job.Args[0])),
-                It.IsAny<EnqueuedState>()));
+        //    _mockJobClient.Verify(x => x.Create(
+        //        It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
+        //        IsMatch(candidate, (string)job.Args[0])),
+        //        It.IsAny<EnqueuedState>()));
 
-            _mockCrm.VerifyAll();
-        }
+        //    _mockCrm.VerifyAll();
+        //}
 
-        [Fact]
-        public void Run_WhenCrmIntegrationPaused_Aborts()
-        {
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+        //[Fact]
+        //public void Run_WhenCrmIntegrationPaused_Aborts()
+        //{
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
 
-            Action action = () => _job.Run(_candidate);
+        //    Action action = () => _job.Run(_candidate);
 
-            action.Should().Throw<InvalidOperationException>()
-                .WithMessage("ApplyCandidateSyncJob - Aborting (CRM integration paused).");
-        }
+        //    action.Should().Throw<InvalidOperationException>()
+        //        .WithMessage("ApplyCandidateSyncJob - Aborting (CRM integration paused).");
+        //}
 
-        private static bool IsMatch(GetIntoTeachingApi.Models.Crm.Candidate candidateA, string candidateBJson)
-        {
-            var candidateB = candidateBJson.DeserializeChangeTracked<GetIntoTeachingApi.Models.Crm.Candidate>();
-            candidateA.Should().BeEquivalentTo(candidateB);
-            return true;
-        }
+        //private static bool IsMatch(GetIntoTeachingApi.Models.Crm.Candidate candidateA, string candidateBJson)
+        //{
+        //    var candidateB = candidateBJson.DeserializeChangeTracked<GetIntoTeachingApi.Models.Crm.Candidate>();
+        //    candidateA.Should().BeEquivalentTo(candidateB);
+        //    return true;
+        //}
     }
 }

--- a/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
+++ b/GetIntoTeachingApiTests/Jobs/UpsertApplicationFormJobTests.cs
@@ -16,152 +16,152 @@ namespace GetIntoTeachingApiTests.Jobs
 {
     public class UpsertApplicationFormJobTests
     {
-        private readonly Mock<IPerformContextAdapter> _mockContext;
-        private readonly Mock<IAppSettings> _mockAppSettings;
-        private readonly Mock<ICrmService> _mockCrm;
-        private readonly ApplicationForm _form;
-        private readonly ApplicationReference _reference;
-        private readonly ApplicationChoice _choice;
-        private readonly ApplicationInterview _interview;
-        private readonly IMetricService _metrics;
-        private readonly UpsertApplicationFormJob _job;
-        private readonly Mock<ILogger<UpsertApplicationFormJob>> _mockLogger;
+        //private readonly Mock<IPerformContextAdapter> _mockContext;
+        //private readonly Mock<IAppSettings> _mockAppSettings;
+        //private readonly Mock<ICrmService> _mockCrm;
+        //private readonly ApplicationForm _form;
+        //private readonly ApplicationReference _reference;
+        //private readonly ApplicationChoice _choice;
+        //private readonly ApplicationInterview _interview;
+        //private readonly IMetricService _metrics;
+        //private readonly UpsertApplicationFormJob _job;
+        //private readonly Mock<ILogger<UpsertApplicationFormJob>> _mockLogger;
 
-        public UpsertApplicationFormJobTests()
-        {
-            _mockContext = new Mock<IPerformContextAdapter>();
-            _mockLogger = new Mock<ILogger<UpsertApplicationFormJob>>();
-            _mockAppSettings = new Mock<IAppSettings>();
-            _mockCrm = new Mock<ICrmService>();
-            _metrics = new MetricService();
-            _job = new UpsertApplicationFormJob(
-                new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _metrics, _mockCrm.Object,
-                _mockLogger.Object, _mockAppSettings.Object);
+        //public UpsertApplicationFormJobTests()
+        //{
+        //    _mockContext = new Mock<IPerformContextAdapter>();
+        //    _mockLogger = new Mock<ILogger<UpsertApplicationFormJob>>();
+        //    _mockAppSettings = new Mock<IAppSettings>();
+        //    _mockCrm = new Mock<ICrmService>();
+        //    _metrics = new MetricService();
+        //    _job = new UpsertApplicationFormJob(
+        //        new Env(), new Mock<IRedisService>().Object, _mockContext.Object, _metrics, _mockCrm.Object,
+        //        _mockLogger.Object, _mockAppSettings.Object);
 
-            _metrics.HangfireJobQueueDuration.RemoveLabelled("UpsertApplicationFormJob");
-            _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
+        //    _metrics.HangfireJobQueueDuration.RemoveLabelled("UpsertApplicationFormJob");
+        //    _mockContext.Setup(m => m.GetJobCreatedAt(null)).Returns(DateTime.UtcNow.AddDays(-1));
 
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(false);
 
-            _reference = new ApplicationReference() { ApplyId = "2" };
-            _interview = new ApplicationInterview() { ApplyId = "4" };
-            _choice = new ApplicationChoice() { ApplyId = "3", Interviews = new List<ApplicationInterview> { _interview } };
-            _form = new ApplicationForm()
-            {
-                ApplyId = "1",
-                References = new List<ApplicationReference> { _reference },
-                Choices = new List<ApplicationChoice> { _choice },
-            };
-        }
+        //    _reference = new ApplicationReference() { ApplyId = "2" };
+        //    _interview = new ApplicationInterview() { ApplyId = "4" };
+        //    _choice = new ApplicationChoice() { ApplyId = "3", Interviews = new List<ApplicationInterview> { _interview } };
+        //    _form = new ApplicationForm()
+        //    {
+        //        ApplyId = "1",
+        //        References = new List<ApplicationReference> { _reference },
+        //        Choices = new List<ApplicationChoice> { _choice },
+        //    };
+        //}
 
-        [Fact]
-        public void Run_OnSuccessWithNewModels_InsertsApplicationFormAndRelatedModels()
-        {
-            var formId = Guid.NewGuid();
-            var choiceId = Guid.NewGuid();
-            var referenceId = Guid.NewGuid();
-            var interviewId = Guid.NewGuid();
+        //[Fact]
+        //public void Run_OnSuccessWithNewModels_InsertsApplicationFormAndRelatedModels()
+        //{
+        //    var formId = Guid.NewGuid();
+        //    var choiceId = Guid.NewGuid();
+        //    var referenceId = Guid.NewGuid();
+        //    var interviewId = Guid.NewGuid();
 
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+        //    _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
 
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationForm>(new[] { _form.ApplyId })).Returns(Array.Empty<ApplicationForm>());
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationChoice>(new[] { _choice.ApplyId })).Returns(Array.Empty<ApplicationChoice>());
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationInterview>(new[] { _interview.ApplyId })).Returns(Array.Empty<ApplicationInterview>());
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationReference>(new[] { _reference.ApplyId })).Returns(Array.Empty<ApplicationReference>());
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationForm>(new[] { _form.ApplyId })).Returns(Array.Empty<ApplicationForm>());
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationChoice>(new[] { _choice.ApplyId })).Returns(Array.Empty<ApplicationChoice>());
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationInterview>(new[] { _interview.ApplyId })).Returns(Array.Empty<ApplicationInterview>());
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationReference>(new[] { _reference.ApplyId })).Returns(Array.Empty<ApplicationReference>());
 
-            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationForm>())).Callback<BaseModel>(f => f.Id = formId);
-            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationChoice>())).Callback<BaseModel>(c => c.Id = choiceId);
-            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationInterview>())).Callback<BaseModel>(i => i.Id = interviewId);
-            _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationReference>())).Callback<BaseModel>(r => r.Id = referenceId);
+        //    _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationForm>())).Callback<BaseModel>(f => f.Id = formId);
+        //    _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationChoice>())).Callback<BaseModel>(c => c.Id = choiceId);
+        //    _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationInterview>())).Callback<BaseModel>(i => i.Id = interviewId);
+        //    _mockCrm.Setup(m => m.Save(It.IsAny<ApplicationReference>())).Callback<BaseModel>(r => r.Id = referenceId);
 
-            var json = _form.SerializeChangeTracked();
-            _job.Run(json, null);
+        //    var json = _form.SerializeChangeTracked();
+        //    _job.Run(json, null);
 
-            _form.Id = formId;
-            _choice.Id = choiceId;
-            _choice.ApplicationFormId = formId;
-            _interview.Id = interviewId;
-            _interview.ApplicationChoiceId = choiceId;
-            _reference.Id = referenceId;
-            _reference.ApplicationFormId = formId;
+        //    _form.Id = formId;
+        //    _choice.Id = choiceId;
+        //    _choice.ApplicationFormId = formId;
+        //    _interview.Id = interviewId;
+        //    _interview.ApplicationChoiceId = choiceId;
+        //    _reference.Id = referenceId;
+        //    _reference.ApplicationFormId = formId;
 
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
 
-            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (1/24)");
-            _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Payload {Redactor.RedactJson(json)}");
-            _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Succeeded - {_form.Id}");
-            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
-        }
+        //    _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (1/24)");
+        //    _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Payload {Redactor.RedactJson(json)}");
+        //    _mockLogger.VerifyInformationWasCalled($"UpsertApplicationFormJob - Succeeded - {_form.Id}");
+        //    _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
+        //}
 
-        [Fact]
-        public void Run_OnSuccessWithExistingModels_UpdatesApplicationFormAndRelatedModels()
-        {
-            var formId = Guid.NewGuid();
-            var choiceId = Guid.NewGuid();
-            var referenceId = Guid.NewGuid();
-            var interviewId = Guid.NewGuid();
+        //[Fact]
+        //public void Run_OnSuccessWithExistingModels_UpdatesApplicationFormAndRelatedModels()
+        //{
+        //    var formId = Guid.NewGuid();
+        //    var choiceId = Guid.NewGuid();
+        //    var referenceId = Guid.NewGuid();
+        //    var interviewId = Guid.NewGuid();
 
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
+        //    _mockContext.Setup(m => m.GetRetryCount(null)).Returns(0);
 
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationForm>(new[] { _form.ApplyId }))
-                .Returns(new[] { new ApplicationForm() { Id = formId, ApplyId = _form.ApplyId } });
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationChoice>(new[] { _choice.ApplyId }))
-                .Returns(new[] { new ApplicationChoice() { Id = choiceId, ApplyId = _choice.ApplyId } });
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationInterview>(new[] { _interview.ApplyId }))
-                .Returns(new[] { new ApplicationInterview() { Id = interviewId, ApplyId = _interview.ApplyId } });
-            _mockCrm.Setup(m => m.GetApplyModels<ApplicationReference>(new[] { _reference.ApplyId }))
-                .Returns(new[] { new ApplicationReference() { Id = referenceId, ApplyId = _reference.ApplyId } });
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationForm>(new[] { _form.ApplyId }))
+        //        .Returns(new[] { new ApplicationForm() { Id = formId, ApplyId = _form.ApplyId } });
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationChoice>(new[] { _choice.ApplyId }))
+        //        .Returns(new[] { new ApplicationChoice() { Id = choiceId, ApplyId = _choice.ApplyId } });
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationInterview>(new[] { _interview.ApplyId }))
+        //        .Returns(new[] { new ApplicationInterview() { Id = interviewId, ApplyId = _interview.ApplyId } });
+        //    _mockCrm.Setup(m => m.GetApplyModels<ApplicationReference>(new[] { _reference.ApplyId }))
+        //        .Returns(new[] { new ApplicationReference() { Id = referenceId, ApplyId = _reference.ApplyId } });
 
-            var json = _form.SerializeChangeTracked();
-            _job.Run(json, null);
+        //    var json = _form.SerializeChangeTracked();
+        //    _job.Run(json, null);
 
-            _form.Id = formId;
-            _choice.Id = choiceId;
-            _choice.ApplicationFormId = formId;
-            _interview.Id = interviewId;
-            _interview.ApplicationChoiceId = choiceId;
-            _reference.Id = referenceId;
-            _reference.ApplicationFormId = formId;
+        //    _form.Id = formId;
+        //    _choice.Id = choiceId;
+        //    _choice.ApplicationFormId = formId;
+        //    _interview.Id = interviewId;
+        //    _interview.ApplicationChoiceId = choiceId;
+        //    _reference.Id = referenceId;
+        //    _reference.ApplicationFormId = formId;
 
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
-            _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
-        }
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationForm>(f => IsMatch(_form, f))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationChoice>(c => IsMatch(_choice, c))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationInterview>(i => IsMatch(_interview, i))), Times.Once);
+        //    _mockCrm.Verify(mock => mock.Save(It.Is<ApplicationReference>(r => IsMatch(_reference, r))), Times.Once);
+        //}
 
-        [Fact]
-        public void Run_OnFailure_Logs()
-        {
-            _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
+        //[Fact]
+        //public void Run_OnFailure_Logs()
+        //{
+        //    _mockContext.Setup(m => m.GetRetryCount(null)).Returns(23);
 
-            _job.Run(_form.SerializeChangeTracked(), null);
+        //    _job.Run(_form.SerializeChangeTracked(), null);
 
-            _mockCrm.Verify(mock => mock.Save(It.IsAny<ApplicationForm>()), Times.Never);
+        //    _mockCrm.Verify(mock => mock.Save(It.IsAny<ApplicationForm>()), Times.Never);
 
-            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (24/24)");
-            _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Deleted");
-            _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
-        }
+        //    _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Started (24/24)");
+        //    _mockLogger.VerifyInformationWasCalled("UpsertApplicationFormJob - Deleted");
+        //    _metrics.HangfireJobQueueDuration.WithLabels("UpsertApplicationFormJob").Count.Should().Be(1);
+        //}
 
-        [Fact]
-        public void Run_WhenCrmIntegrationPaused_Aborts()
-        {
-            _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
+        //[Fact]
+        //public void Run_WhenCrmIntegrationPaused_Aborts()
+        //{
+        //    _mockAppSettings.Setup(m => m.IsCrmIntegrationPaused).Returns(true);
 
-            var json = _form.SerializeChangeTracked();
-            Action action = () => _job.Run(json, null);
+        //    var json = _form.SerializeChangeTracked();
+        //    Action action = () => _job.Run(json, null);
 
-            action.Should().Throw<InvalidOperationException>()
-                .WithMessage("UpsertApplicationFormJob - Aborting (CRM integration paused).");
-        }
+        //    action.Should().Throw<InvalidOperationException>()
+        //        .WithMessage("UpsertApplicationFormJob - Aborting (CRM integration paused).");
+        //}
 
-        private static bool IsMatch(object objectA, object objectB)
-        {
-            objectA.Should().BeEquivalentTo(objectB);
-            return true;
-        }
+        //private static bool IsMatch(object objectA, object objectB)
+        //{
+        //    objectA.Should().BeEquivalentTo(objectB);
+        //    return true;
+        //}
     }
 }


### PR DESCRIPTION
There is an issue in production where the Apply jobs are getting re-queued continuously by a failing bulk job; making the apply jobs empty will let the runners clear them down.