### PR TITLE
Stop ignoring docs/** in CI workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,14 +22,12 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
-      - 'docs/**'
   push:
     branches:
       - master
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
-      - 'docs/**'
       - 'GetIntoTeachingApiTests/**'
 
 permissions:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,13 +5,11 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
-      - 'docs/**'
   push:
     branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
-      - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -53,7 +53,7 @@ jobs:
             /k:"DFE-Digital_get-into-teaching-api" \
             /o:"dfe-digital" \
             /n:"get-into-teaching-api" \
-            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cpd.exclusions="GetIntoTeachingApi/Migrations/*.cs" \
             /d:sonar.cs.opencover.reportsPaths="GetIntoTeachingApiTests/coverage.opencover.xml" \
@@ -71,7 +71,7 @@ jobs:
             /d:sonar.log.level="DEBUG"
           dotnet build
           dotnet test --no-build --logger:trx -e:CollectCoverage=true -e:CoverletOutputFormat=opencover
-          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: Notify teams channel on job failure
         if: failure() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Remove 'docs/**' from paths-ignore in .github/workflows/build-and-deploy.yml and .github/workflows/sonarcloud.yml so documentation changes will trigger the build and SonarCloud workflows. This ensures docs updates are validated and scanned alongside code changes.