### PR TITLE
Add support for Primary education phase

### DIFF
--- a/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
+++ b/GetIntoTeachingApi/Adapters/NotificationClientAdapter.cs
@@ -37,12 +37,12 @@ namespace GetIntoTeachingApi.Adapters
 
         private NotificationClient Client(string apiKey)
         {
-            if (!_clients.ContainsKey(apiKey))
+            if (!_clients.TryGetValue(apiKey, out NotificationClient value))
             {
-                _clients[apiKey] = new NotificationClient(apiKey);
+                value = new NotificationClient(apiKey);
+                _clients[apiKey] = value;
             }
-
-            return _clients[apiKey];
+            return value;
         }
     }
 }

--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/TeachingEventsController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
@@ -81,12 +82,12 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             var typeIds = request.TypeIds == null ? string.Empty : string.Join(",", request.TypeIds);
 
             _metrics.TeachingEventSearchResults
-                .WithLabels(typeIds, request.Radius.ToString())
+                .WithLabels(typeIds, String.Format(CultureInfo.InvariantCulture, "{0}", request.Radius))
                 .Observe(teachingEvents.Count());
 
             var inPesonTeachingEvents = teachingEvents.Where(e => e.IsInPerson);
             _metrics.InPersonTeachingEventResults
-                .WithLabels(typeIds, request.Radius.ToString())
+                .WithLabels(typeIds, String.Format(CultureInfo.InvariantCulture, "{0}", request.Radius)) 
                 .Observe(inPesonTeachingEvents.Count());
 
             return Ok(teachingEvents);

--- a/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
+++ b/GetIntoTeachingApi/Models/Crm/CandidatePastTeachingPosition.cs
@@ -12,6 +12,7 @@ namespace GetIntoTeachingApi.Models.Crm
     {
         public enum EducationPhase
         {
+            Primary = 222750000,
             Secondary = 222750001,
         }
 

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -41,10 +41,21 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators
 
             When(request => request.Candidate.IsReturningToTeaching(), () =>
             {
-                RuleFor(request => request.SubjectTaughtId).NotNull()
-                    .WithMessage("Must be set for candidates returning to teacher training.");
                 RuleFor(request => request.PreferredTeachingSubjectId).NotNull()
-                    .WithMessage("Must be set for candidates returning to teacher training.");
+                    .When(request => request.Candidate.PreferredEducationPhaseId == (int)Candidate.PreferredEducationPhase.Secondary)
+                    .WithMessage("For candidates returning to teacher training, must be set when preferred education phase is secondary.");
+                
+                RuleFor(request => request.PreferredTeachingSubjectId).NotNull()
+                    .When(request => request.Candidate.PreferredEducationPhaseId == null)
+                    .WithMessage("For candidates returning to teacher training, must be set when preferred education phase defaults to secondary.");
+                
+                RuleFor(request => request.SubjectTaughtId).NotNull()
+                    .When(request => request.StageTaughtId == null)
+                    .WithMessage("For candidates returning to teacher training, must be set when stage taught defaults to secondary.");
+                
+                RuleFor(request => request.SubjectTaughtId).NotNull()
+                    .When(request => request.StageTaughtId == (int) CandidatePastTeachingPosition.EducationPhase.Secondary)
+                    .WithMessage("For candidates returning to teacher training, must be set when stage taught is secondary.");
             });
 
             When(request => request.Candidate.IsInterestedInTeaching(), () =>

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -154,10 +154,80 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
                 var result = _validator.TestValidate(_request);
 
                 result.ShouldHaveValidationErrorFor(request => request.SubjectTaughtId)
-                    .WithErrorMessage("Must be set for candidates returning to teacher training.");
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when stage taught defaults to secondary.");
 
                 result.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId)
-                    .WithErrorMessage("Must be set for candidates returning to teacher training.");
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when preferred education phase is secondary.");
+            }
+            
+            [Fact]
+            public void Validate_WhenPreferredEducationPhaseNullRequiredAttributesAreNull_HasErrors()
+            {
+                _request.PreferredEducationPhaseId = null;
+                _request.PreferredTeachingSubjectId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId)
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when preferred education phase is secondary.");
+            }
+            
+            [Fact]
+            public void Validate_WhenPreferredEducationPhasePrimaryRequiredAttributesAreNull_HasErrors()
+            {
+                _request.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Primary;
+                _request.PreferredTeachingSubjectId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldNotHaveValidationErrorFor(request => request.PreferredTeachingSubjectId);
+            }
+            
+            [Fact]
+            public void Validate_WhenPreferredEducationPhaseSecondaryRequiredAttributesAreNull_HasErrors()
+            {
+                _request.PreferredEducationPhaseId = (int)Candidate.PreferredEducationPhase.Secondary;
+                _request.PreferredTeachingSubjectId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldHaveValidationErrorFor(request => request.PreferredTeachingSubjectId)
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when preferred education phase is secondary.");
+            }
+            
+            [Fact]
+            public void Validate_WhenStageTaughtNullRequiredAttributesAreNull_HasErrors()
+            {
+                _request.StageTaughtId = null;
+                _request.SubjectTaughtId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldHaveValidationErrorFor(request => request.SubjectTaughtId)
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when stage taught defaults to secondary.");
+            }
+            
+            [Fact]
+            public void Validate_WhenStageTaughtPrimaryRequiredAttributesAreNull_HasErrors()
+            {
+                _request.StageTaughtId = (int)CandidatePastTeachingPosition.EducationPhase.Primary;
+                _request.SubjectTaughtId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldNotHaveValidationErrorFor(request => request.SubjectTaughtId);
+            }
+            
+            [Fact]
+            public void Validate_WhenStageTaughtSecondaryRequiredAttributesAreNull_HasErrors()
+            {
+                _request.StageTaughtId = (int)CandidatePastTeachingPosition.EducationPhase.Secondary;
+                _request.SubjectTaughtId = null;
+
+                var result = _validator.TestValidate(_request);
+                
+                result.ShouldHaveValidationErrorFor(request => request.SubjectTaughtId)
+                    .WithErrorMessage("For candidates returning to teacher training, must be set when stage taught is secondary.");
             }
         }
 


### PR DESCRIPTION
New (optional) StageTaughtId parameter + updated tests

This adds support for an improved RTTA process to capture interest in primary stage teaching

Requires changes to be pulled through into https://github.com/DFE-Digital/get-into-teaching-api-ruby-client and https://github.com/DFE-Digital/get-into-teaching-api-csharp-client