### PR TITLE
Run PR workflow for docs changes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
-      - 'docs/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
Remove 'docs/**' from paths-ignore in .github/workflows/pull_request.yml so the pull_request workflow will run when documentation files are modified. Ensures CI checks are executed for doc updates.