### PR TITLE
Onboard test envs to logit

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -17,6 +17,7 @@ module "api_application" {
   replicas               = var.replicas
   web_external_hostnames = var.gov_uk_host_names
   web_port               = 8080
+  enable_logit           = var.enable_logit
 }
 
 module "application_configuration" {

--- a/terraform/aks/config/development_aks.tfvars.json
+++ b/terraform/aks/config/development_aks.tfvars.json
@@ -5,5 +5,6 @@
   "infra_key_vault_name": "s189t01-gitapi-dv-inf-kv",
   "cluster": "test",
   "namespace": "git-development",
-  "enable_monitoring": false
+  "enable_monitoring": false,
+  "enable_logit": true
 }

--- a/terraform/aks/config/test_aks.tfvars.json
+++ b/terraform/aks/config/test_aks.tfvars.json
@@ -5,5 +5,6 @@
   "infra_key_vault_name": "s189t01-gitapi-ts-inf-kv",
   "cluster": "test",
   "namespace": "git-test",
-  "enable_monitoring": false
+  "enable_monitoring": false,
+  "enable_logit": true
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -54,6 +54,10 @@ variable "redis_sku_name" {
   type    = string
   default = "Standard"
 }
+variable "enable_logit" {
+  type    = bool
+  default = false
+}
 
 locals {
   azure_credentials       = try(jsondecode(var.azure_credentials), null)


### PR DESCRIPTION
# Description
Ship web and worker application logs to Logit.io. Enabled for non-prod environments first

# Guidance to review
make development_aks terraform-plan
