### PR TITLE
update apply api method to set contact creation channel

### DIFF
--- a/GetIntoTeachingApi/Jobs/ContactChannelCandidateWrapper.cs
+++ b/GetIntoTeachingApi/Jobs/ContactChannelCandidateWrapper.cs
@@ -1,0 +1,37 @@
+using GetIntoTeachingApi.Models.Crm;
+
+namespace GetIntoTeachingApi.Jobs;
+
+public class ContactChannelCandidateWrapper : ICreateContactChannel
+{
+  
+        /// <summary>
+        /// Provides the default read-only contact creation channel integer value.
+        /// </summary>
+        public int? DefaultContactCreationChannel =>
+            (int?)Candidate.Channel.ApplyForTeacherTraining;
+
+        /// <summary>
+        /// Provides the ability to assign and retrieve the channel source creation identifier.
+        /// </summary>
+        public int? CreationChannelSourceId { get; set; }
+
+        /// <summary>
+        /// Provides the ability to assign and retrieve the channel service creation identifier.
+        /// </summary>
+        public int? CreationChannelServiceId { get; set; }
+
+        /// <summary>
+        /// Provides the ability to assign and retrieve the channel activity creation identifier.
+        /// </summary>
+        public int? CreationChannelActivityId { get; set; }
+        
+ 
+        public Candidate ScopedCandidate { get; }
+        
+        // Todo: add some documentation
+        public ContactChannelCandidateWrapper(Candidate candidate)
+        {
+               ScopedCandidate = candidate;
+        }
+}


### PR DESCRIPTION
Adds the new Creation Channel model support to the Apply Candidate sync job.

[Update GiT API to support creation channels](https://trello.com/c/DRqHdEKK/7072-update-git-api-to-support-new-creation-channel-structure-for-apply-data-e11-gc3)
