### PR TITLE
Bump Bogus from 35.6.2 to 35.6.5

### DIFF
--- a/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
+++ b/GetIntoTeachingApiTests/GetIntoTeachingApiTests.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Bogus" Version="35.6.2" />
+	<PackageReference Include="Bogus" Version="35.6.5" />
 	<PackageReference Include="coverlet.msbuild" Version="6.0.2">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Recreating dependabot PR

---
updated-dependencies:
- dependency-name: Bogus dependency-version: 35.6.5 dependency-type: direct:production update-type: version-update:semver-patch ...