### PR TITLE
Disable Hangfire dashboard in production

### DIFF
--- a/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
+++ b/GetIntoTeachingApi/Auth/HangfireDashboardEnvironmentAuthorizationFilter.cs
@@ -15,7 +15,7 @@ namespace GetIntoTeachingApi.Auth
 
         public bool Authorize(DashboardContext context)
         {
-            return new[] { "Development", "Staging", "Production" }.Contains(_env.EnvironmentName);
+            return new[] { "Development", "Staging" }.Contains(_env.EnvironmentName);
         }
     }
 }

--- a/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
+++ b/GetIntoTeachingApiTests/Auth/HangfireDashboardEnvironmentAuthorizationFilterTests.cs
@@ -34,11 +34,11 @@ namespace GetIntoTeachingApiTests.Auth
         }
 
         [Fact]
-        public void Authorize_Production_IsTrue()
+        public void Authorize_Production_IsFalse()
         {
             _mockEnv.Setup(m => m.EnvironmentName).Returns("Production");
 
-            _filter.Authorize(null).Should().BeTrue();
+            _filter.Authorize(null).Should().BeFalse();
         }
 
         [Theory]


### PR DESCRIPTION
[Trello-4412](https://trello.com/c/MxAmntgn/4412-disable-hangfire-dashboard-in-production)

We enabled this (behind basic auth) to more easily monitor the Apply backfill job. Re-disabling it now that's finished.