### PR TITLE
Move workflow secrets to github

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,7 +16,7 @@ on:
   push:
     branches:
       - master
-      
+
 permissions:
   contents: write
   packages: write
@@ -26,7 +26,6 @@ jobs:
   build:
     name: Build and push to Github Container Registry
     runs-on: ubuntu-latest
-    environment: development
     outputs:
       image: ${{steps.docker_image.outputs.IMAGE}}
       image_tag_sha: "sha-${{ steps.vars.outputs.sha_short }}"
@@ -36,21 +35,6 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         id: buildx
@@ -94,7 +78,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_MESSAGE: 'The pipeline has failed to build the API image'
           SLACK_TITLE: 'Failure to Build API '
-          SLACK_WEBHOOK: "${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK }}"
+          SLACK_WEBHOOK: "${{ secrets.SLACK_WEBHOOK }}"
 
   development:
     name: Development Deployment
@@ -116,15 +100,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
       - name: Trigger Development Deployment
         uses: ./.github/workflows/actions/deploy_v2
@@ -170,7 +145,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_MESSAGE: 'Deployment to the development environment has failed'
           SLACK_TITLE: 'Deployment to the development environment has failed'
-          SLACK_WEBHOOK: '${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK }}'
+          SLACK_WEBHOOK: '${{ secrets.SLACK_WEBHOOK }}'
 
   test:
     name: Test Deployment
@@ -193,15 +168,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
-
       - name: Trigger Test Deployment
         uses: ./.github/workflows/actions/deploy_v2
         id: deploy
@@ -219,4 +185,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_MESSAGE: 'Deployment to the test environment has failed'
           SLACK_TITLE: 'Deployment to the test environment has failed'
-          SLACK_WEBHOOK: "${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK }}"
+          SLACK_WEBHOOK: "${{ secrets.SLACK_WEBHOOK }}"

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   build:
     name: Build
-    environment: development
     runs-on: ubuntu-latest
 
     steps:
@@ -22,24 +21,6 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
-            SECRET_VALUE=$(az keyvault secret show --name "SNYK-TOKEN" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SNYK-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@master
@@ -66,7 +47,7 @@ jobs:
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ steps.fetch-secrets.outputs.SNYK-TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_REPOSITORY }}:master
           args: --severity-threshold=high --file=Dockerfile
@@ -82,4 +63,4 @@ jobs:
            SLACK_COLOR: ${{ env.SLACK_ERROR }}
            SLACK_MESSAGE: 'There has been a failure building the application'
            SLACK_TITLE: 'Failure Building Application'
-           SLACK_WEBHOOK: ${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK }}
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,25 +12,9 @@ jobs:
 
   test_dot_net:
     runs-on: ubuntu-latest
-    environment: development
     steps:
 
     - uses: actions/checkout@v4
-
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Fetch secrets from key vault
-      uses: azure/CLI@v2
-      id: fetch-secrets
-      with:
-        inlineScript: |
-          SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-          echo "::add-mask::$SECRET_VALUE"
-          echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
     - name: set-up-environment
       uses: DFE-Digital/github-actions/set-up-environment@master
@@ -64,4 +48,4 @@ jobs:
            SLACK_COLOR:   ${{env.SLACK_FAILURE }}
            SLACK_MESSAGE: Pipeline Failure carrying out job ${{github.job}}
            SLACK_TITLE:   'Failure: ${{ github.workflow }}'
-           SLACK_WEBHOOK: ${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK }}
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest
-    environment: development
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,24 +24,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-
-      - uses: Azure/login@v2
-        with:
-           client-id: ${{ secrets.AZURE_CLIENT_ID }}
-           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
-            SECRET_VALUE=$(az keyvault secret show --name "SONAR-TOKEN" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SONAR-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
@@ -66,7 +47,7 @@ jobs:
             /k:"DFE-Digital_get-into-teaching-api" \
             /o:"dfe-digital" \
             /n:"get-into-teaching-api" \
-            /d:sonar.login="${{ steps.fetch-secrets.outputs.SONAR-TOKEN }}" \
+            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cpd.exclusions="GetIntoTeachingApi/Migrations/*.cs" \
             /d:sonar.cs.opencover.reportsPaths="GetIntoTeachingApiTests/coverage.opencover.xml" \
@@ -84,7 +65,7 @@ jobs:
             /d:sonar.log.level="DEBUG"
           dotnet build
           dotnet test --no-build --logger:trx -e:CollectCoverage=true -e:CoverletOutputFormat=opencover
-          dotnet sonarscanner end /d:sonar.login="${{ steps.fetch-secrets.outputs.SONAR-TOKEN }}"
+          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
       - name: Slack Notification
         if: failure() && github.ref == 'refs/heads/master'
@@ -93,4 +74,4 @@ jobs:
            SLACK_COLOR:   ${{env.SLACK_FAILURE }}
            SLACK_MESSAGE: Pipeline Failure carrying out job ${{github.job}}
            SLACK_TITLE:   'Failure: ${{ github.workflow }}'
-           SLACK_WEBHOOK: ${{ steps.fetch-secrets.outputs.SLACK-WEBHOOK  }}
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK  }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -12,33 +12,11 @@ jobs:
     name: Link Trello card to this PR
     if: "!contains( 'dependabot[bot] snyk-bot' , github.actor )"
     runs-on: ubuntu-latest
-    environment: development
     steps:
-      - uses: Azure/login@v2
-        with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: fetch-secrets
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SLACK-WEBHOOK=$SECRET_VALUE" >> $GITHUB_OUTPUT
-            SECRET_VALUE=$(az keyvault secret show --name "TRELLO-TOKEN" --vault-name "${{ secrets.INFRA_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "TRELLO-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
-            SECRET_VALUE=$(az keyvault secret show --name "TRELLO-KEY" --vault-name "${{ secrets.INFRA_KEY_VAULT }}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "TRELLO-KEY=$SECRET_VALUE" >> $GITHUB_OUTPUT
-
       - name: Add Trello Comment
         uses: DFE-Digital/github-actions/AddTrelloComment@master
         with:
           MESSAGE:      ${{ github.event.pull_request.html_url }}
           CARD:         ${{ github.event.pull_request.body }}
-          TRELLO-KEY:   ${{ steps.fetch-secrets.outputs.TRELLO-KEY }}
-          TRELLO-TOKEN: ${{ steps.fetch-secrets.outputs.TRELLO-TOKEN }}
+          TRELLO-KEY:   ${{ secrets.TRELLO_KEY }}
+          TRELLO-TOKEN: ${{ secrets.TRELLO_TOKEN }}


### PR DESCRIPTION
### Trello card

https://trello.com/c/CAZOMOph/2294-remove-kv-secrets-from-build-and-test-workflow

### Context

Move workflow only secrets from azure keyvault to github secrets.
This removes the github environment from non deploy steps, and makes more sense for a workflow secret.

### Changes proposed in this pull request

Updates to workflows

### Guidance to review

Check workflows all run correctly for this PR
manual build-no-cache: https://github.com/DFE-Digital/get-into-teaching-api/actions/runs/13942519391