### PR TITLE
Daisy-chain ApplyBackfillJob

### DIFF
--- a/GetIntoTeachingApi/Controllers/OperationsController.cs
+++ b/GetIntoTeachingApi/Controllers/OperationsController.cs
@@ -143,7 +143,7 @@ namespace GetIntoTeachingApi.Controllers
                 return BadRequest("Backfill already in progress");
             }
 
-            _jobClient.Enqueue<ApplyBackfillJob>((x) => x.RunAsync(updatedSince));
+            _jobClient.Enqueue<ApplyBackfillJob>((x) => x.RunAsync(updatedSince, 1));
 
             return NoContent();
         }

--- a/GetIntoTeachingApi/Jobs/ApplyBackfillJob.cs
+++ b/GetIntoTeachingApi/Jobs/ApplyBackfillJob.cs
@@ -4,18 +4,22 @@ using System.Linq;
 using System.Threading.Tasks;
 using Flurl;
 using Flurl.Http;
+using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Apply;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
 using Hangfire;
+using Hangfire.Server;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
 
 namespace GetIntoTeachingApi.Jobs
 {
+    [AutomaticRetry(Attempts = 0)]
     public class ApplyBackfillJob : BaseJob
     {
+        public static readonly int PagesPerJob = 10;
         private readonly IBackgroundJobClient _jobClient;
         private readonly ILogger<ApplyBackfillJob> _logger;
         private readonly IAppSettings _appSettings;
@@ -34,29 +38,41 @@ namespace GetIntoTeachingApi.Jobs
         }
 
         [DisableConcurrentExecution(timeoutInSeconds: 60 * 60)]
-        public async Task RunAsync(DateTime updatedSince)
+        public async Task RunAsync(DateTime updatedSince, int startPage = 1)
         {
             _appSettings.IsApplyBackfillInProgress = true;
-            _logger.LogInformation("ApplyBackfillJob - Started");
-            await QueueCandidateSyncJobs(updatedSince);
-            _logger.LogInformation("ApplyBackfillJob - Succeeded");
+            _logger.LogInformation("ApplyBackfillJob - Started - Pages {StartPage} to {EndPage}", startPage, EndPage(startPage));
+            await QueueCandidateSyncJobs(updatedSince, startPage);
+            _logger.LogInformation("ApplyBackfillJob - Succeeded - Pages {StartPage} to {EndPage}", startPage, EndPage(startPage));
             _appSettings.IsApplyBackfillInProgress = false;
         }
 
-        private async Task QueueCandidateSyncJobs(DateTime updatedSince)
+        private static int EndPage(int startPage)
+        {
+            return startPage + PagesPerJob - 1;
+        }
+
+        private async Task QueueCandidateSyncJobs(DateTime updatedSince, int startPage)
         {
             var request = Env.ApplyCandidateApiUrl
                 .AppendPathSegment("candidates")
                 .SetQueryParam("updated_since", updatedSince)
                 .WithOAuthBearerToken(Env.ApplyCandidateApiKey);
 
-            var paginator = new PaginatorClient<Response<IEnumerable<Candidate>>>(request);
+            var paginator = new PaginatorClient<Response<IEnumerable<Candidate>>>(request, startPage);
 
-            while (paginator.HasNext)
+            while (paginator.HasNext && paginator.Page <= EndPage(startPage))
             {
                 var response = await paginator.NextAsync();
                 _logger.LogInformation("ApplyBackfillJob - Syncing {Count} Candidates", response.Data.Count());
-                response.Data.ForEach(c => _jobClient.Schedule<ApplyCandidateSyncJob>(x => x.Run(c), TimeSpan.FromMinutes(30)));
+                response.Data.ForEach(c => _jobClient.Schedule<ApplyCandidateSyncJob>(x => x.Run(c), TimeSpan.FromHours(2)));
+            }
+
+            // When we reach the end page we re-queue the backfill job
+            // to process the next batch of pages.
+            if (paginator.HasNext)
+            {
+                _jobClient.Enqueue<ApplyBackfillJob>((x) => x.RunAsync(updatedSince, paginator.Page));
             }
         }
     }

