### PR TITLE
Scrape custom metrics

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -18,6 +18,8 @@ module "api_application" {
   web_external_hostnames = var.gov_uk_host_names
   web_port               = 8080
   enable_logit           = var.enable_logit
+
+  enable_prometheus_monitoring  = var.enable_prometheus_monitoring
 }
 
 module "application_configuration" {

--- a/terraform/aks/config/development_aks.tfvars.json
+++ b/terraform/aks/config/development_aks.tfvars.json
@@ -6,5 +6,6 @@
   "cluster": "test",
   "namespace": "git-development",
   "enable_monitoring": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -13,5 +13,6 @@
   "redis_sku_name": "Premium",
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/test_aks.tfvars.json
+++ b/terraform/aks/config/test_aks.tfvars.json
@@ -6,5 +6,6 @@
   "cluster": "test",
   "namespace": "git-test",
   "enable_monitoring": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -59,6 +59,11 @@ variable "enable_logit" {
   default = false
 }
 
+variable "enable_prometheus_monitoring" {
+  type    = bool
+  default = false
+}
+
 locals {
   azure_credentials       = try(jsondecode(var.azure_credentials), null)
   app_resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"


### PR DESCRIPTION
### Context
Scrape custom metrics that are exported for gitapi,
which can then be used in dashboards and alerting

https://trello.com/c/Zlih3dRZ/1889-scrape-custom-metrics 

### Changes proposed in this pull request
Add enable_prometheus_monitoring to application deployments and set for each env

### Guidance to review
make development_aks terraform-plan IMAGE_TAG=x

This has been deployed manually to dev & test envs and metrics are available in test prometheus (look for metrics starting with api)

Some metrics (e.g. hangfire) are possibly not being exported, and that may need follow up with the dev team.
