### PR TITLE
Changes to allow degree status (inferred or otherwise) to be returned by the service endpoint.

### DIFF
--- a/GetIntoTeachingApi/Controllers/GetIntoTeaching/MailingListController.cs
+++ b/GetIntoTeachingApi/Controllers/GetIntoTeaching/MailingListController.cs
@@ -68,7 +68,9 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             // graduation year provided to support current behaviour until degree status
             // is fully retired. The intention being to remove this functionality once we
             // fully migrate to the new approach. 
-            request.InferDegreeStatus(_degreeStatusDomainService, _currentYearProvider);
+            int? degreeStatusId =
+                request.InferDegreeStatus(
+                    _degreeStatusDomainService, _currentYearProvider);
 
             // This is the only way we can mock/freeze the current date/time
             // in contract tests (there's no other way to inject it into this class).
@@ -77,7 +79,7 @@ namespace GetIntoTeachingApi.Controllers.GetIntoTeaching
             _jobClient.Enqueue<UpsertCandidateJob>(
                 (upsertCandidateJob) => upsertCandidateJob.Run(json, null));
 
-            return NoContent();
+            return Ok(new { DegreeStatusId = degreeStatusId });
         }
 
         [HttpPost]

--- a/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/IInferDegreeStatus.cs
+++ b/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/IInferDegreeStatus.cs
@@ -30,7 +30,10 @@ namespace GetIntoTeachingApi.Models.Crm.DegreeStatusInference
         /// Implementation of <see cref="ICurrentYearProvider"/> which provides the current date/time
         /// as well as helper methods to convert the current year to an integer representation.
         /// </param>
-        void InferDegreeStatus(
+        /// <returns>
+        /// The nullable integer representation of the inferred degree status.
+        /// </returns>
+        int? InferDegreeStatus(
             IDegreeStatusDomainService degreeStatusDomainService,
             ICurrentYearProvider currentYearProvider);
     }

--- a/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/Readme.txt
+++ b/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/Readme.txt
@@ -1,6 +1,5 @@
 ﻿# Degree Status Inference - Domain Service
-The degree status inference is a domain service that is used to determine the degree status of a user based on their year of study. Based on the year of study a user specifies, their degree status will be inferred based on the currently assumed academic year from 1st Sept 20X1 - 31st Aug 20X2 for example, the statuses applied are as follows:
-
+The degree status inference is a domain service that is used to determine the degree status of a user based on their year of study. The statuses applied are as follows:
 
 * **HasDegree (crm ref: 222750000)** - if the academic year provided has already occurred in relation to the given academic year;
 * **FinalYear (crm ref: 222750001)** - if the academic year provided falls within the current academic year;
@@ -9,7 +8,7 @@ The degree status inference is a domain service that is used to determine the de
 * **NoDegree (crm ref: 222750004)** - if no academic year is provided;
 * **Other (crm ref: 222750005)** - default value if no degree status can be inferred or has not been provisioned.
 
-The service has been applied as a temporary means to ensure the CRM continues to recieve the correct degree status values until this approach becomes deprecated. Once this is the case, the service must be unwound to ensure no degree status Id's are sent to the CRM.  However, the domain service must be retained in order to ensure a degree status can be returned from the service endpoint to ensure the front-end can provide the necessary values to third-party support services.
+The service has been applied as a temporary means to ensure the CRM continues to receive the correct degree status values. Once this approach becomes deprecated, the service must be unwound to ensure no degree status Id's are sent to the CRM.  However, the domain service must be retained in order to ensure a degree status can be returned from the service endpoint to ensure the front-end can provide the necessary values to third-party support services.
 
 ## Service Partial Unwind
 In order to ensure we correctly unwind the service from the CRM but retain the correctly inferred degree status response, the **InferDegreeStatus** method under the **MailingListAddMember.cs** must be modified as follows,

--- a/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/Readme.txt
+++ b/GetIntoTeachingApi/Models/Crm/DegreeStatusInference/Readme.txt
@@ -1,1 +1,37 @@
-﻿TODO: we need to clearly signpost how to remove this domain service.
+﻿# Degree Status Inference - Domain Service
+The degree status inference is a domain service that is used to determine the degree status of a user based on their year of study. Based on the year of study a user specifies, their degree status will be inferred based on the currently assumed academic year from 1st Sept 20X1 - 31st Aug 20X2 for example, the statuses applied are as follows:
+
+
+* **HasDegree (crm ref: 222750000)** - if the academic year provided has already occurred in relation to the given academic year;
+* **FinalYear (crm ref: 222750001)** - if the academic year provided falls within the current academic year;
+* **SecondYear (crm ref: 222750002)** - if the academic year provided falls one year behind the current academic year;
+* **FirstYear (crm ref: 222750003)** - if the academic year provided falls two years or more behind the current academic year;
+* **NoDegree (crm ref: 222750004)** - if no academic year is provided;
+* **Other (crm ref: 222750005)** - default value if no degree status can be inferred or has not been provisioned.
+
+The service has been applied as a temporary means to ensure the CRM continues to recieve the correct degree status values until this approach becomes deprecated. Once this is the case, the service must be unwound to ensure no degree status Id's are sent to the CRM.  However, the domain service must be retained in order to ensure a degree status can be returned from the service endpoint to ensure the front-end can provide the necessary values to third-party support services.
+
+## Service Partial Unwind
+In order to ensure we correctly unwind the service from the CRM but retain the correctly inferred degree status response, the **InferDegreeStatus** method under the **MailingListAddMember.cs** must be modified as follows,
+
+```csharp
+public int? InferDegreeStatus(
+    IDegreeStatusDomainService degreeStatusDomainService,
+    ICurrentYearProvider currentYearProvider)
+{
+    if (GraduationYear != null)
+    {
+        const int GraduationDay = 31;
+        const int GraduationMonth = 8;
+
+        DegreeStatusInferenceRequest degreeStatusInferenceRequest =
+            DegreeStatusInferenceRequest.Create(
+                new GraduationYear(GraduationYear.Value, currentYearProvider), currentYearProvider);
+
+        return degreeStatusDomainService
+            .GetInferredDegreeStatusFromGraduationYear(degreeStatusInferenceRequest);
+    }
+
+    return (int)DegreeStatus.NoDegree;
+}
+```

--- a/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
@@ -164,7 +164,7 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         /// Implementation of <see cref="ICurrentYearProvider"/> which provides the current date/time
         /// as well as helper methods to convert the current year to an integer representation.
         /// </param>
-        public void InferDegreeStatus(
+        public int? InferDegreeStatus(
             IDegreeStatusDomainService degreeStatusDomainService,
             ICurrentYearProvider currentYearProvider)
         {
@@ -184,6 +184,8 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
                 InferredGraduationDate =
                     new DateTime(GraduationYear.Value, GraduationMonth, GraduationDay);
             }
+
+            return DegreeStatusId;
         }
     }
 }

--- a/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/PartialIntegration/MailingListControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/GetIntoTeaching/PartialIntegration/MailingListControllerTests.cs
@@ -70,7 +70,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -91,7 +91,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -112,7 +112,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -133,7 +133,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -154,7 +154,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -175,7 +175,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(
@@ -196,7 +196,7 @@ namespace GetIntoTeachingApiTests.Controllers.GetIntoTeaching.PartialIntegration
             IActionResult response = _controller.AddMember(_request);
 
             // assert
-            response.Should().BeOfType<NoContentResult>();
+            response.Should().BeOfType<OkObjectResult>();
 
             _mockJobClient.Verify(backgroundJobClient =>
                 backgroundJobClient.Create(


### PR DESCRIPTION
Some small changes to allow the degree status Id to be returned by the **MailingList** Service, **AddMember** endpoint. This change is required to support third-party service requirements which use degree status to drive marketing etc.