### PR TITLE
Adviser-Update API to pass citizenship, visa and location data to CRM

### DIFF
--- a/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
+++ b/GetIntoTeachingApi/Models/Crm/Validators/CandidateValidator.cs
@@ -12,110 +12,110 @@ namespace GetIntoTeachingApi.Models.Crm.Validators
         private static readonly string TelephoneRegex = @"^[^a-zA-Z]+$";
         private readonly string[] _validEligibilityRulesPassedValues = new[] { "true", "false" };
 
-        public CandidateValidator(IStore store, IDateTimeProvider dateTime)
+        public CandidateValidator(IStore store, IDateTimeProvider dateTime) 
         {
-            RuleFor(candidate => candidate.FirstName).MaximumLength(256);
-            RuleFor(candidate => candidate.LastName).MaximumLength(256);
-            RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
-            RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
-            RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(25).Matches(@"^[^a-zA-Z]+$");
-            RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
-            RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
-            RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);
-            RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
-            RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
-            RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
-            RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
-            RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
-            RuleFor(candidate => candidate.AddressPostcode)
-                .SetValidator(new PostcodeValidator<Candidate>())
-                .Unless(candidate => candidate.AddressPostcode == null);
-            RuleFor(candidate => candidate.EligibilityRulesPassed)
-                .Must(value => _validEligibilityRulesPassedValues.Contains(value))
-                .Unless(candidate => candidate.EligibilityRulesPassed == null)
-                .WithMessage("Must be true or false (as string values).");
-
-            RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator(store)).Unless(candidate => candidate.PhoneCall == null);
-            RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(store));
-            RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(store));
-            RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(store));
-            RuleForEach(candidate => candidate.TeachingEventRegistrations).SetValidator(new TeachingEventRegistrationValidator(store));
-
-            RuleFor(candidate => candidate.PreferredTeachingSubjectId)
-                .SetValidator(new TeachingSubjectIdValidator<Candidate>(store))
-                .Unless(candidate => candidate.PreferredTeachingSubjectId == null);
-            RuleFor(candidate => candidate.SecondaryPreferredTeachingSubjectId)
-                .SetValidator(new TeachingSubjectIdValidator<Candidate>(store))
-                .Unless(candidate => candidate.SecondaryPreferredTeachingSubjectId == null);
-            RuleFor(candidate => candidate.CountryId)
-                .SetValidator(new CountryIdValidator<Candidate>(store))
-                .Unless(candidate => candidate.CountryId == null);
-            RuleFor(candidate => candidate.PreferredEducationPhaseId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_preferrededucationphase01", store))
-                .Unless(candidate => candidate.PreferredEducationPhaseId == null);
-            RuleFor(candidate => candidate.InitialTeacherTrainingYearId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_ittyear", store))
-                .Unless(candidate => candidate.InitialTeacherTrainingYearId == null);
-            RuleFor(candidate => candidate.ChannelId)
-                .NotNull()
-                .When(candidate => candidate.Id == null)
-                .When(candidate => candidate.ContactChannelCreations.Count == 0)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_channelcreation", store));
-            RuleFor(candidate => candidate.HasGcseEnglishId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
-                .Unless(candidate => candidate.HasGcseEnglishId == null);
-            RuleFor(candidate => candidate.HasGcseMathsId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
-                .Unless(candidate => candidate.HasGcseMathsId == null);
-            RuleFor(candidate => candidate.HasGcseScienceId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
-                .Unless(candidate => candidate.HasGcseScienceId == null);
-            RuleFor(candidate => candidate.PlanningToRetakeGcseScienceId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
-                .Unless(candidate => candidate.PlanningToRetakeGcseScienceId == null);
-            RuleFor(candidate => candidate.PlanningToRetakeGcseEnglishId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
-                .Unless(candidate => candidate.PlanningToRetakeGcseEnglishId == null);
-            RuleFor(candidate => candidate.PlanningToRetakeGcseMathsId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
-                .Unless(candidate => candidate.PlanningToRetakeGcseMathsId == null);
-            RuleFor(candidate => candidate.ConsiderationJourneyStageId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitewhereinconsiderationjourney", store))
-                .Unless(candidate => candidate.ConsiderationJourneyStageId == null);
-            RuleFor(candidate => candidate.TypeId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_typeofcandidate", store))
-                .Unless(candidate => candidate.TypeId == null);
-            RuleFor(candidate => candidate.AssignmentStatusId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidatestatus", store))
-                .Unless(candidate => candidate.AssignmentStatusId == null);
-            RuleFor(candidate => candidate.AdviserEligibilityId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_iscandidateeligibleforadviser", store))
-                .Unless(candidate => candidate.AdviserEligibilityId == null);
-            RuleFor(candidate => candidate.AdviserRequirementId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitewhereinconsiderationjourney", store))
-                .Unless(candidate => candidate.AdviserRequirementId == null);
-            RuleFor(candidate => candidate.EventsSubscriptionChannelId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitiseventsservicesubscriptionchannel", store))
-                .Unless(candidate => candidate.EventsSubscriptionChannelId == null);
-            RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitismlservicesubscriptionchannel", store))
-                .Unless(candidate => candidate.MailingListSubscriptionChannelId == null);
-            RuleFor(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitisttaservicesubscriptionchannel", store))
-                .Unless(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId == null);
-            RuleFor(candidate => candidate.ApplyPhaseId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
-                .Unless(candidate => candidate.ApplyPhaseId == null);
-            RuleFor(candidate => candidate.ApplyPhaseId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplyphase", store))
-                .Unless(candidate => candidate.ApplyPhaseId == null);
-            RuleFor(candidate => candidate.ApplyStatusId)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
-                .Unless(candidate => candidate.ApplyStatusId == null);
-            RuleFor(candidate => candidate.Situation)
-                .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_situation", store))
-                .Unless(candidate => candidate.Situation == null);
+        RuleFor(candidate => candidate.FirstName).MaximumLength(256);
+        RuleFor(candidate => candidate.LastName).MaximumLength(256);
+        RuleFor(candidate => candidate.Email).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+        RuleFor(candidate => candidate.SecondaryEmail).EmailAddress(EmailValidationMode.AspNetCoreCompatible).MaximumLength(100);
+        RuleFor(candidate => candidate.DateOfBirth).LessThan(candidate => dateTime.UtcNow);
+        RuleFor(candidate => candidate.AddressTelephone).MinimumLength(5).MaximumLength(25).Matches(@"^[^a-zA-Z]+$");
+        RuleFor(candidate => candidate.AddressLine1).MaximumLength(1024);
+        RuleFor(candidate => candidate.AddressLine2).MaximumLength(1024);
+        RuleFor(candidate => candidate.AddressLine3).MaximumLength(1024);
+        RuleFor(candidate => candidate.AddressCity).MaximumLength(128);
+        RuleFor(candidate => candidate.AddressStateOrProvince).MaximumLength(100);
+        RuleFor(candidate => candidate.MobileTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
+        RuleFor(candidate => candidate.Telephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
+        RuleFor(candidate => candidate.SecondaryTelephone).MinimumLength(5).MaximumLength(25).Matches(TelephoneRegex);
+        RuleFor(candidate => candidate.AddressPostcode)
+            .SetValidator(new PostcodeValidator<Candidate>())
+            .Unless(candidate => candidate.AddressPostcode == null);
+        RuleFor(candidate => candidate.EligibilityRulesPassed)
+            .Must(value => _validEligibilityRulesPassedValues.Contains(value))
+            .Unless(candidate => candidate.EligibilityRulesPassed == null)
+            .WithMessage("Must be true or false (as string values).");
+        
+        RuleFor(candidate => candidate.PhoneCall).SetValidator(new PhoneCallValidator(store)).Unless(candidate => candidate.PhoneCall == null);
+        RuleFor(candidate => candidate.PrivacyPolicy).SetValidator(new CandidatePrivacyPolicyValidator(store));
+        RuleForEach(candidate => candidate.Qualifications).SetValidator(new CandidateQualificationValidator(store));
+        RuleForEach(candidate => candidate.PastTeachingPositions).SetValidator(new CandidatePastTeachingPositionValidator(store));
+        RuleForEach(candidate => candidate.TeachingEventRegistrations).SetValidator(new TeachingEventRegistrationValidator(store));
+        
+        RuleFor(candidate => candidate.PreferredTeachingSubjectId)
+            .SetValidator(new TeachingSubjectIdValidator<Candidate>(store))
+            .Unless(candidate => candidate.PreferredTeachingSubjectId == null);
+        RuleFor(candidate => candidate.SecondaryPreferredTeachingSubjectId)
+            .SetValidator(new TeachingSubjectIdValidator<Candidate>(store))
+            .Unless(candidate => candidate.SecondaryPreferredTeachingSubjectId == null);
+        RuleFor(candidate => candidate.CountryId)
+            .SetValidator(new CountryIdValidator<Candidate>(store))
+            .Unless(candidate => candidate.CountryId == null);
+        RuleFor(candidate => candidate.PreferredEducationPhaseId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_preferrededucationphase01", store))
+            .Unless(candidate => candidate.PreferredEducationPhaseId == null);
+        RuleFor(candidate => candidate.InitialTeacherTrainingYearId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_ittyear", store))
+            .Unless(candidate => candidate.InitialTeacherTrainingYearId == null);
+        RuleFor(candidate => candidate.ChannelId)
+            .NotNull()
+            .When(candidate => candidate.Id == null)
+            .When(candidate => candidate.ContactChannelCreations.Count == 0)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_channelcreation", store));
+        RuleFor(candidate => candidate.HasGcseEnglishId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
+            .Unless(candidate => candidate.HasGcseEnglishId == null);
+        RuleFor(candidate => candidate.HasGcseMathsId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
+            .Unless(candidate => candidate.HasGcseMathsId == null);
+        RuleFor(candidate => candidate.HasGcseScienceId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitehasgcseenglish", store))
+            .Unless(candidate => candidate.HasGcseScienceId == null);
+        RuleFor(candidate => candidate.PlanningToRetakeGcseScienceId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
+            .Unless(candidate => candidate.PlanningToRetakeGcseScienceId == null);
+        RuleFor(candidate => candidate.PlanningToRetakeGcseEnglishId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
+            .Unless(candidate => candidate.PlanningToRetakeGcseEnglishId == null);
+        RuleFor(candidate => candidate.PlanningToRetakeGcseMathsId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websiteplanningretakeenglishgcse", store))
+            .Unless(candidate => candidate.PlanningToRetakeGcseMathsId == null);
+        RuleFor(candidate => candidate.ConsiderationJourneyStageId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitewhereinconsiderationjourney", store))
+            .Unless(candidate => candidate.ConsiderationJourneyStageId == null);
+        RuleFor(candidate => candidate.TypeId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_typeofcandidate", store))
+            .Unless(candidate => candidate.TypeId == null);
+        RuleFor(candidate => candidate.AssignmentStatusId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidatestatus", store))
+            .Unless(candidate => candidate.AssignmentStatusId == null);
+        RuleFor(candidate => candidate.AdviserEligibilityId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_iscandidateeligibleforadviser", store))
+            .Unless(candidate => candidate.AdviserEligibilityId == null);
+        RuleFor(candidate => candidate.AdviserRequirementId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_websitewhereinconsiderationjourney", store))
+            .Unless(candidate => candidate.AdviserRequirementId == null);
+        RuleFor(candidate => candidate.EventsSubscriptionChannelId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitiseventsservicesubscriptionchannel", store))
+            .Unless(candidate => candidate.EventsSubscriptionChannelId == null);
+        RuleFor(candidate => candidate.MailingListSubscriptionChannelId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitismlservicesubscriptionchannel", store))
+            .Unless(candidate => candidate.MailingListSubscriptionChannelId == null);
+        RuleFor(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_gitisttaservicesubscriptionchannel", store))
+            .Unless(candidate => candidate.TeacherTrainingAdviserSubscriptionChannelId == null);
+        RuleFor(candidate => candidate.ApplyPhaseId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
+            .Unless(candidate => candidate.ApplyPhaseId == null);
+        RuleFor(candidate => candidate.ApplyPhaseId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplyphase", store))
+            .Unless(candidate => candidate.ApplyPhaseId == null);
+        RuleFor(candidate => candidate.ApplyStatusId)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_candidateapplystatus", store))
+            .Unless(candidate => candidate.ApplyStatusId == null);
+        RuleFor(candidate => candidate.Situation)
+            .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_situation", store))
+            .Unless(candidate => candidate.Situation == null);
             RuleFor(candidate => candidate.Citizenship)
                 .SetValidator(new PickListItemIdValidator<Candidate>("contact", "dfe_citizenship", store))
                 .Unless(candidate => candidate.Citizenship == null);

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -131,6 +131,26 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
         /// Overrides the inferred graduation date to adjust its calculation.
         /// </summary>
         public override DateTime? InferredGraduationDate { get; set; }
+        
+        /// <summary>
+        /// The situation (life stage) of the candidate, which can be used to determine their current status or context.
+        /// </summary>
+        public int? Situation { get; set; }
+
+        /// <summary>
+        /// The citizenship status of the candidate, represented as an integer code.
+        /// </summary>
+        public int? Citizenship { get; set; }
+
+        /// <summary>
+        /// The visa status of the candidate, represented as an integer code.
+        /// </summary>
+        public int? VisaStatus { get; set; }
+
+        /// <summary>
+        ///  The location of the candidate,represented as a string 
+        /// </summary>
+        public string Location { get; set; }
 
         public TeacherTrainingAdviserSignUp()
         {

--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidator.cs
@@ -7,6 +7,7 @@ using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.Crm.Validators;
 using GetIntoTeachingApi.Services;
 using GetIntoTeachingApi.Utils;
+using GetIntoTeachingApi.Validators;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators
@@ -22,6 +23,18 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators
             RuleFor(request => request.AcceptedPolicyId).NotNull();
             RuleFor(request => request.CountryId).NotNull();
             RuleFor(request => request.TypeId).NotNull();
+            
+            //ToDo: Check Rules are correct
+
+            RuleFor(request => request.Situation)
+                .SetValidator(new PickListItemIdValidator<TeacherTrainingAdviserSignUp>("contact", "dfe_situation", store))
+                .Unless(request => request.Situation == null);
+            RuleFor(request => request.Citizenship)
+                .SetValidator(new PickListItemIdValidator<TeacherTrainingAdviserSignUp>("contact", "dfe_citizenship", store))
+                .Unless(request => request.Citizenship == null);
+            RuleFor(request => request.VisaStatus)
+                .SetValidator(new PickListItemIdValidator<TeacherTrainingAdviserSignUp>("contact", "dfe_visastatus", store))
+                .Unless(request => request.VisaStatus == null);
 
             RuleFor(request => request.AddressTelephone).NotNull()
                 .When(request => request.PhoneCallScheduledAt != null)
@@ -114,6 +127,8 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators
             });
 
             RuleFor(request => request.Candidate).SetValidator(new CandidateValidator(store, dateTime));
+            
+            
         }
 
         public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)

--- a/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/Crm/Validators/CandidateValidatorTests.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Bogus;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using GetIntoTeachingApi.Models;
 using GetIntoTeachingApi.Models.Crm;
 using GetIntoTeachingApi.Models.Crm.Validators;
 using GetIntoTeachingApi.Services;
+using GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators;
 using Moq;
 using Xunit;
 
@@ -28,8 +30,45 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
         {
             var mockSubject = new TeachingSubject { Id = Guid.NewGuid() };
             var mockCountry = new Country { Id = Guid.NewGuid() };
-            var mockPickListItem = new PickListItem { Id = 123 };
             var mockPrivacyPolicy = new PrivacyPolicy { Id = Guid.NewGuid() };
+
+            PickListItem fakePeferrededucationphase = new PickListItem() { Id = 222750004, EntityName = "contact", AttributeName = "dfe_preferrededucationphase01" };
+            PickListItem fakeCitizenship = new PickListItem { Id = 222750001, EntityName = "contact", AttributeName = "dfe_citizenship" };
+            PickListItem fakeIttyear = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_ittyear" }; 
+            PickListItem fakeChannelcreation = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_channelcreation" };
+            PickListItem fakeWebsitehasgcseenglish = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_websitehasgcseenglish" };
+            PickListItem fakeWebsiteplanningretakeenglishgcse = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_websiteplanningretakeenglishgcse" };
+            PickListItem fakeWebsitewhereinconsiderationjourney = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_websitewhereinconsiderationjourney" };
+            PickListItem fakeTypeofcandidate = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_typeofcandidate" };
+            PickListItem fakeCandidatestatus = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_candidatestatus" };
+            PickListItem fakeIscandidateeligibleforadviser = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_iscandidateeligibleforadviser" };
+            PickListItem fakeGitiseventsservicesubscriptionchannel = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_gitiseventsservicesubscriptionchannel" };
+            PickListItem fakeGitismlservicesubscriptionchannel = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_gitismlservicesubscriptionchannel" };
+            PickListItem fakeGitisttaservicesubscriptionchannel = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_gitisttaservicesubscriptionchannel" };
+            PickListItem fakeCandidateapplystatus = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_candidateapplystatus" };
+            PickListItem fakeCandidateapplyphase = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_candidateapplyphase" };
+            PickListItem fakeSituation = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_situation" };
+            PickListItem fakeVisastatus = new PickListItem() { Id  = 12909, EntityName = "contact", AttributeName = "dfe_visastatus" };
+            
+            List<PickListItem> fakePickList = FakePickListItem.Default.Generate(100);
+            
+            fakePickList.Add(fakePeferrededucationphase);
+            fakePickList.Add(fakeIttyear);
+            fakePickList.Add(fakeCitizenship);
+            fakePickList.Add(fakeChannelcreation);
+            fakePickList.Add(fakeWebsitehasgcseenglish);
+            fakePickList.Add(fakeWebsiteplanningretakeenglishgcse);
+            fakePickList.Add(fakeWebsitewhereinconsiderationjourney);
+            fakePickList.Add(fakeTypeofcandidate);
+            fakePickList.Add(fakeCandidatestatus);
+            fakePickList.Add(fakeIscandidateeligibleforadviser);
+            fakePickList.Add(fakeGitiseventsservicesubscriptionchannel);
+            fakePickList.Add(fakeGitismlservicesubscriptionchannel);
+            fakePickList.Add(fakeGitisttaservicesubscriptionchannel);
+            fakePickList.Add(fakeCandidateapplystatus);
+            fakePickList.Add(fakeCandidateapplyphase);
+            fakePickList.Add(fakeSituation);
+            
 
             _mockStore
                 .Setup(mock => mock.GetTeachingSubjects())
@@ -38,53 +77,8 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 .Setup(mock => mock.GetCountries())
                 .Returns(new[] { mockCountry }.AsQueryable());
             _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_preferrededucationphase01"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_ittyear"))
-                .Returns(new[] { mockPickListItem }.AsQueryable);
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_channelcreation"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitismlservicesubscriptionchannel"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitiseventsservicesubscriptionchannel"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_gitisttaservicesubscriptionchannel"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_websitehasgcseenglish"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_websiteplanningretakeenglishgcse"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_websitewhereinconsiderationjourney"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_typeofcandidate"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_candidatestatus"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_iscandidateeligibleforadviser"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_isadvisorrequiredos"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_candidateapplystatus"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_candidateapplyphase"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
-            _mockStore
-                .Setup(mock => mock.GetPickListItems("contact", "dfe_situation"))
-                .Returns(new[] { mockPickListItem }.AsQueryable());
+                .Setup(mock => mock.GetPickListItems(It.IsAny<string>(), It.IsAny<String>()))
+                .Returns(fakePickList.AsQueryable);
             _mockStore
                 .Setup(mock => mock.GetPrivacyPolicies())
                 .Returns(new[] { mockPrivacyPolicy }.AsQueryable());
@@ -106,32 +100,34 @@ namespace GetIntoTeachingApiTests.Models.Crm.Validators
                 SecondaryTelephone = "07584 734 576",
                 MobileTelephone = "07584 734 576",
                 HasDbsCertificate = true,
-                HasGcseMathsId = mockPickListItem.Id,
-                HasGcseEnglishId = mockPickListItem.Id,
-                AdviserEligibilityId = mockPickListItem.Id,
-                PlanningToRetakeGcseScienceId = mockPickListItem.Id,
-                PlanningToRetakeGcseEnglishId = mockPickListItem.Id,
-                TypeId = mockPickListItem.Id,
-                AssignmentStatusId = mockPickListItem.Id,
+                HasGcseMathsId = fakeWebsitehasgcseenglish.Id, //ToDo: Check this validation
+                HasGcseEnglishId = fakeWebsitehasgcseenglish.Id,
+                AdviserEligibilityId = fakeIscandidateeligibleforadviser.Id,
+                PlanningToRetakeGcseScienceId = fakeWebsiteplanningretakeenglishgcse.Id,
+                PlanningToRetakeGcseEnglishId = fakeWebsiteplanningretakeenglishgcse.Id,
+                TypeId = fakeTypeofcandidate.Id,
+                AssignmentStatusId = fakeTypeofcandidate.Id,
                 DoNotPostalMail = false,
                 EligibilityRulesPassed = "true",
-                ConsiderationJourneyStageId = mockPickListItem.Id,
+                ConsiderationJourneyStageId = fakeWebsitewhereinconsiderationjourney.Id,
                 CountryId = mockCountry.Id,
                 PreferredTeachingSubjectId = mockSubject.Id,
-                PreferredEducationPhaseId = mockPickListItem.Id,
-                InitialTeacherTrainingYearId = mockPickListItem.Id,
-                ChannelId = mockPickListItem.Id,
-                MailingListSubscriptionChannelId = mockPickListItem.Id,
-                EventsSubscriptionChannelId = mockPickListItem.Id,
-                TeacherTrainingAdviserSubscriptionChannelId = mockPickListItem.Id,
-                ApplyPhaseId = mockPickListItem.Id,
-                ApplyStatusId = mockPickListItem.Id,
-                Situation = mockPickListItem.Id,
-                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id }
+                PreferredEducationPhaseId = fakePeferrededucationphase.Id,
+                InitialTeacherTrainingYearId = fakeIttyear.Id,
+                ChannelId = fakeChannelcreation.Id,
+                MailingListSubscriptionChannelId = fakeGitismlservicesubscriptionchannel.Id,
+                EventsSubscriptionChannelId = fakeGitiseventsservicesubscriptionchannel.Id,
+                TeacherTrainingAdviserSubscriptionChannelId = fakeGitisttaservicesubscriptionchannel.Id,
+                ApplyPhaseId = fakeCandidateapplyphase.Id,
+                ApplyStatusId = fakeCandidateapplystatus.Id,
+                Situation = fakeSituation.Id,
+                PrivacyPolicy = new CandidatePrivacyPolicy() { AcceptedPolicyId = (Guid)mockPrivacyPolicy.Id },
+                Citizenship = fakeCitizenship.Id,
+                VisaStatus = fakeVisastatus.Id
             };
 
-            var result = _validator.TestValidate(candidate);
-
+            TestValidationResult<Candidate> result = _validator.TestValidate(candidate);
+   
             result.IsValid.Should().BeTrue();
         }
 

--- a/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/Fakes/FakePickListItem.cs
+++ b/GetIntoTeachingApiTests/Models/GetIntoTeaching/Validators/Fakes/FakePickListItem.cs
@@ -1,0 +1,17 @@
+using Bogus;
+using GetIntoTeachingApi.Models;
+
+namespace GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators;
+
+public class FakePickListItem: Faker<PickListItem>
+{
+    string[] entityNames = new []{ "contact", "dfe_contactchannelcreation" };
+    public FakePickListItem()
+    {
+        RuleFor(p => p.Id, faker => faker.UniqueIndex + 1);
+        RuleFor(p => p.EntityName, faker => faker.PickRandom(entityNames));
+        RuleFor(p => p.AttributeName, faker => faker.Commerce.ProductAdjective());
+    }
+
+    public static Faker<PickListItem> Default = new Faker<FakePickListItem>();
+}

--- a/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
+++ b/GetIntoTeachingApiTests/Models/TeacherTrainingAdviser/Validators/TeacherTrainingAdviserSignUpValidatorTests.cs
@@ -7,7 +7,9 @@ using GetIntoTeachingApi.Models.TeacherTrainingAdviser.Validators;
 using GetIntoTeachingApi.Services;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using GetIntoTeachingApiTests.Models.GetIntoTeaching.Validators;
 using Xunit;
 
 namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
@@ -116,16 +118,29 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
         {
             private readonly TeacherTrainingAdviserSignUpValidator _validator;
             private readonly TeacherTrainingAdviserSignUp _request;
+            private readonly Mock<IStore> _mockStore =  new Mock<IStore>();
 
             public ReturningToTeacherTraining()
             {
-                _validator = new TeacherTrainingAdviserSignUpValidator(new Mock<IStore>().Object, new DateTimeProvider());
+                _validator = new TeacherTrainingAdviserSignUpValidator(_mockStore.Object, new DateTimeProvider());
                 _request = new TeacherTrainingAdviserSignUp() { TypeId = (int)Candidate.Type.ReturningToTeacherTraining };
             }
 
             [Fact]
             public void Validate_WhenValid_HasNoErrors()
             {
+                List<PickListItem> fakePickList = FakePickListItem.Default.Generate(100);
+                _mockStore.Setup(p => p.GetPickListItems(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(fakePickList.AsQueryable);
+                PickListItem fakeCitizenship = new PickListItem { Id = 222750001, EntityName = "contact", AttributeName = "dfe_citizenship" };
+                PickListItem fakeSituation = new PickListItem() { Id = 12909, EntityName = "contact", AttributeName = "dfe_situation" };
+                PickListItem fakeVisastatus = new PickListItem() { Id = 12345, EntityName = "contact", AttributeName = "dfe_visastatus" };
+
+
+                fakePickList.Add(fakeCitizenship);
+                fakePickList.Add(fakeSituation);
+                fakePickList.Add(fakeVisastatus);
+                
                 _request.CandidateId = Guid.NewGuid();
                 _request.PastTeachingPositionId = Guid.NewGuid();
                 _request.AcceptedPolicyId = Guid.NewGuid();
@@ -139,6 +154,9 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
                 _request.TeacherId = "abc123";
                 _request.AddressTelephone = "1234567";
                 _request.AddressPostcode = "KY11 9YU";
+                _request.Citizenship = fakeCitizenship.Id;
+                _request.Situation = fakeSituation.Id;
+                _request.VisaStatus = fakeVisastatus.Id;
 
                 var result = _validator.TestValidate(_request);
 
@@ -261,6 +279,7 @@ namespace GetIntoTeachingApiTests.Models.TeacherTrainingAdviser.Validators
                 _request.Email = "email@address.com";
                 _request.DateOfBirth = DateTime.UtcNow;
                 _request.AddressTelephone = "1234567";
+                _request.Location = "Location";
 
                 var result = _validator.TestValidate(_request);
 


### PR DESCRIPTION
We need to update the API to pass the following data to the CRM

Citizenship (for all mailing list completions)
Visa (only for non-UK citizens)
Location  (only for non-UK citizens)

Fields added and Tests modified.

ToDo: Take a deeper dive into the tests and ensure they are testing the correct things with validations on the CRM