### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -166,7 +166,7 @@ jobs:
           echo "app_hostname=${REVIEW_APP_URL}" >> $GITHUB_OUTPUT
 
       - name: Update PR with Review App URL
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           header: review-app
           number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,6 +42,6 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
 
     - name: Lint Dockerfile
-      uses: brpaz/hadolint-action@master
+      uses: brpaz/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # Pinned at v3.3.0
       with:
         dockerfile: "Dockerfile"


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR