### PR TITLE
Sync events over the last 12 months

### DIFF
--- a/GetIntoTeachingApi/Services/Store.cs
+++ b/GetIntoTeachingApi/Services/Store.cs
@@ -17,7 +17,7 @@ namespace GetIntoTeachingApi.Services
 {
     public class Store : IStore
     {
-        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 4);
+        public static readonly TimeSpan TeachingEventArchiveSize = TimeSpan.FromDays(31 * 12);
         private static readonly HashSet<string> FailedPostcodeLookupCache = new HashSet<string>();
         private readonly GetIntoTeachingDbContext _dbContext;
         private readonly IGeocodeClientAdapter _geocodeClient;


### PR DESCRIPTION
[Trello-4471](https://trello.com/c/6EQ4yqig/4471-consider-increasing-period-for-which-api-syncs-events)

We currently only sync events going back 4 months and we are finding that users are coming across old links to past events from external sources, resulting in a 404 not found error. Instead, if the event did exist but has since passed we would be better to serve a 410 gone with a better error message for the user. The GiT website does this already, but only as far back as the API is syncing; increasing this to 12 months to avoid 404s on recently(ish) past events.

I've tested the sync job locally and it doesn't make it significantly longer.