### PR TITLE
Fix metrics erroring out after update

### DIFF
--- a/GetIntoTeachingApi/AppStart/PrometheusMetrics.cs
+++ b/GetIntoTeachingApi/AppStart/PrometheusMetrics.cs
@@ -5,9 +5,15 @@ using Prometheus;
 
 namespace GetIntoTeachingApi.AppStart
 {
-    public static class PrometheusMetricLabels
+    public static class PrometheusMetrics
     {
-        public static void SetLabels(IEnv env)
+        public static void Configure()
+        {
+            // See: https://github.com/prometheus-net/prometheus-net/issues/407
+            Metrics.DefaultFactory.ExemplarBehavior = ExemplarBehavior.NoExemplars();
+        }
+
+        public static void SetStaticLabels(IEnv env)
         {
             if (!Metrics.DefaultRegistry.StaticLabels.Any())
             {

--- a/GetIntoTeachingApi/AppStart/Startup.cs
+++ b/GetIntoTeachingApi/AppStart/Startup.cs
@@ -74,12 +74,14 @@ namespace GetIntoTeachingApi.AppStart
         {
             using var serviceScope = app.ApplicationServices.CreateScope();
 
+            PrometheusMetrics.Configure();
+
             // We can't do this in test as the DefaultRegistry is shared between runs
             // and we get an error trying to set static labels once metrics have been registed.
             // There doesn't appear to be a way to clear the DefaultRegistry between tests.
             if (!_env.IsTest)
             {
-                PrometheusMetricLabels.SetLabels(_env);
+                PrometheusMetrics.SetStaticLabels(_env);
             }
 
             if (!_env.IsStaging)


### PR DESCRIPTION
[Trello-4472](https://trello.com/c/lrqFaQTM/4472-fix-grafana-panels-re-one-time-passwords)

We recently updated our .NET Core Prometheus Client and the update appears to have introduced a bug with exemplars. Since we don't use exemplars at the moment we can disable the behaviour as a workaround until its patched in the library.