### PR TITLE
Remove proposed change from /api/schools_experience/candidates

### DIFF
--- a/docs/crm_upsert_specs/SchoolsExperienceCandidatesControllerSignUp.md
+++ b/docs/crm_upsert_specs/SchoolsExperienceCandidatesControllerSignUp.md
@@ -240,8 +240,3 @@ flowchart TD
     E -->|no| R
     E -->|yes| UQ
 ```
-
-## Proposed changes
-
-- We want this endpoint to be async. It should accept the same params and return 204 status code without a body.
-- The upsert to the CRM should happen in a background job.


### PR DESCRIPTION
After some consideration. We need to remove the proposed change for this POST endpoint /api/schools_experience/candidates.

The client using this endpoint relies on a live response. We cannot enqueue the creation of a candidate in a background job.