### PR TITLE
Grant GetIntoTeaching role access to adviser sign up

### DIFF
--- a/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
+++ b/GetIntoTeachingApi/Controllers/TeacherTrainingAdviser/CandidatesController.cs
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApi.Controllers.TeacherTrainingAdviser
 {
     [Route("api/teacher_training_adviser/candidates")]
     [ApiController]
-    [Authorize(Roles = "Admin,GetAnAdviser,Apply")]
+    [Authorize(Roles = "Admin,GetAnAdviser,Apply,GetIntoTeaching")]
     public class CandidatesController : ControllerBase
     {
         private readonly ICandidateAccessTokenService _tokenService;

--- a/GetIntoTeachingApi/appsettings.json
+++ b/GetIntoTeachingApi/appsettings.json
@@ -93,6 +93,11 @@
             "Endpoint": "POST:/api/get_into_teaching/callbacks",
             "Period": "1m",
             "Limit": 250
+          },
+          {
+            "Endpoint": "POST:/api/teacher_training_adviser/candidates",
+            "Period": "1m",
+            "Limit": 250
           }
         ]
       },

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -50,7 +50,7 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
         [Fact]
         public void Authorize_IsPresent()
         {
-            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser,Apply");
+            typeof(CandidatesController).Should().BeDecoratedWith<AuthorizeAttribute>(a => a.Roles == "Admin,GetAnAdviser,Apply,GetIntoTeaching");
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
+++ b/GetIntoTeachingApiTests/Integration/RateLimitTests.cs
@@ -37,6 +37,7 @@ namespace GetIntoTeachingApiTests.Integration
         [InlineData("/api/teaching_events/attendees", "GIT", 250)]
         [InlineData("/api/teaching_events", "GIT", 100)]
         [InlineData("/api/get_into_teaching/callbacks", "GIT", 250)]
+        [InlineData("/api/teacher_training_adviser/candidates", "GIT", 250)]
         [InlineData("/api/candidates/access_tokens", "TTA", 500)]
         [InlineData("/api/teacher_training_adviser/candidates", "TTA", 250)]
         [InlineData("/api/candidates/matchback", "APPLY", 500)]


### PR DESCRIPTION
[Trello-4444](https://trello.com/c/0PFn0Tb7/4444-spike-investigate-moving-the-adviser-funnel-to-git)

We are planning on migrating the TTA service into the GiT website. For the spike the GiT app needs to be able to submit to the TTA endpoints; once we're happy with the solution the API namespaces will be updated to reflect the TTA service migration into GiT.