### PR TITLE
Various dependency updates

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -17,12 +17,12 @@
 		<PackageReference Include="Hangfire.Core" Version="1.8.1" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.7">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.7">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -58,7 +58,7 @@
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Castle.Core" Version="5.1.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.7" />
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.19.12" />
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.39" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+	<PackageReference Include="coverlet.msbuild" Version="6.0.0">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
@@ -30,12 +30,12 @@
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 	<PackageReference Include="Moq" Version="4.18.4" />
-	<PackageReference Include="WireMock.Net" Version="1.5.25" />
+	<PackageReference Include="WireMock.Net" Version="1.5.28" />
 	<PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="6.0.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
     <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />


### PR DESCRIPTION
- Microsoft.EntityFrameworkCore.Tools 7.0.5 -> 7.0.7
- Microsoft.EntityFrameworkCore.Design 7.0.5 -> 7.0.7
- WireMock.Net 1.5.25 -> 1.5.28
- coverlet.msbuild 3.2.0 -> 6.0.0
- coverlet.collector 3.2.0 -> 6.0.0