### PR TITLE
Require first name on matchback

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -7,6 +7,7 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public ExistingCandidateRequestValidator()
         {
+            RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
         }
     }

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new ExistingCandidateRequest { Email = "email@address.com" };
+            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "First" };
 
             var result = _validator.TestValidate(request);
 
@@ -50,6 +50,14 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = $"{new string('a', 50)}@{new string('a', 50)}.com" });
 
             result.ShouldHaveValidationErrorFor(r => r.Email);
+        }
+
+        [Fact]
+        public void Validate_FirstNameIsEmpty_HasError()
+        {
+            var result = _validator.TestValidate(new ExistingCandidateRequest() { FirstName = "" });
+
+            result.ShouldHaveValidationErrorFor(r => r.FirstName);
         }
     }
 }


### PR DESCRIPTION
[Trello-4372](https://trello.com/c/iDqBrbp4/4372-clean-up-existingcandidaterequest-model)

We only use the email address in the matchback logic itself, but we reference the candidate by their first name in the email that we send out with their access code; we need to retain this field/ensure make it mandatory.