### PR TITLE
Add GraduationYear to adviser sign-up payload

### DIFF
--- a/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
+++ b/GetIntoTeachingApi/Models/TeacherTrainingAdviser/TeacherTrainingAdviserSignUp.cs
@@ -396,7 +396,8 @@ namespace GetIntoTeachingApi.Models.TeacherTrainingAdviser
                     DegreeStatusId = DegreeStatusId,
                     DegreeSubject = DegreeSubject,
                     TypeId = DegreeTypeId,
-                    DegreeCountry = (Guid?)DegreeCountry
+                    DegreeCountry = (Guid?)DegreeCountry,
+                    GraduationYear = InferredGraduationDate
                 });
             }
         }

--- a/GetIntoTeachingApiTests/Contracts/Input/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
@@ -8,6 +8,7 @@
   "typeId": 222750000,
   "ukDegreeGradeId": 222750001,
   "degreeStatusId": 222750001,
+  "graduationYear": 2026,
   "degreeTypeId": 222750000,
   "degreeCountry": "72f5c2e6-74f9-e811-a97a-000d3a2760f2",
   "initialTeacherTrainingYearId": 22303,

--- a/GetIntoTeachingApiTests/Contracts/Input/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Input/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
@@ -8,6 +8,7 @@
   "typeId": 222750000,
   "ukDegreeGradeId": null,
   "degreeStatusId": 222750003,
+  "graduationYear": 2035,
   "degreeTypeId": 222750000,
   "degreeCountry": "72f5c2e6-74f9-e811-a97a-000d3a2760f2",
   "initialTeacherTrainingYearId": null,

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_primary_has_retaking_gcses_overseas.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_primary_has_retaking_gcses_overseas.json
@@ -322,6 +322,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : null
+      },
+      {
         "Key": "dfe_subject",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_secondary_has_gcses_is_in_uk.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_equivalent_degree_secondary_has_gcses_is_in_uk.json
@@ -322,6 +322,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : null
+      },
+      {
         "Key": "dfe_subject",
         "Value": null
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_primary_has_gcses_in_the_uk_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_primary_has_gcses_in_the_uk_and_telephone.json
@@ -332,6 +332,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : null
+      },
+      {
         "Key": "dfe_subject",
         "Value": "Physics"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_secodary_retaking_gcses_overseas_and_no_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_has_degree_secodary_retaking_gcses_overseas_and_no_telephone.json
@@ -336,6 +336,10 @@
         "Value": "Maths"
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : null
+      },
+      {
         "Key": "dfe_type",
         "Value": {
           "Value": 222750000

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_final_year_overseas_and_telephone.json
@@ -332,6 +332,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : "2026-08-31T00:00:00"
+      },
+      {
         "Key": "dfe_subject",
         "Value": "Physics"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_a_new_candidate_not_returning_studying_for_degree_not_final_year_overseas_and_telephone.json
@@ -328,6 +328,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : "2035-08-31T00:00:00"
+      },
+      {
         "Key": "dfe_subject",
         "Value": "Physics"
       },

--- a/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_when_in_a_closed_state_not_returning_existing_data_change_country.json
+++ b/GetIntoTeachingApiTests/Contracts/Output/TeacherTrainingAdviser/sign_up_with_an_existing_candidate_when_in_a_closed_state_not_returning_existing_data_change_country.json
@@ -328,6 +328,10 @@
         }
       },
       {
+        "Key" : "dfe_graduationyear",
+        "Value" : null
+      },
+      {
         "Key": "dfe_subject",
         "Value": "Maths"
       },

--- a/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
+++ b/GetIntoTeachingApiTests/Controllers/TeacherTrainingAdviser/CandidatesControllerTests.cs
@@ -184,6 +184,8 @@ namespace GetIntoTeachingApiTests.Controllers.TeacherTrainingAdviser
             // assert
             Assert.IsType<OkObjectResult>(response);
             Assert.Equal(222750000, responseObject.GetType().GetProperty("DegreeStatusId").GetValue(responseObject, null));
+            Assert.Equal(2024, request.GraduationYear);
+            Assert.Equal(new DateTime(2024, 08, 31), request.InferredGraduationDate);
 
             _mockJobClient.Verify(job =>
                 job.Create(


### PR DESCRIPTION
Include GraduationYear (from InferredGraduationDate) when mapping degree information into the TeacherTrainingAdviser sign-up payload. Update unit tests to assert GraduationYear and InferredGraduationDate are set correctly, while preserving existing DegreeStatusId verification.