### PR TITLE
Add trello key to workflow action

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -25,6 +25,9 @@ jobs:
             SECRET_VALUE=$(az keyvault secret show --name "TRELLO-TOKEN" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
             echo "::add-mask::$SECRET_VALUE"
             echo "TRELLO-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
+            SECRET_VALUE=$(az keyvault secret show --name "TRELLO-KEY" --vault-name "${{ secrets.INFRA_KEY_VAULT }}" --query "value" -o tsv)
+            echo "::add-mask::$SECRET_VALUE"
+            echo "TRELLO-KEY=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
       - name: Add Trello Comment
         uses: DFE-Digital/github-actions/AddTrelloComment@master


### PR DESCRIPTION
This adds a missing `trello-key` to the github action, allowing for trello tickets to be linked to github PRs