--- a/GetIntoTeachingApi/Jobs/BaseJob.cs
+++ b/GetIntoTeachingApi/Jobs/BaseJob.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
-using System.Text;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;

--- a/GetIntoTeachingApi/Services/IPaginatorClient.cs
+++ b/GetIntoTeachingApi/Services/IPaginatorClient.cs
@@ -6,5 +6,6 @@ namespace GetIntoTeachingApi.Services
     {
         Task<T> NextAsync();
         bool HasNext { get; }
+        int Page { get; }
     }
 }

--- a/GetIntoTeachingApi/Services/PaginatorClient.cs
+++ b/GetIntoTeachingApi/Services/PaginatorClient.cs
@@ -8,7 +8,7 @@ namespace GetIntoTeachingApi.Services
     {
         private readonly IFlurlRequest _request;
         private bool _hasNext;
-        private int _page;
+        public int Page { get; private set; }
 
         public bool HasNext
         {
@@ -18,17 +18,17 @@ namespace GetIntoTeachingApi.Services
             }
         }
 
-        public PaginatorClient(IFlurlRequest request)
+        public PaginatorClient(IFlurlRequest request, int startPage = 1)
         {
             _request = request;
             _hasNext = true;
-            _page = 1;
+            Page = startPage;
         }
 
         public async Task<T> NextAsync()
         {
             var response = await _request
-                .SetQueryParam("page", _page)
+                .SetQueryParam("page", Page)
                 .GetAsync();
             var headers = response.Headers;
 
@@ -41,7 +41,7 @@ namespace GetIntoTeachingApi.Services
             var currentPage = headers.FirstOrDefault("Current-Page");
             _hasNext = currentPage != totalPages;
 
-            _page++;
+            Page++;
 
             return await response.GetJsonAsync<T>();
         }

--- a/GetIntoTeachingApiTests/Services/PaginatorClientTests.cs
+++ b/GetIntoTeachingApiTests/Services/PaginatorClientTests.cs
@@ -12,14 +12,49 @@ namespace GetIntoTeachingApiTests.Services
     public class PaginatorClientTests
     {
         private readonly IPaginatorClient<string> _paginator;
+        private readonly IFlurlRequest _request;
 
         public PaginatorClientTests()
         {
-            var request = "https://test.com"
+            _request = "https://test.com"
                .AppendPathSegment("data")
                .WithOAuthBearerToken("abc-123");
 
-            _paginator = new PaginatorClient<string>(request);
+            _paginator = new PaginatorClient<string>(_request);
+        }
+
+
+        [Fact]
+        public async void Constructot_WithCustomStartPage()
+        {
+            var paginator = new PaginatorClient<string>(_request, 2);
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 2 data", 2, 3);
+            MockResponse(httpTest, "page 3 data", 3, 3);
+
+            paginator.Page.Should().Be(2);
+
+            await paginator.NextAsync();
+
+            paginator.Page.Should().Be(3);
+        }
+
+        [Fact]
+        public async void Page_Increments()
+        {
+            using var httpTest = new HttpTest();
+            MockResponse(httpTest, "page 1 data", 1, 2);
+            MockResponse(httpTest, "page 2 data", 2, 2);
+
+            _paginator.Page.Should().Be(1);
+
+            await _paginator.NextAsync();
+
+            _paginator.Page.Should().Be(2);
+
+            await _paginator.NextAsync();
+
+            _paginator.Page.Should().Be(3);
         }
 
         [Fact]


### PR DESCRIPTION
When we ran the `ApplyBackfillJob` in production it took longer than 30 minutes to complete and resulted in the job timing out and retrying (which reqeueud a high number of duplicate jobs).

As the Apply candidate API does not let us query a date range we are instead going to chain the backfill jobs so that each one processes a subset of pages and re-queues for the next set. Whilst we could do this concurrently we want to avoid putting too much load on the Apply candidate API, so sequentially is a better fit.

The delay in processing the queued `ApplyCandidateSyncJob` has also been increased to two hours, which should let us more easily monitor the backfill job progress.