### PR TITLE
Added maintenance window for prod postgress

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -14,5 +14,10 @@
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
   "enable_logit": true,
-  "enable_prometheus_monitoring": true
+  "enable_prometheus_monitoring": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  }
 }


### PR DESCRIPTION
Terraform Plan : 

` Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # module.api_application.kubernetes_deployment.main will be updated in-place
  ~ resource "kubernetes_deployment" "main" {
        id               = "git-production/getintoteachingapi-production"
        # (1 unchanged attribute hidden)

      ~ spec {
            # (5 unchanged attributes hidden)

          ~ template {
              ~ metadata {
                  ~ annotations = {
                      + "prometheus.io/path"   = "/metrics"
                      + "prometheus.io/port"   = "8080"
                      + "prometheus.io/scrape" = "true"
                        # (2 unchanged elements hidden)
                    }
                    # (2 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }

            # (2 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.postgres.data.azurerm_monitor_diagnostic_categories.main[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "azurerm_monitor_diagnostic_categories" "main" {
      + id                  = (known after apply)
      + log_category_groups = (known after apply)
      + log_category_types  = (known after apply)
      + logs                = (known after apply)
      + metrics             = (known after apply)
      + resource_id         = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-gitapi-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-gitapi-pd-pg"
    }

  # module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place
  ~ resource "azurerm_postgresql_flexible_server" "main" {
        id                            = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-gitapi-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-gitapi-pd-pg"
        name                          = "s189p01-gitapi-pd-pg"
        tags                          = {
            "Environment"      = "Prod"
            "Product"          = "Get into teaching website"
            "Service Offering" = ""
        }
        # (16 unchanged attributes hidden)

      + maintenance_window {
          + day_of_week  = 0
          + start_hour   = 3
          + start_minute = 0
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
`