### PR TITLE
Add link to swagger docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ## Get Into Teaching API 
 ### Technical Documentation
 
-This page is intentionally boring
+
+Please see the [Swagger documentation](https://getintoteachingapi-test.test.teacherservices.cloud/swagger/index.html) for full details of the API.


### PR DESCRIPTION
This adds a link to the Swagger docs detailing the API methods and parameters