### PR TITLE
Revert "Disable Hanfire Prometheus metrics exporter"

### DIFF
--- a/GetIntoTeachingApi/Utils/Env.cs
+++ b/GetIntoTeachingApi/Utils/Env.cs
@@ -12,7 +12,7 @@ namespace GetIntoTeachingApi.Utils
         public bool IsStaging => EnvironmentName == "Staging";
         public bool IsTest => EnvironmentName == "Test";
         public string GitCommitSha => Environment.GetEnvironmentVariable("GIT_COMMIT_SHA");
-        public bool ExportHangireToPrometheus => false;
+        public bool ExportHangireToPrometheus => InstanceIndex == "0";
         public string InstanceIndex => Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX");
         public string DatabaseInstanceName => Environment.GetEnvironmentVariable("DATABASE_INSTANCE_NAME");
         public string HangfireInstanceName => Environment.GetEnvironmentVariable("HANGFIRE_INSTANCE_NAME");

--- a/GetIntoTeachingApiTests/Utils/EnvTests.cs
+++ b/GetIntoTeachingApiTests/Utils/EnvTests.cs
@@ -26,7 +26,7 @@ namespace GetIntoTeachingApiTests.Utils
         }
 
         [Theory]
-        [InlineData("0", false)]
+        [InlineData("0", true)]
         [InlineData("1", false)]
         [InlineData("10", false)]
         public void ExportHangfireToPrometheus_TrueOnlyForFirstInstance(string instance, bool expected)


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#1209

I think this was just an issue due to the unusually high volumes of jobs we queued up during the recent Apply backfill operation; reverting it so we get job metrics back in production.