### PR TITLE
Added maintenance window for prod postgress

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -12,5 +12,10 @@
   "redis_family": "P",
   "redis_sku_name": "Premium",
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
-  "postgres_enable_high_availability": true
+  "postgres_enable_high_availability": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  }
 }


### PR DESCRIPTION
Terraform Plan : 

`  # module.postgres.data.azurerm_monitor_diagnostic_categories.main[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "azurerm_monitor_diagnostic_categories" "main" {
      + id                  = (known after apply)
      + log_category_groups = (known after apply)
      + log_category_types  = (known after apply)
      + logs                = (known after apply)
      + metrics             = (known after apply)
      + resource_id         = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-gitapi-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-gitapi-pd-pg"
    }

  # module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place
  ~ resource "azurerm_postgresql_flexible_server" "main" {
        id                            = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-gitapi-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-gitapi-pd-pg"
        name                          = "s189p01-gitapi-pd-pg"
      ~ public_network_access_enabled = false -> true
        tags                          = {
            "Environment"      = "Prod"
            "Product"          = "Get into teaching website"
            "Service Offering" = ""
        }
        # (15 unchanged attributes hidden)

      + maintenance_window {
          + day_of_week  = 0
          + start_hour   = 3
          + start_minute = 0
        }

        # (2 unchanged blocks hidden)
    }

  # module.statuscake[0].statuscake_uptime_check.main["https://getintoteachingapi-production.teacherservices.cloud/healthcheck"] will be updated in-place
  ~ resource "statuscake_uptime_check" "main" {
      ~ contact_groups = [
          - "282453",
            # (1 unchanged element hidden)
        ]
        id             = "6974683"
        name           = "https://getintoteachingapi-production.teacherservices.cloud/healthcheck"
        tags           = []
        # (6 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.`