### PR TITLE
Add `inactive` status to ApplicationChoice.cs

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
+++ b/GetIntoTeachingApi/Models/Crm/ApplicationChoice.cs
@@ -29,6 +29,7 @@ namespace GetIntoTeachingApi.Models.Crm
             Withdrawn = 222750011,
             ConditionsNotMet = 222750012,
             OfferDeferred = 222750013,
+            Inactive = 222750014,
         }
 
         [EntityField("dfe_applyapplicationform", typeof(EntityReference), "dfe_applyapplicationform")]


### PR DESCRIPTION
This new status is required by the Apply system to synchronise correctly.

It is currently being added to the CRM system too.