### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -13,8 +13,8 @@
 		<PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
 		<PackageReference Include="CsvHelper" Version="30.0.1" />
 		<PackageReference Include="GeocodeSharp" Version="2.1.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.0" />
-		<PackageReference Include="Hangfire.Core" Version="1.8.0" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.1" />
+		<PackageReference Include="Hangfire.Core" Version="1.8.1" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
@@ -34,7 +34,7 @@
 		<PackageReference Include="Otp.NET" Version="1.3.0" />
 		<PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.0.0" />
-		<PackageReference Include="Sentry.AspNetCore" Version="3.31.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -28,7 +28,7 @@
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.11.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 	<PackageReference Include="Moq" Version="4.18.4" />
 	<PackageReference Include="WireMock.Net" Version="1.5.25" />
 	<PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
- Hangfire.AspNetCore 1.8.0 -> 1.8.1
- Hangfire.Core 1.8.0 -> 1.8.1
- Sentry.AspNetCore 3.31.0 -> 3.33.0
- Microsoft.NET.Test.Sdk 17.5.0 -> 17.6.0