### PR TITLE
Reverts alpine:8.0 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /source/GetIntoTeachingApi
 RUN dotnet publish -c release -o /app
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 WORKDIR /app
 COPY --from=build /app ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet-core
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 WORKDIR /source
 ARG GIT_COMMIT_SHA
 ENV ASPNETCORE_URLS=http://+:8080


### PR DESCRIPTION
Revert "Bump dotnet/aspnet from 7.0-alpine to 8.0-alpine (#1322)"
    
This reverts commit af9e32213116f100375f8624489cd872f534fa64.

Revert "Bump dotnet/sdk from 7.0-alpine to 8.0-alpine (#1323)"
    
This reverts commit 2bef8d8fad01e5ea9ed835f217ad3da006dfde89.