### PR TITLE
Remove request logging from API

### DIFF
--- a/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/GetIntoTeachingApi/Middleware/RequestResponseLoggingMiddleware.cs
@@ -28,7 +28,6 @@ namespace GetIntoTeachingApi.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            await LogRequest(context);
             await LogResponse(context);
         }
 
@@ -81,18 +80,6 @@ namespace GetIntoTeachingApi.Middleware
         {
             var input = $"{method} {path}";
             return _config.CompactLoggingPatterns.All(regex => !regex.IsMatch(input));
-        }
-
-        private async Task LogRequest(HttpContext context)
-        {
-            context.Request.EnableBuffering();
-
-            // Copy request body stream, resetting position for next middleware.
-            await using var stream = _recyclableMemoryStreamManager.GetStream();
-            await context.Request.Body.CopyToAsync(stream);
-            context.Request.Body.Position = 0;
-
-            LogInformation("HTTP Request", ReadStream(stream), context.Request);
         }
 
         private async Task LogResponse(HttpContext context)

--- a/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
+++ b/GetIntoTeachingApiTests/Middleware/RequestResponseLoggingMiddlewareTests.cs
@@ -55,8 +55,7 @@ namespace GetIntoTeachingApiTests.Middleware
                 _context.Request.QueryString,
                 Payload = string.Empty,
             };
-
-            _mockLogger.VerifyInformationWasCalled($"HTTP Request: {expectedInfo}");
+            
             _mockLogger.VerifyInformationWasCalled($"HTTP Response: {expectedInfo}");
         }
 
@@ -88,8 +87,7 @@ namespace GetIntoTeachingApiTests.Middleware
                 _context.Request.QueryString,
                 Payload = redactedJson,
             };
-
-            _mockLogger.VerifyInformationWasCalled($"HTTP Request: {expectedInfo}");
+            
             _mockLogger.VerifyInformationWasCalled($"HTTP Response: {expectedInfo}");
         }
 
@@ -108,8 +106,7 @@ namespace GetIntoTeachingApiTests.Middleware
                 _context.Request.QueryString,
                 Payload = string.Empty,
             };
-
-            _mockLogger.VerifyInformationWasCalled($"HTTP Request: {expectedInfo}");
+            
             _mockLogger.VerifyInformationWasCalled($"HTTP Response: {expectedInfo}");
         }
 


### PR DESCRIPTION
Remove request logging from the API - requested by infra team to reduce logging volumes.