### PR TITLE
Remove test path from PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,6 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
-      - 'GetIntoTeachingApiTests/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
Delete the 'GetIntoTeachingApiTests/**' entry from .github/workflows/pull_request.yml exclusion paths