### PR TITLE
Hardcode azurerm version to 3.104.2

### DIFF
--- a/terraform/aks/provider.tf
+++ b/terraform/aks/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.52"
+      version = "3.104.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Hardcode Azurerm version to 3.104.2 as later versions cause "Public Network Access is not supported along with Virtual Network feature." errord 