### PR TITLE
Revert "Require first name on matchback"

### DIFF
--- a/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
+++ b/GetIntoTeachingApi/Models/Validators/ExistingCandidateRequestValidator.cs
@@ -7,7 +7,6 @@ namespace GetIntoTeachingApi.Models.Validators
     {
         public ExistingCandidateRequestValidator()
         {
-            RuleFor(request => request.FirstName).NotEmpty();
             RuleFor(request => request.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
         }
     }

--- a/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Validators/ExistingCandidateRequestValidatorTests.cs
@@ -20,7 +20,7 @@ namespace GetIntoTeachingApiTests.Models.Validators
         [Fact]
         public void Validate_WhenValid_HasNoErrors()
         {
-            var request = new ExistingCandidateRequest { Email = "email@address.com", FirstName = "First" };
+            var request = new ExistingCandidateRequest { Email = "email@address.com" };
 
             var result = _validator.TestValidate(request);
 
@@ -50,14 +50,6 @@ namespace GetIntoTeachingApiTests.Models.Validators
             var result = _validator.TestValidate(new ExistingCandidateRequest() { Email = $"{new string('a', 50)}@{new string('a', 50)}.com" });
 
             result.ShouldHaveValidationErrorFor(r => r.Email);
-        }
-
-        [Fact]
-        public void Validate_FirstNameIsEmpty_HasError()
-        {
-            var result = _validator.TestValidate(new ExistingCandidateRequest() { FirstName = "" });
-
-            result.ShouldHaveValidationErrorFor(r => r.FirstName);
         }
     }
 }


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-api#1217

Reverting as Apply makes this request without a first name and it results in an error; we need to update the apply endpoint to only use email address prior to making first name mandatory.