### PR TITLE
[669] Update the buildx action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
-        with:
-          version: v0.9.1  # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: vars


### PR DESCRIPTION
## What
It was pinned to 0.9.1 for compatibility with GOV.UK PaaS. Now that we run on AKS, this limitations does not apply and we can use the default version.

