### PR TITLE
Redact postcode in JSON serialization

### DIFF
--- a/GetIntoTeachingApi/Utils/Redactor.cs
+++ b/GetIntoTeachingApi/Utils/Redactor.cs
@@ -25,6 +25,7 @@ namespace GetIntoTeachingApi.Utils
             "addressLine1",
             "addressLine2",
             "addressLine3",
+            "addressPostcode",
         };
 
         public static string RedactJson(string json)

--- a/GetIntoTeachingApiTests/Utils/RedactorTests.cs
+++ b/GetIntoTeachingApiTests/Utils/RedactorTests.cs
@@ -36,7 +36,7 @@ namespace GetIntoTeachingApiTests.Utils
                         password = "******",
                     },
                     email = "******",
-                    addressPostcode = "TE7 1NG",
+                    addressPostcode = "******",
                 }
             );
 


### PR DESCRIPTION
Add `addressPostcode` to the list of fields to redact when serializing JSON.

Trello ticket: [Obfuscate postcode](https://trello.com/c/bFEbXgSY/6607-obfuscate-addresspostcode-field)