### PR TITLE
Disable Hanfire Prometheus metrics exporter

### DIFF
--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Utils
         public bool IsStaging => EnvironmentName == "Staging";
         public bool IsTest => EnvironmentName == "Test";
         public string GitCommitSha => Environment.GetEnvironmentVariable("GIT_COMMIT_SHA");
-        public bool ExportHangireToPrometheus => InstanceIndex == "0";
+        public bool ExportHangireToPrometheus => false;
         public string InstanceIndex => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Theory]
-        [InlineData("0", true)]
+        [InlineData("0", false)]
         [InlineData("1", false)]
         [InlineData("10", false)]
         public void ExportHangfireToPrometheus_TrueOnlyForFirstInstance(string instance, bool expected)


### PR DESCRIPTION
[Trello-4378](https://trello.com/c/v7zsQVLT/4378-fix-slow-production-db-issues)

We recently performed an Apply backfill in production which has resulted in many more records being in the database than usual. The logs indicate the Hangfire exporter is perhaps running an inefficient query and flooding the database with requests it can't keep up with.

Disable Hangfire Prometheus exporter in all environments.
