### PR TITLE
Prevent duplicate degree subject

### DIFF
--- a/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
+++ b/GetIntoTeachingApi/Jobs/UpsertCandidateJob.cs
@@ -41,7 +41,7 @@ namespace GetIntoTeachingApi.Jobs
         public void Run(string json, PerformContext context)
         {
             var candidate = json.DeserializeChangeTracked<Candidate>();
-
+            
             if (Deduplicate(Signature(candidate), context, _contextAdapter))
             {
                 _logger.LogInformation("UpsertCandidateJob - Deduplicating");

--- a/GetIntoTeachingApi/Services/CandidateUpserter.cs
+++ b/GetIntoTeachingApi/Services/CandidateUpserter.cs
@@ -33,8 +33,8 @@ namespace GetIntoTeachingApi.Services
             UpdateEventSubscriptionType(candidate);
 
             SaveCandidate(candidate);
-
             SaveQualifications(qualifications, candidate);
+            
             SavePastTeachingPositions(pastTeachingPositions, candidate);
             SaveApplicationForms(applicationForms, candidate);
             SaveTeachingEventRegistrations(registrations, candidate);
@@ -43,6 +43,9 @@ namespace GetIntoTeachingApi.Services
             SaveSchoolExperiences(schoolExperiences, candidate);
 
             IncrementCallbackBookingQuotaNumberOfBookings(phoneCall);
+            
+            // Re-add qualifications back to candidate object to ensure it is correctly returned
+            AddQualifications(qualifications, candidate);
         }
 
         private static IEnumerable<TeachingEventRegistration> ClearTeachingEventRegistrations(Candidate candidate)
@@ -145,8 +148,22 @@ namespace GetIntoTeachingApi.Services
         private void SaveCandidate(Candidate candidate)
         {
             candidate.IsNewRegistrant = candidate.Id == null;
-
             _crm.Save(candidate);
+        }
+        
+        private void SaveQualifications(IEnumerable<CandidateQualification> qualifications, Candidate candidate)
+        {
+            foreach (var qualification in qualifications)
+            {
+                // only add the degree qualification to the CRM if it doesn't already exist
+                if (!_crm.CandidateHasDegreeQualification((Guid)candidate.Id, CandidateQualification.DegreeType.Degree,
+                        qualification.DegreeSubject))
+                {
+                    qualification.CandidateId = (Guid)candidate.Id;
+                    // call the CRM immediate so we get qualification ID and prevent duplicate records from being created
+                    _crm.Save(qualification);
+                }
+            }
         }
 
         private void SaveTeachingEventRegistrations(IEnumerable<TeachingEventRegistration> registrations, Candidate candidate)
@@ -165,21 +182,7 @@ namespace GetIntoTeachingApi.Services
                 _jobClient.Enqueue<UpsertModelWithCandidateIdJob<TeachingEventRegistration>>((x) => x.Run(json, null));
             }
         }
-
-        private void SaveQualifications(IEnumerable<CandidateQualification> qualifications, Candidate candidate)
-        {
-            foreach (var qualification in qualifications)
-            {
-                if (!_crm.CandidateHasDegreeQualification((Guid)candidate.Id, CandidateQualification.DegreeType.Degree,
-                        qualification.DegreeSubject))
-                {
-                    qualification.CandidateId = (Guid)candidate.Id;
-                    string json = qualification.SerializeChangeTracked();
-
-                    _jobClient.Enqueue<UpsertModelWithCandidateIdJob<CandidateQualification>>((x) => x.Run(json, null));    
-                }
-            }
-        }
+        
 
         private void SaveApplicationForms(IEnumerable<ApplicationForm> applicationForms, Candidate candidate)
         {

--- a/GetIntoTeachingApi/Services/CrmService.cs
+++ b/GetIntoTeachingApi/Services/CrmService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using FluentValidation;
+using Flurl.Util;
 using GetIntoTeachingApi.Adapters;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
+using NuGet.Protocol;
 
 namespace GetIntoTeachingApi.Services
 {
@@ -247,6 +249,14 @@ namespace GetIntoTeachingApi.Services
             return _service.CreateQuery("msevtmgt_eventregistration", Context()).FirstOrDefault(entity =>
                 entity.GetAttributeValue<EntityReference>("msevtmgt_contactid").Id == candidateId &&
                 entity.GetAttributeValue<EntityReference>("msevtmgt_eventid").Id == teachingEventId) == null;
+        }
+
+        public bool CandidateHasDegreeQualification(Guid candidateId, CandidateQualification.DegreeType degreeType, string degreeSubject)
+        {
+            // this check helps prevent duplicate qualification records from being created
+            return !(_service.CreateQuery("dfe_candidatequalification", Context()).FirstOrDefault(entity =>
+                entity.GetAttributeValue<EntityReference>("dfe_contactid").Id == candidateId &&
+                entity.GetAttributeValue<int?>("dfe_type") == (int)CandidateQualification.DegreeType.Degree) == null);
         }
 
         public void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context)

--- a/GetIntoTeachingApi/Services/ICrmService.cs
+++ b/GetIntoTeachingApi/Services/ICrmService.cs
@@ -28,6 +28,9 @@ namespace GetIntoTeachingApi.Services
         bool CandidateAlreadyHasLocalEventSubscriptionType(Guid candidateId);
         bool CandidateYetToAcceptPrivacyPolicy(Guid candidateId, Guid privacyPolicyId);
         bool CandidateYetToRegisterForTeachingEvent(Guid candidateId, Guid teachingEventId);
+
+        bool CandidateHasDegreeQualification(Guid candidateId, CandidateQualification.DegreeType degreeType,
+            string degreeSubject);
         void Save(BaseModel model);
         void AddLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);
         void DeleteLink(Entity source, Relationship relationship, Entity target, OrganizationServiceContext context);

--- a/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
+++ b/GetIntoTeachingApiTests/Helpers/ContractCrmService.cs
@@ -85,6 +85,11 @@ namespace GetIntoTeachingApiTests.Helpers
             return _crmService.CandidateYetToRegisterForTeachingEvent(candidateId, teachingEventId);
         }
 
+        public bool CandidateHasDegreeQualification(Guid candidateId, CandidateQualification.DegreeType degreeType, string degreeSubject)
+        {
+            return _crmService.CandidateHasDegreeQualification(candidateId, degreeType, degreeSubject);
+        }
+
         public string CheckStatus()
         {
             return _crmService.CheckStatus();

--- a/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
+++ b/GetIntoTeachingApiTests/Services/CandidateUpserterTests.cs
@@ -99,11 +99,8 @@ namespace GetIntoTeachingApiTests.Services
             _upserter.Upsert(_candidate);
 
             qualification.CandidateId = candidateId;
-
-            _mockJobClient.Verify(x => x.Create(
-                           It.Is<Job>(job => job.Type == typeof(UpsertModelWithCandidateIdJob<CandidateQualification>) && job.Method.Name == "Run" &&
-                           IsMatch(qualification, (string)job.Args[0])),
-                           It.IsAny<EnqueuedState>()));
+            
+            _mockCrm.Verify(mock => mock.Save(It.Is<CandidateQualification>(q => q.CandidateId == candidateId)), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
This change improves the synchronisation of qualification records:

* adds checks to ensure a qualification record is not re-created if it already exists
* creates qualification records immediately, rather than via a queued job