### PR TITLE
Adds optional param to TeachingEventAddAttendee

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/TeachingEventAddAttendee.cs
@@ -15,6 +15,10 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
 
         [SwaggerSchema(WriteOnly = true)]
         public Guid? EventId { get; set; }
+
+        [SwaggerSchema(WriteOnly = true)]
+        public int? ChannelId { get; set; }
+
         [SwaggerSchema(WriteOnly = true)]
         public Guid? AcceptedPolicyId { get; set; }
         public Guid? PreferredTeachingSubjectId { get; set; }
@@ -136,7 +140,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         {
             if (CandidateId == null)
             {
-                candidate.ChannelId = (int?)Candidate.Channel.Event;
+                candidate.ChannelId = ChannelId ?? (int?)Candidate.Channel.Event;
             }
         }
 


### PR DESCRIPTION
Teams need to be able to attribute event sign-ups in the same way that they do for mailing list and adviser with a query parameter in the format ?channel={channel_id}
- Adds `ChannelId` to the `TeachingEventAddAttendee` model