### PR TITLE
Add logging to track TTA sign ups

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -65,6 +65,8 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
             string json = request.Candidate.SerializeChangeTracked();
             _jobClient.Enqueue<UpsertCandidateJob>((x) => x.Run(json, null));
 
+            _logger.LogInformation("TeacherTrainingAdviser - CandidatesController - Sign Up - {Client}", User.Identity.Name);
+
             return NoContent();
         }
 

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -117,6 +117,8 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
                 It.Is<Job>(job => job.Type == typeof(UpsertCandidateJob) && job.Method.Name == "Run" &&
                 IsMatch(request.Candidate, (string)job.Args[0])),
                 It.IsAny<EnqueuedState>()));
+
+            _mockLogger.VerifyInformationWasCalled("TeacherTrainingAdviser - CandidatesController - Sign Up - TTA");
         }
 
         [Fact]


### PR DESCRIPTION
We can't currently differentiate between TTA sign ups from the get an adviser service and apply; adding this log line for a quick way to track the sign ups on rolling out the feature.