### PR TITLE
GIT endpoints for CRM spec

### DIFF
--- a/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerBook.md
+++ b/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerBook.md
@@ -1,0 +1,103 @@
+## POST `/api/get_into_teaching/callbacks`
+
+Please check existing code and swagger doc for reference. There might be mistakes or things that I've missed here.
+https://getintoteachingapi-test.test.teacherservices.cloud/swagger/index.html
+
+**File:** `Controllers/GetIntoTeaching/CallbacksController.cs:38`
+
+Schedules a callback (phone call) for a candidate. Validates the request, builds a `Candidate` with minimal business logic (phone call + privacy policy), serializes with change tracking, and enqueues an `UpsertCandidateJob` to persist to CRM. Returns `204 No Content` — CRM upsert is async.
+
+## What it does (step by step)
+
+1. Validates the request (ModelState via FluentValidation `GetIntoTeachingCallbackValidator`) — returns `400` with serialized errors if invalid
+2. Constructs a `Candidate` via `request.Candidate` (calls `CreateCandidate()`):
+   - **Maps scalar fields**: candidate ID, email, first name, last name, address telephone
+   - **Configures channel** via `ConfigureChannel()`: sets `ChannelId` (GetIntoTeachingCallback when `DISABLE_DEFAULT_CREATION_CHANNELS=1` and candidate is new), or creates `ContactChannelCreation` entries with `CreationChannelSourceId` (GIT Website), `CreationChannelServiceId` (Mailing List), `CreationChannelActivityId` (null)
+   - **Schedules phone call** (if `PhoneCallScheduledAt` is set):
+     - Creates a `PhoneCall` with destination **hardcoded to UK**, channel `WebsiteCallbackRequest`, subject including full name, and `TalkingPoints`
+   - **Accepts privacy policy**: if `AcceptedPolicyId` is set, creates a `CandidatePrivacyPolicy` with the accepted policy ID and current timestamp
+3. Serializes the constructed candidate with change tracking (`SerializeChangeTracked`)
+4. Enqueues `UpsertCandidateJob.Run(json, null)` via Hangfire (async CRM upsert)
+5. Returns `204 No Content`
+
+## Request
+
+```json
+{
+  "candidateId": null,
+  "email": "jane.doe@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "addressTelephone": "07123456789",
+  "phoneCallScheduledAt": "2026-06-20T14:30:00Z",
+  "talkingPoints": "I want to know more about teaching Maths",
+  "acceptedPolicyId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+### Field details
+
+| Param | Type | Required | Notes |
+|-------|------|----------|-------|
+| `email` | `string` | **Yes** | Validated for format + max 100 chars |
+| `firstName` | `string` | **Yes** | Non-empty |
+| `lastName` | `string` | **Yes** | Non-empty |
+| `addressTelephone` | `string` | **Yes** | Validated 5-25 chars, no alpha chars |
+| `phoneCallScheduledAt` | `DateTime` | **Yes** | Must be in the future |
+| `talkingPoints` | `string` | **Yes** | Non-empty — what the candidate wants to discuss |
+| `acceptedPolicyId` | `Guid` | **Yes** | |
+| `candidateId` | `Guid` | No | Set for existing candidates (matchback/exchange) — null for new callbacks |
+| `creationChannelSourceId` | `int` | No | Overrides default GIT Website source |
+| `creationChannelServiceId` | `int` | No | Overrides default Mailing List service |
+| `creationChannelActivityId` | `int` | No | Overrides default null activity |
+
+## Responses
+
+### `204 No Content` — callback queued for upsert
+
+No body.
+
+### `400 Bad Request` — validation failed. This is a new proposed error format
+
+```json
+{
+    "errors": [
+        {
+            "error": "BadRequest",
+            "message": "Email is not a valid email address"
+        }
+    ]
+}
+```
+
+## What happens next (async job)
+
+The `UpsertCandidateJob` runs asynchronously (same job as all other upsert endpoints):
+
+1. **Deduplication**: if a job with the same signature (`candidate.Id + Email + changed properties`) is already queued, the duplicate is silently dropped
+2. **CRM pause check**: throws `InvalidOperationException` if CRM integration is paused (Hangfire retry will fire)
+3. **Upsert**: calls `ICandidateUpserter.Upsert(candidate)` to persist the candidate, phone call, privacy policy, and contact channel creation to CRM
+4. **Retry & failure**: on repeated failure, after all retries exhausted, sends a failure notification email via GOV.UK Notify (`CandidateRegistrationFailedEmailTemplateId`)
+
+## Flow
+
+```mermaid
+flowchart TD
+    Client["Client App"]
+    B["Book()"]
+    V["1. Validate request\n(FluentValidation)"]
+    C["2. Build Candidate via CreateCandidate()\n━━━━━━━━━━━━━━━━━━━━━━\n• Map scalars (name, email, phone)\n• Configure channel\n• Schedule phone call (UK only)\n• Accept privacy policy"]
+    J["3. Serialize + enqueue\nUpsertCandidateJob"]
+    R["4. 204 No Content"]
+
+    Client --> B --> V
+    V -->|invalid| 400
+    V -->|valid| C --> J --> R
+```
+
+## Rate limiting
+
+| Scope | Endpoint | Period | Limit |
+|-------|----------|--------|-------|
+| Global (IpRateLimiting) | `POST:/api/get_into_teaching/callbacks` | 1m | 60 |
+| GIT client | `POST:/api/get_into_teaching/callbacks` | 1m | 250 |

--- a/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerExchangeAccessToken.md
+++ b/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerExchangeAccessToken.md
@@ -1,0 +1,109 @@
+## POST `/api/get_into_teaching/callbacks/exchange_access_token/{accessToken}`
+
+Please check existing code and swagger doc for reference. There might be mistakes or things that I've missed here.
+https://getintoteachingapi-test.test.teacherservices.cloud/swagger/index.html
+
+**File:** `Controllers/GetIntoTeaching/CallbacksController.cs:63`
+
+Second step of the two-step email verification flow for Get Into Teaching callbacks. The user proves they own the email by providing the 6-digit PIN they received from `POST /api/candidates/access_tokens`. If valid, returns their existing CRM data pre-populated into a `GetIntoTeachingCallback`.
+
+## What it does (step by step)
+
+1. Sets `request.Reference` to `User.Identity.Name` (JWT client ID) if not already set
+2. Calls `_crm.MatchCandidate(request)` — live CRM query by email (`Services/CrmService.cs:161`)
+   - Generates equivalent email variants via `EmailReconciler` (gmail.com ↔ googlemail.com)
+   - Searches `emailaddress1` and `emailaddress2` for any variant
+   - Filters to active (`statecode = Active`) candidates only
+   - Orders by `dfe_duplicatescorecalculated` descending, then `modifiedon` descending
+   - Takes the top match
+   - Loads related data: qualifications, past teaching positions, event registrations
+3. Calls `_tokenService.IsValid(accessToken, request, candidateId)` — recomputes the TOTP from `Slugify(request)` + server `TOTP_SECRET_KEY` via OtpNet (`Services/CandidateAccessTokenService.cs:37-60`). Valid for ~15 minutes
+4. If candidate not found or PIN invalid → `401 Unauthorized` (same response for both cases to avoid revealing candidate existence)
+5. If valid → returns `200 OK` with `new GetIntoTeachingCallback(candidate)` which calls `PopulateWithCandidate()` — populates `CandidateId`, `Email`, `FirstName`, `LastName`, `AddressTelephone` (with `StripExitCode` removing leading `00`)
+
+## Request
+
+```json
+{
+  "email": "candidate@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "dateOfBirth": "1995-06-15",
+  "reference": "ref"
+}
+```
+
+| Param | Location | Type | Required | Notes |
+|-------|----------|------|----------|-------|
+| `accessToken` | URL path | `string` | **Yes** | The 6-digit PIN |
+| `email` | body | `string` | **Yes** | Must match what was sent to `access_tokens` |
+| `firstName` | body | `string` | No | Must match what was sent to `access_tokens` |
+| `lastName` | body | `string` | No | Must match what was sent to `access_tokens` |
+| `dateOfBirth` | body | `DateTime` | No | Must match what was sent to `access_tokens` |
+| `reference` | body | `string` | No | Set from JWT if not provided; not used in TOTP |
+
+The body fields used in TOTP computation (`email`, `firstName`, `lastName`, `dateOfBirth`) must match exactly what was sent to `POST /api/candidates/access_tokens` — if any of them differ, the PIN won't verify. `reference` is excluded from TOTP and doesn't need to match.
+
+## Responses
+
+### `200 OK` — PIN valid
+
+Returns a full `GetIntoTeachingCallback` JSON with the candidate's existing CRM data pre-populated (same response shape as matchback).
+
+```json
+{
+  "candidateId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "acceptedPolicyId": null,
+  "email": "candidate@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "addressTelephone": "123456789",
+  "phoneCallScheduledAt": null,
+  "talkingPoints": null,
+  "creationChannelSourceId": null,
+  "creationChannelServiceId": null,
+  "creationChannelActivityId": null,
+  "defaultContactCreationChannel": 222750043,
+  "defaultCreationChannelSourceId": 222750003,
+  "defaultCreationChannelServiceId": 222750007,
+  "defaultCreationChannelActivityId": null
+}
+```
+
+Only `CandidateId`, `Email`, `FirstName`, `LastName`, `AddressTelephone` are populated from CRM. All other fields are null or computed from `ICreateContactChannel` interface defaults.
+
+### `401 Unauthorized` — This is a new proposed error format
+
+```json
+{
+    "errors": [
+        {
+            "error": "BadRequest",
+            "message": "You did not supply valid authentication credentials"
+        }
+    ]
+}
+```
+
+- Unlike the `Book`(/api/get_into_teaching/callbacks) endpoint, this method does **not** validate `ModelState` — it relies on the CRM match providing a null return for invalid email lookups
+- Unlike the TTA `matchback` endpoint, this endpoint does **not** check for CRM integration pause
+- The returned `GetIntoTeachingCallback` is the same model used by the `Book` and `matchback` endpoints
+
+## Flow
+
+```mermaid
+flowchart TD
+    Client["Client App"]
+    C["ExchangeAccessToken(pin, body)"]
+    Ref["1. Set Reference from JWT"]
+    M["2. MatchCandidate(email)\n→ live CRM query"]
+    V["3. IsValid(pin, request, candidateId)\n→ recompute TOTP from data + secret"]
+    Populate["4. Build GetIntoTeachingCallback\nfrom CRM candidate"]
+    R["200 OK\n(pre-populated callback)"]
+
+    Client --> C --> Ref --> M
+    M -->|null| 401
+    M -->|found| V
+    V -->|invalid| 401
+    V -->|valid| Populate --> R
+```

--- a/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerMatchback.md
+++ b/docs/crm_upsert_specs/GetIntoTeachingCallbacksControllerMatchback.md
@@ -1,0 +1,128 @@
+## POST `/api/get_into_teaching/callbacks/matchback`
+
+Please check existing code and swagger doc for reference. There might be mistakes or things that I've missed here.
+https://getintoteachingapi-test.test.teacherservices.cloud/swagger/index.html
+
+**File:** `Controllers/GetIntoTeaching/CallbacksController.cs:90`
+
+Matches a candidate by email in CRM and returns a pre-populated `GetIntoTeachingCallback` with their known data (name, phone number, candidate ID). This is a live request to the CRM. Unlike `exchange_access_token`, this endpoint requires no PIN — it matches and returns data in a single call.
+
+## What it does (step by step)
+
+1. Sets `request.Reference` to `User.Identity.Name` (JWT client ID) if not already set
+2. Validates the request (ModelState via `ExistingCandidateRequestValidator`) — email is non-empty, valid format, max 100 chars — returns `400` if invalid
+3. Calls `_crm.MatchCandidate(request)` — live CRM query (`Services/CrmService.cs:161`):
+   - Generates equivalent email variants (e.g. gmail.com ↔ googlemail.com) via `EmailReconciler`
+   - Searches `emailaddress1` and `emailaddress2` for any variant
+   - Filters to active (`statecode = Active`) candidates only
+   - Orders by `dfe_duplicatescorecalculated` descending, then `modifiedon` descending
+   - Takes the top match
+   - Loads related data: qualifications, past teaching positions, event registrations
+4. If no candidate found — returns `404 NotFound`
+5. Builds a `GetIntoTeachingCallback` from the matched candidate via `PopulateWithCandidate()` — populates `CandidateId`, `Email`, `FirstName`, `LastName`, `AddressTelephone` (with `StripExitCode` removing leading `00`)
+6. Returns `200 OK` with the pre-populated callback
+
+## Request
+
+```json
+{
+  "email": "candidate@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "dateOfBirth": "1995-06-15",
+  "reference": "ref"
+}
+```
+
+| Param | Type | Required | Notes |
+|-------|------|----------|-------|
+| `email` | `string` | **Yes** | Validated for format + max 100 chars |
+| `firstName` | `string` | No | Used in matchback (may improve CRM match quality) |
+| `lastName` | `string` | No | Used in matchback |
+| `dateOfBirth` | `DateTime` | No | Used in matchback |
+| `reference` | `string` | No | Fallback to JWT client ID if not provided; used for metrics only |
+
+## Responses
+
+### `200 OK` — candidate matched
+
+Returns a full `GetIntoTeachingCallback` JSON. Only 5 fields are populated from CRM (`PopulateWithCandidate()`); the rest are null or computed defaults.
+
+```json
+{
+  "candidateId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "acceptedPolicyId": null,
+  "email": "candidate@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "addressTelephone": "123456789",
+  "phoneCallScheduledAt": null,
+  "talkingPoints": null,
+  "creationChannelSourceId": null,
+  "creationChannelServiceId": null,
+  "creationChannelActivityId": null,
+  "defaultContactCreationChannel": 222750043,
+  "defaultCreationChannelSourceId": 222750003,
+  "defaultCreationChannelServiceId": 222750007,
+  "defaultCreationChannelActivityId": null
+}
+```
+
+### `400 Bad Request` — invalid email. This is a new proposed error format
+```json
+{
+    "errors": [
+        {
+            "error": "BadRequest",
+            "message": "Email is not a valid email address"
+        }
+    ]
+}
+```
+
+### `404 Not Found` — candidate not found. This is a new proposed error format
+
+```json
+{
+    "errors": [
+        {
+            "error": "NotFound",
+            "message": "Candidate with #{email} not found"
+        }
+    ]
+}
+```
+
+
+## Notes
+
+- Unlike the TTA `matchback` endpoint, this endpoint does **not** check for CRM integration pause — it always queries CRM live
+- No background job
+- The same `GetIntoTeachingCallback` model is shared with the `Book`(/api/get_into_teaching/callbacks) and `exchange_access_token` endpoints
+- The response populates only `CandidateId`, `Email`, `FirstName`, `LastName`, `AddressTelephone`. All other fields (`AcceptedPolicyId`, `PhoneCallScheduledAt`, `TalkingPoints`, `CreationChannel*`) are null. The `Default*` fields are computed from `ICreateContactChannel` interface constants.
+
+## Flow
+
+```mermaid
+flowchart TD
+    Client["Client App"]
+    M["Matchback()"]
+    Ref["1. Set Reference from JWT"]
+    V["2. Validate request\n(email required)"]
+    Match["3. MatchCandidate(email)\n→ live CRM query:\nemailaddress1/2,\nactive only,\ntop by duplicate score"]
+    Populate["4. Build GetIntoTeachingCallback\nfrom matched candidate"]
+    R["5. 200 OK + pre-populated callback"]
+
+    Client --> M --> Ref --> V
+    V -->|invalid| 400
+    V -->|valid| Match
+    Match -->|null| 404
+    Match -->|found| Populate --> R
+```
+
+## Proposed changes
+### Require dateOfBirth param
+
+This endpoint has been flagged as a potential security risk because the only required param is `email`. This makes it easy to get information on candidates.
+
+We propose to make `dateOfBirth` param required along side the `email`.


### PR DESCRIPTION
This adds the CRM specs for 3 POST endpoints in the get_into_teaching namespace

/api/get_into_teaching/callbacks
/api/get_into_teaching/matchbacks
/api/get_into_teaching/candidates/exchange_access_token/{accessToken}

Please view this in a markdown viewer