### PR TITLE
Enable DB monitoring

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -5,7 +5,7 @@
   "infra_key_vault_name": "s189p01-gitapi-pd-inf-kv",
   "cluster": "production",
   "namespace": "git-production",
-  "enable_monitoring": false,
+  "enable_monitoring": true,
   "enable_statuscake_alerts": true,
   "replicas": 2,
   "redis_capacity": 1,


### PR DESCRIPTION
**Context**
The database was stuck at 100% CPU which created outages in school experience. We should enable monitoring to know before it breaks.

**Change**
Set 'enable_monitoring' to 'true' in the configuration for production