### PR TITLE
Update Azure Redis Max Memory policy

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -13,6 +13,7 @@ module "redis-cache" {
   use_azure               = true
   azure_enable_monitoring = var.enable_monitoring
   azure_patch_schedule    = [{ "day_of_week" : "Sunday", "start_hour_utc" : 01 }]
+  azure_maxmemory_policy  = "allkeys-lfu"
 }
 
 module "postgres" {


### PR DESCRIPTION
### Context

Update the azure redis max memory policy to allkeys-lfu to match PAAS redis

### Changes proposed in this pull request
Updated the azure_maxmemory_policy var to "allkeys-lfu" as existing in PAAS in terraform/aks/databases.tf

### Guidance to review

See the updated azure max memory policy for s189t01-gitapi-development-redis 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml


