### PR TITLE
Use default values for subscription channel IDs

### DIFF
--- a/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
+++ b/GetIntoTeachingApi/Models/GetIntoTeaching/MailingListAddMember.cs
@@ -137,11 +137,11 @@ namespace GetIntoTeachingApi.Models.GetIntoTeaching
         {
             var utcNow = DateTimeProvider.UtcNow;
 
-            SubscriptionManager.SubscribeToMailingList(candidate, utcNow, ChannelId);
+            SubscriptionManager.SubscribeToMailingList(candidate, utcNow);
 
             if (!string.IsNullOrWhiteSpace(AddressPostcode))
             {
-                SubscriptionManager.SubscribeToEvents(candidate, utcNow, ChannelId);
+                SubscriptionManager.SubscribeToEvents(candidate, utcNow);
             }
         }
 

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -257,7 +257,7 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
             DefaultPreferredTeachingSubjectId(candidate);
             UpdateClosedAdviserStatus(candidate);
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow, ChannelId);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTimeProvider.UtcNow);
 
             return candidate;
         }

--- a/GetIntoTeachingApi/Services/SubscriptionManager.cs
+++ b/GetIntoTeachingApi/Services/SubscriptionManager.cs
@@ -5,10 +5,10 @@ namespace GetIntoTeachingApi.Services
 {
     public static class SubscriptionManager
     {
-        public static void SubscribeToMailingList(Candidate candidate, DateTime utcNow, int? channelId = null)
+        public static void SubscribeToMailingList(Candidate candidate, DateTime utcNow)
         {
             candidate.HasMailingListSubscription = true;
-            candidate.MailingListSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
+            candidate.MailingListSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.MailingListSubscriptionStartAt = utcNow;
             candidate.MailingListSubscriptionDoNotEmail = false;
             candidate.MailingListSubscriptionDoNotBulkEmail = false;
@@ -24,10 +24,10 @@ namespace GetIntoTeachingApi.Services
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, false);
         }
 
-        public static void SubscribeToEvents(Candidate candidate, DateTime utcNow, int? channelId = null)
+        public static void SubscribeToEvents(Candidate candidate, DateTime utcNow)
         {
             candidate.HasEventsSubscription = true;
-            candidate.EventsSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
+            candidate.EventsSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.EventsSubscriptionStartAt = utcNow;
             candidate.EventsSubscriptionDoNotEmail = false;
             candidate.EventsSubscriptionDoNotBulkEmail = false;
@@ -52,10 +52,10 @@ namespace GetIntoTeachingApi.Services
             candidate.DoNotSendMm = ConsentValue(candidate.DoNotSendMm, true);
         }
 
-        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow, int? channelId = null)
+        public static void SubscribeToTeacherTrainingAdviser(Candidate candidate, DateTime utcNow)
         {
             candidate.HasTeacherTrainingAdviserSubscription = true;
-            candidate.TeacherTrainingAdviserSubscriptionChannelId = channelId ?? (int)Candidate.SubscriptionChannel.Subscribed;
+            candidate.TeacherTrainingAdviserSubscriptionChannelId = (int)Candidate.SubscriptionChannel.Subscribed;
             candidate.TeacherTrainingAdviserSubscriptionStartAt = utcNow;
             candidate.TeacherTrainingAdviserSubscriptionDoNotEmail = false;
             candidate.TeacherTrainingAdviserSubscriptionDoNotBulkEmail = candidate.IsReturningToTeaching();

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/MailingListAddMemberTests.cs
@@ -150,8 +150,8 @@ namespace GetIntoTeachingApiTests.Models.GetIntoTeaching
             var request = new MailingListAddMember() { ChannelId = 123, AddressPostcode = "TE7 8KE" };
 
             request.Candidate.ChannelId.Should().Be(123);
-            request.Candidate.MailingListSubscriptionChannelId.Should().Be(123);
-            request.Candidate.EventsSubscriptionChannelId.Should().Be(123);
+            request.Candidate.MailingListSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
+            request.Candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUpTests.cs
@@ -287,7 +287,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser
             var request = new TeacherTrainingAdviserSignUp() { ChannelId = 123 };
 
             request.Candidate.ChannelId.Should().Be(123);
-            request.Candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be(123);
+            request.Candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
         }
 
         [Fact]

--- a/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
+++ b/GetIntoTeachingApiTests/Services/SubscriptionManagerTests.cs
@@ -30,9 +30,9 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow, 123);
+            SubscriptionManager.SubscribeToMailingList(candidate, DateTime.UtcNow);
 
-            candidate.MailingListSubscriptionChannelId.Should().Be(123);
+            candidate.MailingListSubscriptionChannelId.Should().Be((int) Candidate.SubscriptionChannel.Subscribed);
         }
 
         [Fact]
@@ -84,9 +84,9 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow, 123);
+            SubscriptionManager.SubscribeToEvents(candidate, DateTime.UtcNow);
 
-            candidate.EventsSubscriptionChannelId.Should().Be(123);
+            candidate.EventsSubscriptionChannelId.Should().Be((int)Candidate.SubscriptionChannel.Subscribed);
             candidate.EventsSubscriptionTypeId.Should().Be((int)Candidate.SubscriptionType.SingleEvent);
         }
 
@@ -122,9 +122,9 @@ namespace GetIntoTeachingApiTests.Services
         {
             var candidate = new Candidate();
 
-            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow, 123);
+            SubscriptionManager.SubscribeToTeacherTrainingAdviser(candidate, DateTime.UtcNow);
 
-            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be(123);
+            candidate.TeacherTrainingAdviserSubscriptionChannelId.Should().Be((int) Candidate.SubscriptionChannel.Subscribed);
         }
 
         [Fact]


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/0WVQ6tXc/8109-use-default-creation-channels-on-subscription-records)

An issue was raised [here](https://trello.com/c/CH6rIbQX) which was blocking users from signing up to the mailing list. Upon investigation, this was caused by a mismatch between subscription channel IDs and candidate channel IDs.

This fix switches subscriptions to use their default channel IDs.

NB: this work will very shortly be replaced by the creation channel records framework