### PR TITLE
Add a blank Sentry DSN for github build steps

### DIFF
--- a/.github/common_environment.yml
+++ b/.github/common_environment.yml
@@ -5,3 +5,4 @@
   SLACK_ICON:            https://raw.githubusercontent.com/DFE-Digital/get-into-teaching-api/master/.github/image.png?size=48
   SLACK_USERNAME:        GiT Workflows
   SLACK_FOOTER:          Get Into Teaching API Service
+  SENTRY__DSN:           ""


### PR DESCRIPTION
This adds a blank `SENTRY__DSN=""` env var for use during github build and test steps.

A forthcoming update to the Sentry library requires to DSN to be set to an empty string, rather than remaining undefined.

The Sentry DSN is set to real values on production and staging.