### PR TITLE
Bump up versions of the libraries

### DIFF
--- a/GetIntoTeachingApi/GetIntoTeachingApi.csproj
+++ b/GetIntoTeachingApi/GetIntoTeachingApi.csproj
@@ -13,8 +13,8 @@
 		<PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
 		<PackageReference Include="CsvHelper" Version="30.0.1" />
 		<PackageReference Include="GeocodeSharp" Version="2.1.0" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.1" />
-		<PackageReference Include="Hangfire.Core" Version="1.8.1" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.3" />
+		<PackageReference Include="Hangfire.Core" Version="1.8.3" />
 		<PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
 		<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7" />
@@ -26,7 +26,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.6" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.7" />
 		<PackageReference Include="morelinq" Version="3.4.2" />
 		<PackageReference Include="Npgsql" Version="7.0.4" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
@@ -55,12 +55,12 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="Serilog" Version="2.12.0" />
+		<PackageReference Include="Serilog" Version="3.0.1" />
 		<PackageReference Include="Castle.Core" Version="5.1.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.7" />
 		<PackageReference Include="Hangfire.PostgreSql" Version="1.19.12" />
-		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.39" />
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.9" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.5" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.5" />

--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -28,7 +28,7 @@
 	</PackageReference>
 	<PackageReference Include="FluentAssertions" Version="6.11.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 	<PackageReference Include="Moq" Version="4.18.4" />
 	<PackageReference Include="WireMock.Net" Version="1.5.28" />
 	<PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
[Trello-4739](https://trello.com/c/9hjifceg/4739-carry-out-dependency-updates)

Updates

Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.3
Bump Hangfire.AspNetCore from 1.8.1 to 1.8.3
Bump Serilog from 2.12.0 to 3.0.1
Bump Microsoft.VisualStudio.Web.CodeGeneration.Design from 7.0.6 to 7.0.7
Bump Microsoft.PowerPlatform.Dataverse.Client from 1.0.39 to 1.1.9 