### PR TITLE
[853] Upgrade postgres to B_Standard_B2s

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -10,5 +10,6 @@
   "replicas": 2,
   "redis_capacity": 1,
   "redis_family": "P",
-  "redis_sku_name": "Premium"
+  "redis_sku_name": "Premium",
+  "postgres_flexible_server_sku": "B_Standard_B2s"
 }


### PR DESCRIPTION
## Description
The database was maxing out CPU and ran out of credits. It was upgraded manually which is looking good since CPU credits are now slowly increasing.

## How to review
Run terraform plan, it should show no change