### PR TITLE
Remove quotes from failure message

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -269,7 +269,7 @@ jobs:
           title: Build and Deploy
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           message: |
-            "Deployment to the ${{ matrix.environment }} environment has failed"
+            Deployment to the ${{ matrix.environment }} environment has failed
 
   deploy_production:
     name: Deploy to production environment


### PR DESCRIPTION
Double quotes on the message for github-actions/send-to-teams-channel causes a failure of the teams notification
- remove the quotes